### PR TITLE
feat: backend core — DB schema, CRUD commands, IPC events

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -110,6 +110,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "bento-ya"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "git2",
  "portable-pty",
  "rusqlite",
@@ -118,7 +119,9 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "thiserror 1.0.69",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -321,8 +324,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
+uuid = { version = "1", features = ["v4"] }
+thiserror = "1"
+chrono = { version = "0.4", features = ["serde"] }
 portable-pty = "0.8"
 git2 = "0.19"
 

--- a/src-tauri/src/commands/column.rs
+++ b/src-tauri/src/commands/column.rs
@@ -1,0 +1,103 @@
+use crate::db::{self, AppState, Column};
+use crate::error::AppError;
+use tauri::State;
+
+#[tauri::command]
+pub fn create_column(
+    state: State<AppState>,
+    workspace_id: String,
+    name: String,
+    position: i64,
+) -> Result<Column, AppError> {
+    if name.trim().is_empty() {
+        return Err(AppError::InvalidInput("Column name cannot be empty".to_string()));
+    }
+    if position < 0 {
+        return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::insert_column(&conn, &workspace_id, name.trim(), position)?)
+}
+
+#[tauri::command]
+pub fn list_columns(
+    state: State<AppState>,
+    workspace_id: String,
+) -> Result<Vec<Column>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::list_columns(&conn, &workspace_id)?)
+}
+
+#[tauri::command]
+pub fn update_column(
+    state: State<AppState>,
+    id: String,
+    name: Option<String>,
+    position: Option<i64>,
+    color: Option<Option<String>>,
+    visible: Option<bool>,
+) -> Result<Column, AppError> {
+    if let Some(ref n) = name {
+        if n.trim().is_empty() {
+            return Err(AppError::InvalidInput("Column name cannot be empty".to_string()));
+        }
+    }
+    if let Some(pos) = position {
+        if pos < 0 {
+            return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+        }
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let color_ref = color.as_ref().map(|c| c.as_deref());
+    Ok(db::update_column(
+        &conn,
+        &id,
+        name.as_deref(),
+        position,
+        color_ref,
+        visible,
+    )?)
+}
+
+#[tauri::command]
+pub fn reorder_columns(
+    state: State<AppState>,
+    workspace_id: String,
+    column_ids: Vec<String>,
+) -> Result<Vec<Column>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    for (i, col_id) in column_ids.iter().enumerate() {
+        db::update_column(&conn, col_id, None, Some(i as i64), None, None)?;
+    }
+
+    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::list_columns(&conn, &workspace_id)?)
+}
+
+#[tauri::command]
+pub fn delete_column(state: State<AppState>, id: String) -> Result<(), AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    // Check if column has tasks
+    let task_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM tasks WHERE column_id = ?1",
+            rusqlite::params![id],
+            |row| row.get(0),
+        )
+        .map_err(AppError::from)?;
+
+    if task_count > 0 {
+        return Err(AppError::InvalidInput(format!(
+            "Column has {} task(s). Move or delete them first.",
+            task_count
+        )));
+    }
+
+    db::delete_column(&conn, &id)?;
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,7 @@
+pub mod column;
+pub mod task;
+pub mod workspace;
+
 #[tauri::command]
 pub fn greet(name: &str) -> String {
     format!("Hello, {}! Welcome to Bento-ya.", name)

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -1,0 +1,132 @@
+use crate::db::{self, AppState, Task};
+use crate::error::AppError;
+use tauri::State;
+
+#[tauri::command]
+pub fn create_task(
+    state: State<AppState>,
+    workspace_id: String,
+    column_id: String,
+    title: String,
+    description: Option<String>,
+) -> Result<Task, AppError> {
+    if title.trim().is_empty() {
+        return Err(AppError::InvalidInput("Task title cannot be empty".to_string()));
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::insert_task(
+        &conn,
+        &workspace_id,
+        &column_id,
+        title.trim(),
+        description.as_deref(),
+    )?)
+}
+
+#[tauri::command]
+pub fn get_task(state: State<AppState>, id: String) -> Result<Task, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::get_task(&conn, &id)?)
+}
+
+#[tauri::command]
+pub fn list_tasks(state: State<AppState>, workspace_id: String) -> Result<Vec<Task>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::list_tasks(&conn, &workspace_id)?)
+}
+
+#[tauri::command]
+pub fn update_task(
+    state: State<AppState>,
+    id: String,
+    title: Option<String>,
+    description: Option<Option<String>>,
+    column_id: Option<String>,
+    position: Option<i64>,
+    agent_mode: Option<Option<String>>,
+    priority: Option<String>,
+) -> Result<Task, AppError> {
+    if let Some(ref t) = title {
+        if t.trim().is_empty() {
+            return Err(AppError::InvalidInput("Task title cannot be empty".to_string()));
+        }
+    }
+    if let Some(pos) = position {
+        if pos < 0 {
+            return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+        }
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let desc_ref = description.as_ref().map(|d| d.as_deref());
+    let mode_ref = agent_mode.as_ref().map(|m| m.as_deref());
+    Ok(db::update_task(
+        &conn,
+        &id,
+        title.as_deref(),
+        desc_ref,
+        column_id.as_deref(),
+        position,
+        mode_ref,
+        priority.as_deref(),
+    )?)
+}
+
+#[tauri::command]
+pub fn move_task(
+    state: State<AppState>,
+    id: String,
+    target_column_id: String,
+    position: i64,
+) -> Result<Task, AppError> {
+    if position < 0 {
+        return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    // Update column and position atomically
+    let ts = db::now();
+    conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = ?2, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![target_column_id, position, ts, id],
+    )
+    .map_err(AppError::from)?;
+
+    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::get_task(&conn, &id)?)
+}
+
+#[tauri::command]
+pub fn reorder_tasks(
+    state: State<AppState>,
+    column_id: String,
+    task_ids: Vec<String>,
+) -> Result<Vec<Task>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let ts = db::now();
+
+    for (i, task_id) in task_ids.iter().enumerate() {
+        conn.execute(
+            "UPDATE tasks SET position = ?1, updated_at = ?2 WHERE id = ?3 AND column_id = ?4",
+            rusqlite::params![i as i64, ts, task_id, column_id],
+        )
+        .map_err(AppError::from)?;
+    }
+
+    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    // Get the workspace_id from the column to list tasks
+    let col = db::get_column(&conn, &column_id)?;
+    Ok(db::list_tasks(&conn, &col.workspace_id)?)
+}
+
+#[tauri::command]
+pub fn delete_task(state: State<AppState>, id: String) -> Result<(), AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    db::delete_task(&conn, &id)?;
+    Ok(())
+}

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,0 +1,87 @@
+use crate::db::{self, AppState, Column, Workspace};
+use crate::error::AppError;
+use tauri::State;
+
+const DEFAULT_COLUMNS: &[&str] = &["Backlog", "Working", "Review", "Done"];
+
+#[tauri::command]
+pub fn create_workspace(
+    state: State<AppState>,
+    name: String,
+    repo_path: String,
+) -> Result<Workspace, AppError> {
+    if name.trim().is_empty() {
+        return Err(AppError::InvalidInput("Workspace name cannot be empty".to_string()));
+    }
+    if repo_path.trim().is_empty() {
+        return Err(AppError::InvalidInput("Repository path cannot be empty".to_string()));
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    let ws = db::insert_workspace(&conn, name.trim(), repo_path.trim())?;
+
+    // Auto-create default columns
+    for (i, col_name) in DEFAULT_COLUMNS.iter().enumerate() {
+        db::insert_column(&conn, &ws.id, col_name, i as i64)?;
+    }
+
+    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(ws)
+}
+
+#[tauri::command]
+pub fn get_workspace(state: State<AppState>, id: String) -> Result<Workspace, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::get_workspace(&conn, &id)?)
+}
+
+#[tauri::command]
+pub fn list_workspaces(state: State<AppState>) -> Result<Vec<Workspace>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::list_workspaces(&conn)?)
+}
+
+#[tauri::command]
+pub fn update_workspace(
+    state: State<AppState>,
+    id: String,
+    name: Option<String>,
+    repo_path: Option<String>,
+    tab_order: Option<i64>,
+    is_active: Option<bool>,
+) -> Result<Workspace, AppError> {
+    if let Some(ref n) = name {
+        if n.trim().is_empty() {
+            return Err(AppError::InvalidInput("Workspace name cannot be empty".to_string()));
+        }
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::update_workspace(
+        &conn,
+        &id,
+        name.as_deref(),
+        repo_path.as_deref(),
+        tab_order,
+        is_active,
+    )?)
+}
+
+#[tauri::command]
+pub fn delete_workspace(state: State<AppState>, id: String) -> Result<(), AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    // CASCADE handles associated columns/tasks
+    db::delete_workspace(&conn, &id)?;
+    Ok(())
+}
+
+/// List columns for a workspace (used internally, also exposed as command).
+pub fn get_default_columns(
+    state: &State<AppState>,
+    workspace_id: &str,
+) -> Result<Vec<Column>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::list_columns(&conn, workspace_id)?)
+}

--- a/src-tauri/src/db/migrations/001_initial.sql
+++ b/src-tauri/src/db/migrations/001_initial.sql
@@ -1,0 +1,67 @@
+-- 001_initial.sql: Full v0.1 schema for Bento-ya
+-- Tables: workspaces, columns, tasks, agent_sessions
+
+CREATE TABLE IF NOT EXISTS workspaces (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    repo_path TEXT NOT NULL,
+    tab_order INTEGER NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS columns (
+    id TEXT PRIMARY KEY NOT NULL,
+    workspace_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    color TEXT,
+    visible INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY NOT NULL,
+    workspace_id TEXT NOT NULL,
+    column_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    position INTEGER NOT NULL DEFAULT 0,
+    priority TEXT NOT NULL DEFAULT 'medium',
+    agent_mode TEXT,
+    branch_name TEXT,
+    files_touched TEXT DEFAULT '[]',
+    checklist TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+    FOREIGN KEY (column_id) REFERENCES columns(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS agent_sessions (
+    id TEXT PRIMARY KEY NOT NULL,
+    task_id TEXT NOT NULL,
+    pid INTEGER,
+    status TEXT NOT NULL DEFAULT 'idle',
+    pty_cols INTEGER NOT NULL DEFAULT 80,
+    pty_rows INTEGER NOT NULL DEFAULT 24,
+    last_output TEXT,
+    exit_code INTEGER,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_columns_workspace ON columns(workspace_id, position);
+CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_column ON tasks(column_id, position);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_task ON agent_sessions(task_id);
+
+CREATE TABLE IF NOT EXISTS _migrations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    applied_at TEXT NOT NULL
+);

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,1 +1,681 @@
-// SQLite connection and schema management
+pub mod schema;
+
+use chrono::Utc;
+use rusqlite::{params, Connection, Result as SqlResult};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// Application state holding the database connection.
+pub struct AppState {
+    pub db: Mutex<Connection>,
+}
+
+/// Returns the path to the Bento-ya data directory (~/.bentoya/).
+fn data_dir() -> PathBuf {
+    let home = dirs_home();
+    home.join(".bentoya")
+}
+
+fn dirs_home() -> PathBuf {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Returns the path to the SQLite database file.
+pub fn db_path() -> PathBuf {
+    data_dir().join("data.db")
+}
+
+/// Initialize the database: create directory, open connection, run migrations.
+pub fn init() -> SqlResult<Connection> {
+    let dir = data_dir();
+    if !dir.exists() {
+        fs::create_dir_all(&dir).expect("Failed to create ~/.bentoya/ directory");
+    }
+
+    let path = db_path();
+    let conn = Connection::open(&path)?;
+
+    // Enable WAL mode for better concurrent read performance
+    conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+    // Enable foreign key constraints
+    conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+
+    run_migrations(&conn)?;
+
+    Ok(conn)
+}
+
+/// Initialize an in-memory database for testing.
+#[cfg(test)]
+pub fn init_test() -> SqlResult<Connection> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+    run_migrations(&conn)?;
+    Ok(conn)
+}
+
+/// Run all pending migrations.
+fn run_migrations(conn: &Connection) -> SqlResult<()> {
+    // Ensure migrations table exists
+    conn.execute_batch(schema::CREATE_MIGRATIONS_TABLE)?;
+
+    let migrations: Vec<(&str, &str)> = vec![
+        ("001_initial", include_str!("migrations/001_initial.sql")),
+    ];
+
+    for (name, sql) in migrations {
+        let already_applied: bool = conn
+            .prepare("SELECT COUNT(*) FROM _migrations WHERE name = ?1")?
+            .query_row(params![name], |row| row.get::<_, i64>(0))
+            .map(|count| count > 0)?;
+
+        if !already_applied {
+            conn.execute_batch(sql)?;
+            conn.execute(
+                "INSERT INTO _migrations (name, applied_at) VALUES (?1, ?2)",
+                params![name, now()],
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Generate a new UUID v4 string.
+pub fn new_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+/// Current timestamp as ISO 8601 string.
+pub fn now() -> String {
+    Utc::now().to_rfc3339()
+}
+
+// ─── Data models ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Workspace {
+    pub id: String,
+    pub name: String,
+    pub repo_path: String,
+    pub tab_order: i64,
+    pub is_active: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Column {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub position: i64,
+    pub color: Option<String>,
+    pub visible: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    pub id: String,
+    pub workspace_id: String,
+    pub column_id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub position: i64,
+    pub priority: String,
+    pub agent_mode: Option<String>,
+    pub branch_name: Option<String>,
+    pub files_touched: String,
+    pub checklist: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSession {
+    pub id: String,
+    pub task_id: String,
+    pub pid: Option<i64>,
+    pub status: String,
+    pub pty_cols: i64,
+    pub pty_rows: i64,
+    pub last_output: Option<String>,
+    pub exit_code: Option<i64>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+// ─── CRUD helpers: Workspace ───────────────────────────────────────────────
+
+pub fn insert_workspace(conn: &Connection, name: &str, repo_path: &str) -> SqlResult<Workspace> {
+    let id = new_id();
+    let ts = now();
+    conn.execute(
+        "INSERT INTO workspaces (id, name, repo_path, tab_order, is_active, created_at, updated_at) VALUES (?1, ?2, ?3, 0, 0, ?4, ?5)",
+        params![id, name, repo_path, ts, ts],
+    )?;
+    get_workspace(conn, &id)
+}
+
+pub fn get_workspace(conn: &Connection, id: &str) -> SqlResult<Workspace> {
+    conn.query_row(
+        "SELECT id, name, repo_path, tab_order, is_active, created_at, updated_at FROM workspaces WHERE id = ?1",
+        params![id],
+        |row| {
+            Ok(Workspace {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                repo_path: row.get(2)?,
+                tab_order: row.get(3)?,
+                is_active: row.get::<_, i64>(4)? != 0,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        },
+    )
+}
+
+pub fn list_workspaces(conn: &Connection) -> SqlResult<Vec<Workspace>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, name, repo_path, tab_order, is_active, created_at, updated_at FROM workspaces ORDER BY tab_order",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(Workspace {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            repo_path: row.get(2)?,
+            tab_order: row.get(3)?,
+            is_active: row.get::<_, i64>(4)? != 0,
+            created_at: row.get(5)?,
+            updated_at: row.get(6)?,
+        })
+    })?;
+    rows.collect()
+}
+
+pub fn update_workspace(
+    conn: &Connection,
+    id: &str,
+    name: Option<&str>,
+    repo_path: Option<&str>,
+    tab_order: Option<i64>,
+    is_active: Option<bool>,
+) -> SqlResult<Workspace> {
+    let current = get_workspace(conn, id)?;
+    let ts = now();
+    conn.execute(
+        "UPDATE workspaces SET name = ?1, repo_path = ?2, tab_order = ?3, is_active = ?4, updated_at = ?5 WHERE id = ?6",
+        params![
+            name.unwrap_or(&current.name),
+            repo_path.unwrap_or(&current.repo_path),
+            tab_order.unwrap_or(current.tab_order),
+            is_active.unwrap_or(current.is_active) as i64,
+            ts,
+            id,
+        ],
+    )?;
+    get_workspace(conn, id)
+}
+
+pub fn delete_workspace(conn: &Connection, id: &str) -> SqlResult<()> {
+    conn.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+// ─── CRUD helpers: Column ──────────────────────────────────────────────────
+
+pub fn insert_column(
+    conn: &Connection,
+    workspace_id: &str,
+    name: &str,
+    position: i64,
+) -> SqlResult<Column> {
+    let id = new_id();
+    let ts = now();
+    conn.execute(
+        "INSERT INTO columns (id, workspace_id, name, position, visible, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, 1, ?5, ?6)",
+        params![id, workspace_id, name, position, ts, ts],
+    )?;
+    get_column(conn, &id)
+}
+
+pub fn get_column(conn: &Connection, id: &str) -> SqlResult<Column> {
+    conn.query_row(
+        "SELECT id, workspace_id, name, position, color, visible, created_at, updated_at FROM columns WHERE id = ?1",
+        params![id],
+        |row| {
+            Ok(Column {
+                id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                name: row.get(2)?,
+                position: row.get(3)?,
+                color: row.get(4)?,
+                visible: row.get::<_, i64>(5)? != 0,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        },
+    )
+}
+
+pub fn list_columns(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<Column>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, workspace_id, name, position, color, visible, created_at, updated_at FROM columns WHERE workspace_id = ?1 ORDER BY position",
+    )?;
+    let rows = stmt.query_map(params![workspace_id], |row| {
+        Ok(Column {
+            id: row.get(0)?,
+            workspace_id: row.get(1)?,
+            name: row.get(2)?,
+            position: row.get(3)?,
+            color: row.get(4)?,
+            visible: row.get::<_, i64>(5)? != 0,
+            created_at: row.get(6)?,
+            updated_at: row.get(7)?,
+        })
+    })?;
+    rows.collect()
+}
+
+pub fn update_column(
+    conn: &Connection,
+    id: &str,
+    name: Option<&str>,
+    position: Option<i64>,
+    color: Option<Option<&str>>,
+    visible: Option<bool>,
+) -> SqlResult<Column> {
+    let current = get_column(conn, id)?;
+    let ts = now();
+    let new_color = match color {
+        Some(c) => c.map(|s| s.to_string()),
+        None => current.color.clone(),
+    };
+    conn.execute(
+        "UPDATE columns SET name = ?1, position = ?2, color = ?3, visible = ?4, updated_at = ?5 WHERE id = ?6",
+        params![
+            name.unwrap_or(&current.name),
+            position.unwrap_or(current.position),
+            new_color,
+            visible.unwrap_or(current.visible) as i64,
+            ts,
+            id,
+        ],
+    )?;
+    get_column(conn, id)
+}
+
+pub fn delete_column(conn: &Connection, id: &str) -> SqlResult<()> {
+    conn.execute("DELETE FROM columns WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+// ─── CRUD helpers: Task ────────────────────────────────────────────────────
+
+pub fn insert_task(
+    conn: &Connection,
+    workspace_id: &str,
+    column_id: &str,
+    title: &str,
+    description: Option<&str>,
+) -> SqlResult<Task> {
+    let id = new_id();
+    let ts = now();
+    // Get next position in column
+    let max_pos: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
+            params![column_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(-1);
+    conn.execute(
+        "INSERT INTO tasks (id, workspace_id, column_id, title, description, position, priority, files_touched, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'medium', '[]', ?7, ?8)",
+        params![id, workspace_id, column_id, title, description, max_pos + 1, ts, ts],
+    )?;
+    get_task(conn, &id)
+}
+
+pub fn get_task(conn: &Connection, id: &str) -> SqlResult<Task> {
+    conn.query_row(
+        "SELECT id, workspace_id, column_id, title, description, position, priority, agent_mode, branch_name, files_touched, checklist, created_at, updated_at FROM tasks WHERE id = ?1",
+        params![id],
+        |row| {
+            Ok(Task {
+                id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                column_id: row.get(2)?,
+                title: row.get(3)?,
+                description: row.get(4)?,
+                position: row.get(5)?,
+                priority: row.get(6)?,
+                agent_mode: row.get(7)?,
+                branch_name: row.get(8)?,
+                files_touched: row.get::<_, String>(9).unwrap_or_else(|_| "[]".to_string()),
+                checklist: row.get(10)?,
+                created_at: row.get(11)?,
+                updated_at: row.get(12)?,
+            })
+        },
+    )
+}
+
+pub fn list_tasks(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<Task>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, workspace_id, column_id, title, description, position, priority, agent_mode, branch_name, files_touched, checklist, created_at, updated_at FROM tasks WHERE workspace_id = ?1 ORDER BY column_id, position",
+    )?;
+    let rows = stmt.query_map(params![workspace_id], |row| {
+        Ok(Task {
+            id: row.get(0)?,
+            workspace_id: row.get(1)?,
+            column_id: row.get(2)?,
+            title: row.get(3)?,
+            description: row.get(4)?,
+            position: row.get(5)?,
+            priority: row.get(6)?,
+            agent_mode: row.get(7)?,
+            branch_name: row.get(8)?,
+            files_touched: row.get::<_, String>(9).unwrap_or_else(|_| "[]".to_string()),
+            checklist: row.get(10)?,
+            created_at: row.get(11)?,
+            updated_at: row.get(12)?,
+        })
+    })?;
+    rows.collect()
+}
+
+pub fn update_task(
+    conn: &Connection,
+    id: &str,
+    title: Option<&str>,
+    description: Option<Option<&str>>,
+    column_id: Option<&str>,
+    position: Option<i64>,
+    agent_mode: Option<Option<&str>>,
+    priority: Option<&str>,
+) -> SqlResult<Task> {
+    let current = get_task(conn, id)?;
+    let ts = now();
+    let new_desc = match description {
+        Some(d) => d.map(|s| s.to_string()),
+        None => current.description.clone(),
+    };
+    let new_agent_mode = match agent_mode {
+        Some(m) => m.map(|s| s.to_string()),
+        None => current.agent_mode.clone(),
+    };
+    conn.execute(
+        "UPDATE tasks SET title = ?1, description = ?2, column_id = ?3, position = ?4, agent_mode = ?5, priority = ?6, updated_at = ?7 WHERE id = ?8",
+        params![
+            title.unwrap_or(&current.title),
+            new_desc,
+            column_id.unwrap_or(&current.column_id),
+            position.unwrap_or(current.position),
+            new_agent_mode,
+            priority.unwrap_or(&current.priority),
+            ts,
+            id,
+        ],
+    )?;
+    get_task(conn, id)
+}
+
+pub fn delete_task(conn: &Connection, id: &str) -> SqlResult<()> {
+    conn.execute("DELETE FROM tasks WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+// ─── CRUD helpers: AgentSession ────────────────────────────────────────────
+
+pub fn insert_agent_session(conn: &Connection, task_id: &str) -> SqlResult<AgentSession> {
+    let id = new_id();
+    let ts = now();
+    conn.execute(
+        "INSERT INTO agent_sessions (id, task_id, status, pty_cols, pty_rows, created_at, updated_at) VALUES (?1, ?2, 'idle', 80, 24, ?3, ?4)",
+        params![id, task_id, ts, ts],
+    )?;
+    get_agent_session(conn, &id)
+}
+
+pub fn get_agent_session(conn: &Connection, id: &str) -> SqlResult<AgentSession> {
+    conn.query_row(
+        "SELECT id, task_id, pid, status, pty_cols, pty_rows, last_output, exit_code, created_at, updated_at FROM agent_sessions WHERE id = ?1",
+        params![id],
+        |row| {
+            Ok(AgentSession {
+                id: row.get(0)?,
+                task_id: row.get(1)?,
+                pid: row.get(2)?,
+                status: row.get(3)?,
+                pty_cols: row.get(4)?,
+                pty_rows: row.get(5)?,
+                last_output: row.get(6)?,
+                exit_code: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+            })
+        },
+    )
+}
+
+pub fn list_agent_sessions(conn: &Connection, task_id: &str) -> SqlResult<Vec<AgentSession>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, task_id, pid, status, pty_cols, pty_rows, last_output, exit_code, created_at, updated_at FROM agent_sessions WHERE task_id = ?1",
+    )?;
+    let rows = stmt.query_map(params![task_id], |row| {
+        Ok(AgentSession {
+            id: row.get(0)?,
+            task_id: row.get(1)?,
+            pid: row.get(2)?,
+            status: row.get(3)?,
+            pty_cols: row.get(4)?,
+            pty_rows: row.get(5)?,
+            last_output: row.get(6)?,
+            exit_code: row.get(7)?,
+            created_at: row.get(8)?,
+            updated_at: row.get(9)?,
+        })
+    })?;
+    rows.collect()
+}
+
+pub fn update_agent_session(
+    conn: &Connection,
+    id: &str,
+    pid: Option<Option<i64>>,
+    status: Option<&str>,
+    exit_code: Option<Option<i64>>,
+    last_output: Option<Option<&str>>,
+) -> SqlResult<AgentSession> {
+    let current = get_agent_session(conn, id)?;
+    let ts = now();
+    let new_pid = match pid {
+        Some(p) => p,
+        None => current.pid,
+    };
+    let new_exit_code = match exit_code {
+        Some(e) => e,
+        None => current.exit_code,
+    };
+    let new_last_output = match last_output {
+        Some(o) => o.map(|s| s.to_string()),
+        None => current.last_output.clone(),
+    };
+    conn.execute(
+        "UPDATE agent_sessions SET pid = ?1, status = ?2, exit_code = ?3, last_output = ?4, updated_at = ?5 WHERE id = ?6",
+        params![
+            new_pid,
+            status.unwrap_or(&current.status),
+            new_exit_code,
+            new_last_output,
+            ts,
+            id,
+        ],
+    )?;
+    get_agent_session(conn, id)
+}
+
+pub fn delete_agent_session(conn: &Connection, id: &str) -> SqlResult<()> {
+    conn.execute("DELETE FROM agent_sessions WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_schema_creation() {
+        let conn = init_test().unwrap();
+        // Verify tables exist by querying sqlite_master
+        let tables: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert!(tables.contains(&"workspaces".to_string()));
+        assert!(tables.contains(&"columns".to_string()));
+        assert!(tables.contains(&"tasks".to_string()));
+        assert!(tables.contains(&"agent_sessions".to_string()));
+        assert!(tables.contains(&"_migrations".to_string()));
+    }
+
+    #[test]
+    fn test_migrations_idempotent() {
+        let conn = init_test().unwrap();
+        // Running migrations again should not fail
+        run_migrations(&conn).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_workspace_crud() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "Test Project", "/tmp/test").unwrap();
+        assert_eq!(ws.name, "Test Project");
+        assert_eq!(ws.repo_path, "/tmp/test");
+        assert!(!ws.is_active);
+
+        let fetched = get_workspace(&conn, &ws.id).unwrap();
+        assert_eq!(fetched.id, ws.id);
+
+        let updated = update_workspace(&conn, &ws.id, Some("Renamed"), None, None, Some(true)).unwrap();
+        assert_eq!(updated.name, "Renamed");
+        assert!(updated.is_active);
+
+        let all = list_workspaces(&conn).unwrap();
+        assert_eq!(all.len(), 1);
+
+        delete_workspace(&conn, &ws.id).unwrap();
+        let all = list_workspaces(&conn).unwrap();
+        assert_eq!(all.len(), 0);
+    }
+
+    #[test]
+    fn test_column_crud() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        assert_eq!(col.name, "Backlog");
+        assert_eq!(col.position, 0);
+        assert!(col.visible);
+
+        let updated = update_column(&conn, &col.id, Some("Todo"), Some(1), None, None).unwrap();
+        assert_eq!(updated.name, "Todo");
+        assert_eq!(updated.position, 1);
+
+        let cols = list_columns(&conn, &ws.id).unwrap();
+        assert_eq!(cols.len(), 1);
+
+        delete_column(&conn, &col.id).unwrap();
+        let cols = list_columns(&conn, &ws.id).unwrap();
+        assert_eq!(cols.len(), 0);
+    }
+
+    #[test]
+    fn test_task_crud() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        let task = insert_task(&conn, &ws.id, &col.id, "Fix bug", Some("Critical issue")).unwrap();
+        assert_eq!(task.title, "Fix bug");
+        assert_eq!(task.description.as_deref(), Some("Critical issue"));
+        assert_eq!(task.position, 0);
+        assert_eq!(task.priority, "medium");
+
+        // Second task gets position 1
+        let task2 = insert_task(&conn, &ws.id, &col.id, "Add feature", None).unwrap();
+        assert_eq!(task2.position, 1);
+
+        let updated = update_task(&conn, &task.id, Some("Fix critical bug"), None, None, None, None, Some("high")).unwrap();
+        assert_eq!(updated.title, "Fix critical bug");
+        assert_eq!(updated.priority, "high");
+
+        let tasks = list_tasks(&conn, &ws.id).unwrap();
+        assert_eq!(tasks.len(), 2);
+
+        delete_task(&conn, &task.id).unwrap();
+        let tasks = list_tasks(&conn, &ws.id).unwrap();
+        assert_eq!(tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_agent_session_crud() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        let task = insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+        let session = insert_agent_session(&conn, &task.id).unwrap();
+        assert_eq!(session.status, "idle");
+        assert_eq!(session.pty_cols, 80);
+        assert_eq!(session.pty_rows, 24);
+
+        let updated = update_agent_session(&conn, &session.id, Some(Some(12345)), Some("running"), None, None).unwrap();
+        assert_eq!(updated.pid, Some(12345));
+        assert_eq!(updated.status, "running");
+
+        let sessions = list_agent_sessions(&conn, &task.id).unwrap();
+        assert_eq!(sessions.len(), 1);
+
+        delete_agent_session(&conn, &session.id).unwrap();
+        let sessions = list_agent_sessions(&conn, &task.id).unwrap();
+        assert_eq!(sessions.len(), 0);
+    }
+
+    #[test]
+    fn test_cascade_delete() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        let task = insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+        insert_agent_session(&conn, &task.id).unwrap();
+
+        // Deleting workspace should cascade to columns, tasks, sessions
+        delete_workspace(&conn, &ws.id).unwrap();
+        assert!(get_column(&conn, &col.id).is_err());
+        assert!(get_task(&conn, &task.id).is_err());
+    }
+
+    #[test]
+    fn test_foreign_key_enforcement() {
+        let conn = init_test().unwrap();
+        // Inserting a column with a non-existent workspace should fail
+        let result = insert_column(&conn, "nonexistent-id", "Bad Column", 0);
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -1,0 +1,74 @@
+/// Schema definitions — source of truth for the v0.1 data model.
+/// Migration files should match these definitions.
+
+pub const CREATE_WORKSPACES: &str = "
+CREATE TABLE IF NOT EXISTS workspaces (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    repo_path TEXT NOT NULL,
+    tab_order INTEGER NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+)";
+
+pub const CREATE_COLUMNS: &str = "
+CREATE TABLE IF NOT EXISTS columns (
+    id TEXT PRIMARY KEY NOT NULL,
+    workspace_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    color TEXT,
+    visible INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+)";
+
+pub const CREATE_TASKS: &str = "
+CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY NOT NULL,
+    workspace_id TEXT NOT NULL,
+    column_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    position INTEGER NOT NULL DEFAULT 0,
+    priority TEXT NOT NULL DEFAULT 'medium',
+    agent_mode TEXT,
+    branch_name TEXT,
+    files_touched TEXT DEFAULT '[]',
+    checklist TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+    FOREIGN KEY (column_id) REFERENCES columns(id) ON DELETE CASCADE
+)";
+
+pub const CREATE_AGENT_SESSIONS: &str = "
+CREATE TABLE IF NOT EXISTS agent_sessions (
+    id TEXT PRIMARY KEY NOT NULL,
+    task_id TEXT NOT NULL,
+    pid INTEGER,
+    status TEXT NOT NULL DEFAULT 'idle',
+    pty_cols INTEGER NOT NULL DEFAULT 80,
+    pty_rows INTEGER NOT NULL DEFAULT 24,
+    last_output TEXT,
+    exit_code INTEGER,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+)";
+
+pub const CREATE_INDEXES: &[&str] = &[
+    "CREATE INDEX IF NOT EXISTS idx_columns_workspace ON columns(workspace_id, position)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_column ON tasks(column_id, position)",
+    "CREATE INDEX IF NOT EXISTS idx_agent_sessions_task ON agent_sessions(task_id)",
+];
+
+pub const CREATE_MIGRATIONS_TABLE: &str = "
+CREATE TABLE IF NOT EXISTS _migrations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    applied_at TEXT NOT NULL
+)";

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,44 @@
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("Database error: {0}")]
+    DatabaseError(String),
+}
+
+impl From<rusqlite::Error> for AppError {
+    fn from(err: rusqlite::Error) -> Self {
+        match err {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::NotFound("Record not found".to_string())
+            }
+            _ => AppError::DatabaseError(err.to_string()),
+        }
+    }
+}
+
+// Tauri requires serializable errors
+impl Serialize for AppError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("AppError", 2)?;
+        let (kind, message) = match self {
+            AppError::NotFound(msg) => ("NotFound", msg.as_str()),
+            AppError::InvalidInput(msg) => ("InvalidInput", msg.as_str()),
+            AppError::DatabaseError(msg) => ("DatabaseError", msg.as_str()),
+        };
+        state.serialize_field("kind", kind)?;
+        state.serialize_field("message", message)?;
+        state.end()
+    }
+}

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,0 +1,124 @@
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+
+// ─── Event channel name helpers ────────────────────────────────────────────
+
+pub fn pty_output_channel(task_id: &str) -> String {
+    format!("pty:{}:output", task_id)
+}
+
+pub fn pty_exit_channel(task_id: &str) -> String {
+    format!("pty:{}:exit", task_id)
+}
+
+pub fn agent_status_channel(task_id: &str) -> String {
+    format!("agent:{}:status", task_id)
+}
+
+pub fn task_updated_channel(task_id: &str) -> String {
+    format!("task:{}:updated", task_id)
+}
+
+pub fn git_changes_channel(task_id: &str) -> String {
+    format!("git:{}:changes", task_id)
+}
+
+pub fn workspace_updated_channel(workspace_id: &str) -> String {
+    format!("workspace:{}:updated", workspace_id)
+}
+
+// ─── Event payloads ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyOutputPayload {
+    pub task_id: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyExitPayload {
+    pub task_id: String,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentStatusPayload {
+    pub task_id: String,
+    pub status: AgentStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatus {
+    Running,
+    Completed,
+    Failed,
+    NeedsAttention,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskUpdatedPayload {
+    pub task_id: String,
+    pub column_id: Option<String>,
+    pub title: Option<String>,
+    pub position: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitChangesPayload {
+    pub task_id: String,
+    pub files: Vec<FileChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChange {
+    pub path: String,
+    pub status: FileChangeStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileChangeStatus {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceUpdatedPayload {
+    pub workspace_id: String,
+    pub name: Option<String>,
+}
+
+// ─── Emit helpers ──────────────────────────────────────────────────────────
+
+pub fn emit_pty_output(app: &AppHandle, payload: PtyOutputPayload) {
+    let channel = pty_output_channel(&payload.task_id);
+    let _ = app.emit(&channel, &payload);
+}
+
+pub fn emit_pty_exit(app: &AppHandle, payload: PtyExitPayload) {
+    let channel = pty_exit_channel(&payload.task_id);
+    let _ = app.emit(&channel, &payload);
+}
+
+pub fn emit_agent_status(app: &AppHandle, payload: AgentStatusPayload) {
+    let channel = agent_status_channel(&payload.task_id);
+    let _ = app.emit(&channel, &payload);
+}
+
+pub fn emit_task_updated(app: &AppHandle, payload: TaskUpdatedPayload) {
+    let channel = task_updated_channel(&payload.task_id);
+    let _ = app.emit(&channel, &payload);
+}
+
+pub fn emit_git_changes(app: &AppHandle, payload: GitChangesPayload) {
+    let channel = git_changes_channel(&payload.task_id);
+    let _ = app.emit(&channel, &payload);
+}
+
+pub fn emit_workspace_updated(app: &AppHandle, payload: WorkspaceUpdatedPayload) {
+    let channel = workspace_updated_channel(&payload.workspace_id);
+    let _ = app.emit(&channel, &payload);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod commands;
 pub mod checklist;
 pub mod config;
 pub mod db;
+pub mod error;
 pub mod git;
 pub mod pipeline;
 pub mod process;
@@ -21,7 +22,29 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .manage(state)
-        .invoke_handler(tauri::generate_handler![commands::greet])
+        .invoke_handler(tauri::generate_handler![
+            commands::greet,
+            // Workspace CRUD
+            commands::workspace::create_workspace,
+            commands::workspace::get_workspace,
+            commands::workspace::list_workspaces,
+            commands::workspace::update_workspace,
+            commands::workspace::delete_workspace,
+            // Column CRUD
+            commands::column::create_column,
+            commands::column::list_columns,
+            commands::column::update_column,
+            commands::column::reorder_columns,
+            commands::column::delete_column,
+            // Task CRUD
+            commands::task::create_task,
+            commands::task::get_task,
+            commands::task::list_tasks,
+            commands::task::update_task,
+            commands::task::move_task,
+            commands::task::reorder_tasks,
+            commands::task::delete_task,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod checklist;
 pub mod config;
 pub mod db;
 pub mod error;
+pub mod events;
 pub mod git;
 pub mod pipeline;
 pub mod process;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,10 +8,19 @@ pub mod git;
 pub mod pipeline;
 pub mod process;
 
+use db::AppState;
+use std::sync::Mutex;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let conn = db::init().expect("Failed to initialize database");
+    let state = AppState {
+        db: Mutex::new(conn),
+    };
+
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .manage(state)
         .invoke_handler(tauri::generate_handler![commands::greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,0 +1,144 @@
+// Typed invoke() and listen() wrappers for Tauri IPC.
+// Provides type-safe communication between React frontend and Rust backend.
+
+import { invoke as tauriInvoke } from '@tauri-apps/api/core'
+import { listen as tauriListen, type UnlistenFn } from '@tauri-apps/api/event'
+import type {
+  AppError,
+  Column,
+  Task,
+  Workspace,
+} from '../types/events'
+
+// ─── Typed invoke wrapper ──────────────────────────────────────────────────
+
+async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  return tauriInvoke<T>(cmd, args)
+}
+
+// ─── Typed listen wrapper ──────────────────────────────────────────────────
+
+function listen<T>(event: string, handler: (payload: T) => void): Promise<UnlistenFn> {
+  return tauriListen<T>(event, (e) => handler(e.payload))
+}
+
+// ─── Workspace commands ────────────────────────────────────────────────────
+
+export async function createWorkspace(name: string, repoPath: string): Promise<Workspace> {
+  return invoke<Workspace>('create_workspace', { name, repoPath })
+}
+
+export async function getWorkspace(id: string): Promise<Workspace> {
+  return invoke<Workspace>('get_workspace', { id })
+}
+
+export async function listWorkspaces(): Promise<Workspace[]> {
+  return invoke<Workspace[]>('list_workspaces')
+}
+
+export async function updateWorkspace(
+  id: string,
+  updates: {
+    name?: string
+    repoPath?: string
+    tabOrder?: number
+    isActive?: boolean
+  },
+): Promise<Workspace> {
+  return invoke<Workspace>('update_workspace', { id, ...updates })
+}
+
+export async function deleteWorkspace(id: string): Promise<void> {
+  return invoke<void>('delete_workspace', { id })
+}
+
+// ─── Column commands ───────────────────────────────────────────────────────
+
+export async function createColumn(
+  workspaceId: string,
+  name: string,
+  position: number,
+): Promise<Column> {
+  return invoke<Column>('create_column', { workspaceId, name, position })
+}
+
+export async function listColumns(workspaceId: string): Promise<Column[]> {
+  return invoke<Column[]>('list_columns', { workspaceId })
+}
+
+export async function updateColumn(
+  id: string,
+  updates: {
+    name?: string
+    position?: number
+    color?: string | null
+    visible?: boolean
+  },
+): Promise<Column> {
+  return invoke<Column>('update_column', { id, ...updates })
+}
+
+export async function reorderColumns(
+  workspaceId: string,
+  columnIds: string[],
+): Promise<Column[]> {
+  return invoke<Column[]>('reorder_columns', { workspaceId, columnIds })
+}
+
+export async function deleteColumn(id: string): Promise<void> {
+  return invoke<void>('delete_column', { id })
+}
+
+// ─── Task commands ─────────────────────────────────────────────────────────
+
+export async function createTask(
+  workspaceId: string,
+  columnId: string,
+  title: string,
+  description?: string,
+): Promise<Task> {
+  return invoke<Task>('create_task', { workspaceId, columnId, title, description })
+}
+
+export async function getTask(id: string): Promise<Task> {
+  return invoke<Task>('get_task', { id })
+}
+
+export async function listTasks(workspaceId: string): Promise<Task[]> {
+  return invoke<Task[]>('list_tasks', { workspaceId })
+}
+
+export async function updateTask(
+  id: string,
+  updates: {
+    title?: string
+    description?: string | null
+    columnId?: string
+    position?: number
+    agentMode?: string | null
+    priority?: string
+  },
+): Promise<Task> {
+  return invoke<Task>('update_task', { id, ...updates })
+}
+
+export async function moveTask(
+  id: string,
+  targetColumnId: string,
+  position: number,
+): Promise<Task> {
+  return invoke<Task>('move_task', { id, targetColumnId, position })
+}
+
+export async function reorderTasks(columnId: string, taskIds: string[]): Promise<Task[]> {
+  return invoke<Task[]>('reorder_tasks', { columnId, taskIds })
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  return invoke<void>('delete_task', { id })
+}
+
+// ─── Event listeners ───────────────────────────────────────────────────────
+
+export { listen, type UnlistenFn }
+export type { AppError }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,125 @@
+// Event payload TypeScript interfaces — source of truth for all event channel names.
+// Keep in sync with src-tauri/src/events.rs.
+
+// ─── Event channel name helpers ────────────────────────────────────────────
+
+export const EventChannels = {
+  ptyOutput: (taskId: string) => `pty:${taskId}:output` as const,
+  ptyExit: (taskId: string) => `pty:${taskId}:exit` as const,
+  agentStatus: (taskId: string) => `agent:${taskId}:status` as const,
+  taskUpdated: (taskId: string) => `task:${taskId}:updated` as const,
+  gitChanges: (taskId: string) => `git:${taskId}:changes` as const,
+  workspaceUpdated: (id: string) => `workspace:${id}:updated` as const,
+} as const
+
+// ─── Event payloads ────────────────────────────────────────────────────────
+
+export interface PtyOutputPayload {
+  task_id: string
+  data: number[]
+}
+
+export interface PtyExitPayload {
+  task_id: string
+  exit_code: number | null
+}
+
+export type AgentStatus = 'running' | 'completed' | 'failed' | 'needs_attention'
+
+export interface AgentStatusPayload {
+  task_id: string
+  status: AgentStatus
+}
+
+export interface TaskUpdatedPayload {
+  task_id: string
+  column_id?: string | null
+  title?: string | null
+  position?: number | null
+}
+
+export type FileChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed'
+
+export interface FileChange {
+  path: string
+  status: FileChangeStatus
+}
+
+export interface GitChangesPayload {
+  task_id: string
+  files: FileChange[]
+}
+
+export interface WorkspaceUpdatedPayload {
+  workspace_id: string
+  name?: string | null
+}
+
+// ─── Discriminated union for all events ────────────────────────────────────
+
+export type AppEvent =
+  | { type: 'pty_output'; payload: PtyOutputPayload }
+  | { type: 'pty_exit'; payload: PtyExitPayload }
+  | { type: 'agent_status'; payload: AgentStatusPayload }
+  | { type: 'task_updated'; payload: TaskUpdatedPayload }
+  | { type: 'git_changes'; payload: GitChangesPayload }
+  | { type: 'workspace_updated'; payload: WorkspaceUpdatedPayload }
+
+// ─── Backend data models (matching Rust structs) ───────────────────────────
+
+export interface Workspace {
+  id: string
+  name: string
+  repo_path: string
+  tab_order: number
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface Column {
+  id: string
+  workspace_id: string
+  name: string
+  position: number
+  color: string | null
+  visible: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface Task {
+  id: string
+  workspace_id: string
+  column_id: string
+  title: string
+  description: string | null
+  position: number
+  priority: string
+  agent_mode: string | null
+  branch_name: string | null
+  files_touched: string
+  checklist: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface AgentSession {
+  id: string
+  task_id: string
+  pid: number | null
+  status: string
+  pty_cols: number
+  pty_rows: number
+  last_output: string | null
+  exit_code: number | null
+  created_at: string
+  updated_at: string
+}
+
+// ─── Error response type ───────────────────────────────────────────────────
+
+export interface AppError {
+  kind: 'NotFound' | 'InvalidInput' | 'DatabaseError'
+  message: string
+}


### PR DESCRIPTION
## Summary

- **T002 — Database Schema & Migrations**: SQLite via rusqlite with full v0.1 data model (workspaces, columns, tasks, agent_sessions). Idempotent migration runner, WAL mode, FK enforcement, UUID primary keys, ISO 8601 timestamps. CRUD helpers for all tables with 8 unit tests.
- **T003 — Backend CRUD Commands**: 17 Tauri IPC command handlers for workspace/column/task CRUD. AppError enum with thiserror, input validation, transactional mutations. Workspace creation auto-creates default columns (Backlog, Working, Review, Done).
- **T006 — Tauri IPC Event System**: Rust event types and emit helpers for 6 event channels (PTY output/exit, agent status, task updated, git changes, workspace updated). TypeScript typed `invoke()` and `listen()` wrappers matching all Rust structs.

## Test plan

- [x] `cargo test --lib` — 8 DB unit tests pass (schema creation, CRUD, cascades, FK enforcement, idempotent migrations)
- [x] `cargo check` — Rust compiles clean
- [x] `pnpm run type-check` — TypeScript passes