### PR TITLE
feat: git branch manager + diff viewer (T005, T012)

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,0 +1,76 @@
+use crate::git::{branch_manager, change_tracker, conflict_detector};
+
+#[tauri::command]
+pub async fn create_task_branch(
+    repo_path: String,
+    task_slug: String,
+    base_branch: Option<String>,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || {
+        branch_manager::create_task_branch(&repo_path, &task_slug, base_branch.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn switch_branch(repo_path: String, branch: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || branch_manager::switch_branch(&repo_path, &branch))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_current_branch(repo_path: String) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || branch_manager::get_current_branch(&repo_path))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn list_task_branches(
+    repo_path: String,
+) -> Result<Vec<branch_manager::BranchInfo>, String> {
+    tokio::task::spawn_blocking(move || branch_manager::list_task_branches(&repo_path))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn delete_task_branch(repo_path: String, branch: String) -> Result<bool, String> {
+    tokio::task::spawn_blocking(move || branch_manager::delete_task_branch(&repo_path, &branch))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_changes(
+    repo_path: String,
+    branch: String,
+) -> Result<change_tracker::ChangeSummary, String> {
+    tokio::task::spawn_blocking(move || change_tracker::get_changes(&repo_path, &branch))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_diff(
+    repo_path: String,
+    branch: String,
+    file_path: Option<String>,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || {
+        change_tracker::get_diff(&repo_path, &branch, file_path.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_conflict_matrix(
+    repo_path: String,
+) -> Result<conflict_detector::ConflictMatrix, String> {
+    tokio::task::spawn_blocking(move || conflict_detector::get_conflict_matrix(&repo_path))
+        .await
+        .map_err(|e| e.to_string())?
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,5 @@
+pub mod git;
+
 #[tauri::command]
 pub fn greet(name: &str) -> String {
     format!("Hello, {}! Welcome to Bento-ya.", name)

--- a/src-tauri/src/git/branch_manager.rs
+++ b/src-tauri/src/git/branch_manager.rs
@@ -1,0 +1,244 @@
+use git2::{BranchType, Repository, Signature, StashFlags};
+use serde::Serialize;
+
+const BRANCH_PREFIX: &str = "bentoya/";
+const AUTO_STASH_PREFIX: &str = "bentoya-auto-stash-";
+
+#[derive(Debug, Serialize)]
+pub struct BranchInfo {
+    pub name: String,
+    pub is_head: bool,
+    pub upstream: Option<String>,
+}
+
+/// Slugify a task title: lowercase, replace non-alphanumeric with hyphens,
+/// collapse multiple hyphens, strip leading/trailing hyphens, truncate to 50 chars.
+pub fn slugify(input: &str) -> String {
+    let slug: String = input
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    let collapsed: String = slug
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    collapsed.chars().take(50).collect()
+}
+
+/// Detect the default base branch: try "main", then "master", then current HEAD.
+fn detect_base_branch(repo: &Repository) -> Result<String, git2::Error> {
+    for name in &["main", "master"] {
+        if repo.find_branch(name, BranchType::Local).is_ok() {
+            return Ok(name.to_string());
+        }
+    }
+    let head = repo.head()?;
+    Ok(head.shorthand().unwrap_or("HEAD").to_string())
+}
+
+/// Create a task branch `bentoya/<slug>` from the base branch.
+pub fn create_task_branch(
+    repo_path: &str,
+    task_slug: &str,
+    base_branch: Option<&str>,
+) -> Result<String, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+
+    let base = match base_branch {
+        Some(b) => b.to_string(),
+        None => detect_base_branch(&repo).map_err(|e| e.to_string())?,
+    };
+
+    let slug = slugify(task_slug);
+    let branch_name = format!("{}{}", BRANCH_PREFIX, slug);
+
+    let base_ref = repo
+        .find_branch(&base, BranchType::Local)
+        .map_err(|e| format!("Base branch '{}' not found: {}", base, e))?;
+
+    let commit = base_ref
+        .get()
+        .peel_to_commit()
+        .map_err(|e| e.to_string())?;
+
+    repo.branch(&branch_name, &commit, false)
+        .map_err(|e| format!("Failed to create branch '{}': {}", branch_name, e))?;
+
+    Ok(branch_name)
+}
+
+fn is_working_tree_dirty(repo: &Repository) -> Result<bool, git2::Error> {
+    let statuses = repo.statuses(None)?;
+    Ok(!statuses.is_empty())
+}
+
+/// Checkout a branch with automatic stash/restore of uncommitted changes.
+///
+/// Flow:
+/// 1. If working tree is dirty → stash with a tagged message
+/// 2. Checkout target branch
+/// 3. If a matching auto-stash exists for the target → pop it
+pub fn switch_branch(repo_path: &str, branch: &str) -> Result<(), String> {
+    let mut repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+
+    let current = get_current_branch_inner(&repo).unwrap_or_default();
+
+    // Auto-stash if working tree is dirty
+    if is_working_tree_dirty(&repo).map_err(|e| e.to_string())? {
+        let sig = repo
+            .signature()
+            .or_else(|_| Signature::now("Bento-ya", "bentoya@local"))
+            .map_err(|e| e.to_string())?;
+
+        let message = format!("{}{}", AUTO_STASH_PREFIX, current);
+        repo.stash_save(&sig, &message, Some(StashFlags::INCLUDE_UNTRACKED))
+            .map_err(|e| format!("Failed to stash changes: {}", e))?;
+    }
+
+    // Checkout target branch — scope the borrow so `obj` is dropped before stash ops
+    let ref_name = format!("refs/heads/{}", branch);
+    {
+        let obj = repo
+            .revparse_single(&ref_name)
+            .map_err(|e| format!("Branch '{}' not found: {}", branch, e))?;
+
+        repo.checkout_tree(&obj, None)
+            .map_err(|e| format!("Failed to checkout '{}': {}", branch, e))?;
+    }
+
+    repo.set_head(&ref_name)
+        .map_err(|e| format!("Failed to set HEAD to '{}': {}", branch, e))?;
+
+    // Auto-restore stash for target branch
+    let stash_message = format!("{}{}", AUTO_STASH_PREFIX, branch);
+    let mut stash_index: Option<usize> = None;
+
+    repo.stash_foreach(|index, msg, _oid| {
+        if msg == stash_message {
+            stash_index = Some(index);
+            return false; // stop iteration
+        }
+        true
+    })
+    .ok(); // no stashes is fine
+
+    if let Some(idx) = stash_index {
+        repo.stash_pop(idx, None)
+            .map_err(|e| format!("Failed to restore stash: {}", e))?;
+    }
+
+    Ok(())
+}
+
+fn get_current_branch_inner(repo: &Repository) -> Result<String, String> {
+    let head = repo.head().map_err(|e| e.to_string())?;
+    Ok(head.shorthand().unwrap_or("HEAD").to_string())
+}
+
+/// Return the current branch name.
+pub fn get_current_branch(repo_path: &str) -> Result<String, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    get_current_branch_inner(&repo)
+}
+
+/// List all branches matching the `bentoya/*` prefix.
+pub fn list_task_branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let branches = repo
+        .branches(Some(BranchType::Local))
+        .map_err(|e| e.to_string())?;
+
+    let head = repo.head().ok();
+    let head_name = head
+        .as_ref()
+        .and_then(|h| h.shorthand().map(String::from));
+
+    let mut result = Vec::new();
+
+    for branch_result in branches {
+        let (branch, _) = branch_result.map_err(|e| e.to_string())?;
+        let name = branch
+            .name()
+            .map_err(|e| e.to_string())?
+            .unwrap_or("")
+            .to_string();
+
+        if name.starts_with(BRANCH_PREFIX) {
+            let upstream = branch
+                .upstream()
+                .ok()
+                .and_then(|u| u.name().ok().flatten().map(String::from));
+
+            result.push(BranchInfo {
+                is_head: head_name.as_deref() == Some(name.as_str()),
+                name,
+                upstream,
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+/// Delete a task branch. Returns `true` if the branch was unmerged (deleted anyway).
+pub fn delete_task_branch(repo_path: &str, branch: &str) -> Result<bool, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+
+    let mut branch_ref = repo
+        .find_branch(branch, BranchType::Local)
+        .map_err(|e| format!("Branch '{}' not found: {}", branch, e))?;
+
+    if branch_ref.is_head() {
+        return Err("Cannot delete the currently checked out branch".to_string());
+    }
+
+    // Check if merged into the default base branch
+    let base = detect_base_branch(&repo).unwrap_or_default();
+    let is_unmerged = repo
+        .find_branch(&base, BranchType::Local)
+        .ok()
+        .and_then(|base_branch| {
+            let base_commit = base_branch.get().peel_to_commit().ok()?;
+            let branch_commit = branch_ref.get().peel_to_commit().ok()?;
+            let merge_base = repo.merge_base(base_commit.id(), branch_commit.id()).ok()?;
+            Some(merge_base != branch_commit.id())
+        })
+        .unwrap_or(true);
+
+    branch_ref.delete().map_err(|e| e.to_string())?;
+
+    Ok(is_unmerged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slugify_basic() {
+        assert_eq!(slugify("Add User Auth"), "add-user-auth");
+    }
+
+    #[test]
+    fn test_slugify_special_chars() {
+        assert_eq!(slugify("fix: login bug!"), "fix-login-bug");
+    }
+
+    #[test]
+    fn test_slugify_whitespace() {
+        assert_eq!(slugify("  spaces  "), "spaces");
+    }
+
+    #[test]
+    fn test_slugify_truncation() {
+        let long_input = "a".repeat(60);
+        assert_eq!(slugify(&long_input).len(), 50);
+    }
+
+    #[test]
+    fn test_slugify_hyphens() {
+        assert_eq!(slugify("foo---bar"), "foo-bar");
+    }
+}

--- a/src-tauri/src/git/change_tracker.rs
+++ b/src-tauri/src/git/change_tracker.rs
@@ -1,0 +1,176 @@
+use git2::{BranchType, Diff, DiffFormat, DiffOptions, Patch, Repository};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct FileChange {
+    pub path: String,
+    pub status: String,
+    pub additions: usize,
+    pub deletions: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChangeSummary {
+    pub files: Vec<FileChange>,
+    pub total_additions: usize,
+    pub total_deletions: usize,
+    pub total_files: usize,
+}
+
+/// Detect the default base branch: try "main", then "master", then current HEAD.
+fn find_base_branch(repo: &Repository) -> Result<String, git2::Error> {
+    for name in &["main", "master"] {
+        if repo.find_branch(name, BranchType::Local).is_ok() {
+            return Ok(name.to_string());
+        }
+    }
+    let head = repo.head()?;
+    Ok(head.shorthand().unwrap_or("HEAD").to_string())
+}
+
+/// Compute a tree-to-tree diff between the base branch and a task branch,
+/// optionally filtered to a single file path.
+fn get_branch_diff<'a>(
+    repo: &'a Repository,
+    branch: &str,
+    file_path: Option<&str>,
+) -> Result<Diff<'a>, String> {
+    let base_name = find_base_branch(repo).map_err(|e| e.to_string())?;
+
+    let base_branch = repo
+        .find_branch(&base_name, BranchType::Local)
+        .map_err(|e| format!("Base branch '{}' not found: {}", base_name, e))?;
+    let base_tree = base_branch
+        .get()
+        .peel_to_commit()
+        .map_err(|e| e.to_string())?
+        .tree()
+        .map_err(|e| e.to_string())?;
+
+    let task_branch = repo
+        .find_branch(branch, BranchType::Local)
+        .map_err(|e| format!("Branch '{}' not found: {}", branch, e))?;
+    let task_tree = task_branch
+        .get()
+        .peel_to_commit()
+        .map_err(|e| e.to_string())?
+        .tree()
+        .map_err(|e| e.to_string())?;
+
+    let mut opts = DiffOptions::new();
+    if let Some(path) = file_path {
+        opts.pathspec(path);
+    }
+
+    repo.diff_tree_to_tree(Some(&base_tree), Some(&task_tree), Some(&mut opts))
+        .map_err(|e| e.to_string())
+}
+
+fn status_label(status: git2::Delta) -> String {
+    match status {
+        git2::Delta::Added => "added",
+        git2::Delta::Deleted => "deleted",
+        git2::Delta::Modified => "modified",
+        git2::Delta::Renamed => "renamed",
+        git2::Delta::Copied => "copied",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+/// Return a summary of all changed files on a branch vs its base,
+/// including per-file addition/deletion counts.
+pub fn get_changes(repo_path: &str, branch: &str) -> Result<ChangeSummary, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let diff = get_branch_diff(&repo, branch, None)?;
+
+    let stats = diff.stats().map_err(|e| e.to_string())?;
+    let num_deltas = diff.deltas().len();
+
+    // First pass: collect owned file info from deltas
+    let mut file_infos: Vec<(String, String)> = Vec::with_capacity(num_deltas);
+    for delta in diff.deltas() {
+        let path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        file_infos.push((path, status_label(delta.status())));
+    }
+
+    // Second pass: get per-file line stats from patches
+    let mut files = Vec::with_capacity(num_deltas);
+    for (i, (path, status)) in file_infos.into_iter().enumerate() {
+        let (additions, deletions) = Patch::from_diff(&diff, i)
+            .ok()
+            .flatten()
+            .and_then(|patch| {
+                let (_, adds, dels) = patch.line_stats().ok()?;
+                Some((adds, dels))
+            })
+            .unwrap_or((0, 0));
+
+        files.push(FileChange {
+            path,
+            status,
+            additions,
+            deletions,
+        });
+    }
+
+    Ok(ChangeSummary {
+        total_additions: stats.insertions(),
+        total_deletions: stats.deletions(),
+        total_files: stats.files_changed(),
+        files,
+    })
+}
+
+/// Return a unified diff string for a branch vs its base.
+/// If `file_path` is provided, only that file's diff is returned.
+pub fn get_diff(
+    repo_path: &str,
+    branch: &str,
+    file_path: Option<&str>,
+) -> Result<String, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let diff = get_branch_diff(&repo, branch, file_path)?;
+
+    let mut output = String::new();
+    diff.print(DiffFormat::Patch, |_delta, _hunk, line| {
+        match line.origin() {
+            '+' | '-' | ' ' => {
+                output.push(line.origin());
+                output.push_str(&String::from_utf8_lossy(line.content()));
+            }
+            _ => {
+                // File headers, hunk headers, binary markers
+                output.push_str(&String::from_utf8_lossy(line.content()));
+            }
+        }
+        true
+    })
+    .map_err(|e| e.to_string())?;
+
+    Ok(output)
+}
+
+/// Return the list of file paths touched on a branch vs its base.
+pub fn get_files_touched(repo_path: &str, branch: &str) -> Result<Vec<String>, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let diff = get_branch_diff(&repo, branch, None)?;
+
+    let files: Vec<String> = diff
+        .deltas()
+        .filter_map(|delta| {
+            delta
+                .new_file()
+                .path()
+                .or_else(|| delta.old_file().path())
+                .map(|p| p.to_string_lossy().to_string())
+        })
+        .collect();
+
+    Ok(files)
+}

--- a/src-tauri/src/git/conflict_detector.rs
+++ b/src-tauri/src/git/conflict_detector.rs
@@ -1,0 +1,82 @@
+use std::collections::{HashMap, HashSet};
+
+use git2::{BranchType, Repository};
+use serde::Serialize;
+
+use super::change_tracker::get_files_touched;
+
+const BRANCH_PREFIX: &str = "bentoya/";
+
+#[derive(Debug, Serialize)]
+pub struct ConflictEntry {
+    pub file: String,
+    pub branches: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConflictMatrix {
+    pub conflicts: Vec<ConflictEntry>,
+    pub has_conflicts: bool,
+}
+
+/// Compare all active `bentoya/*` branches and return files that are modified
+/// by more than one branch (potential merge conflicts).
+pub fn get_conflict_matrix(repo_path: &str) -> Result<ConflictMatrix, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let branches = repo
+        .branches(Some(BranchType::Local))
+        .map_err(|e| e.to_string())?;
+
+    // Collect all bentoya/* branch names
+    let mut task_branches = Vec::new();
+    for branch_result in branches {
+        let (branch, _) = branch_result.map_err(|e| e.to_string())?;
+        let name = branch
+            .name()
+            .map_err(|e| e.to_string())?
+            .unwrap_or("")
+            .to_string();
+        if name.starts_with(BRANCH_PREFIX) {
+            task_branches.push(name);
+        }
+    }
+
+    // Build file → set of branches map
+    let mut file_map: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for branch_name in &task_branches {
+        match get_files_touched(repo_path, branch_name) {
+            Ok(files) => {
+                for file in files {
+                    file_map
+                        .entry(file)
+                        .or_default()
+                        .insert(branch_name.clone());
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    // Filter to files touched by 2+ branches
+    let mut conflicts: Vec<ConflictEntry> = file_map
+        .into_iter()
+        .filter(|(_, branches)| branches.len() > 1)
+        .map(|(file, branches)| {
+            let mut branch_list: Vec<String> = branches.into_iter().collect();
+            branch_list.sort();
+            ConflictEntry {
+                file,
+                branches: branch_list,
+            }
+        })
+        .collect();
+
+    conflicts.sort_by(|a, b| a.file.cmp(&b.file));
+    let has_conflicts = !conflicts.is_empty();
+
+    Ok(ConflictMatrix {
+        conflicts,
+        has_conflicts,
+    })
+}

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,1 +1,3 @@
-// Git operations: branch management, change tracking, conflict detection
+pub mod branch_manager;
+pub mod change_tracker;
+pub mod conflict_detector;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
-pub mod commands;
 pub mod checklist;
+pub mod commands;
 pub mod config;
 pub mod db;
 pub mod git;
@@ -12,7 +12,17 @@ pub mod process;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![commands::greet])
+        .invoke_handler(tauri::generate_handler![
+            commands::greet,
+            commands::git::create_task_branch,
+            commands::git::switch_branch,
+            commands::git::get_current_branch,
+            commands::git::list_task_branches,
+            commands::git::delete_task_branch,
+            commands::git::get_changes,
+            commands::git::get_diff,
+            commands::git::get_conflict_matrix,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/components/review/diff-viewer.tsx
+++ b/src/components/review/diff-viewer.tsx
@@ -1,0 +1,430 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { BundledLanguage, Highlighter, ThemedToken } from 'shiki'
+
+// --- Types ---
+
+interface DiffLine {
+  type: 'context' | 'add' | 'remove'
+  content: string
+  oldLineNumber: number | null
+  newLineNumber: number | null
+}
+
+interface DiffHunk {
+  header: string
+  lines: DiffLine[]
+}
+
+interface DiffFile {
+  oldPath: string
+  newPath: string
+  additions: number
+  deletions: number
+  hunks: DiffHunk[]
+}
+
+export interface DiffViewerProps {
+  /** Raw unified diff string */
+  diff: string
+  /** Default collapsed state per file (default: false) */
+  defaultCollapsed?: boolean
+}
+
+// --- Diff Parser ---
+
+const FILE_HEADER_RE = /^diff --git a\/(.+) b\/(.+)$/
+const HUNK_HEADER_RE = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/
+
+function parseDiff(raw: string): DiffFile[] {
+  const lines = raw.split('\n')
+  const files: DiffFile[] = []
+  let currentFile: DiffFile | null = null
+  let currentHunk: DiffHunk | null = null
+  let oldLine = 0
+  let newLine = 0
+
+  for (const line of lines) {
+    const fileMatch = line.match(FILE_HEADER_RE)
+    if (fileMatch) {
+      currentFile = {
+        oldPath: fileMatch[1] ?? '',
+        newPath: fileMatch[2] ?? '',
+        additions: 0,
+        deletions: 0,
+        hunks: [],
+      }
+      files.push(currentFile)
+      currentHunk = null
+      continue
+    }
+
+    // Skip index and --- / +++ header lines
+    if (line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++')) {
+      continue
+    }
+
+    const hunkMatch = line.match(HUNK_HEADER_RE)
+    if (hunkMatch && currentFile) {
+      oldLine = parseInt(hunkMatch[1] ?? '0', 10)
+      newLine = parseInt(hunkMatch[2] ?? '0', 10)
+      currentHunk = { header: line, lines: [] }
+      currentFile.hunks.push(currentHunk)
+      continue
+    }
+
+    if (!currentHunk || !currentFile) continue
+
+    if (line.startsWith('+')) {
+      currentHunk.lines.push({
+        type: 'add',
+        content: line.slice(1),
+        oldLineNumber: null,
+        newLineNumber: newLine++,
+      })
+      currentFile.additions++
+    } else if (line.startsWith('-')) {
+      currentHunk.lines.push({
+        type: 'remove',
+        content: line.slice(1),
+        oldLineNumber: oldLine++,
+        newLineNumber: null,
+      })
+      currentFile.deletions++
+    } else if (line.startsWith(' ')) {
+      currentHunk.lines.push({
+        type: 'context',
+        content: line.slice(1),
+        oldLineNumber: oldLine++,
+        newLineNumber: newLine++,
+      })
+    }
+  }
+
+  return files
+}
+
+// --- Shiki Lazy Loader ---
+
+const LANG_MAP: Record<string, BundledLanguage> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  jsx: 'jsx',
+  rs: 'rust',
+  py: 'python',
+  css: 'css',
+  html: 'html',
+  json: 'json',
+  md: 'markdown',
+  toml: 'toml',
+  yaml: 'yaml',
+  yml: 'yaml',
+  sh: 'bash',
+  sql: 'sql',
+  svg: 'xml',
+  xml: 'xml',
+}
+
+function detectLanguage(filePath: string): BundledLanguage | null {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
+  return LANG_MAP[ext] ?? null
+}
+
+let highlighterPromise: Promise<Highlighter> | null = null
+const loadedLangs = new Set<string>()
+
+async function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = import('shiki').then((mod) =>
+      mod.createHighlighter({ themes: ['github-dark'], langs: [] })
+    )
+  }
+  return highlighterPromise
+}
+
+async function tokenizeCode(
+  code: string,
+  lang: BundledLanguage
+): Promise<ThemedToken[][] | null> {
+  try {
+    const hl = await getHighlighter()
+    if (!loadedLangs.has(lang)) {
+      await hl.loadLanguage(lang)
+      loadedLangs.add(lang)
+    }
+    const result = hl.codeToTokens(code, { lang, theme: 'github-dark' })
+    return result.tokens
+  } catch {
+    return null
+  }
+}
+
+// --- Styles ---
+
+const LINE_BG = {
+  add: 'rgba(74, 222, 128, 0.1)',
+  remove: 'rgba(248, 113, 113, 0.1)',
+  context: 'transparent',
+} as const
+
+const GUTTER_COLOR = {
+  add: '#4ADE80',
+  remove: '#F87171',
+  context: 'var(--text-muted)',
+} as const
+
+// --- Components ---
+
+function TokenizedLine({ tokens }: { tokens: ThemedToken[] }) {
+  return (
+    <>
+      {tokens.map((token, i) => (
+        <span key={i} style={{ color: token.color }}>
+          {token.content}
+        </span>
+      ))}
+    </>
+  )
+}
+
+function DiffLineRow({
+  line,
+  tokens,
+}: {
+  line: DiffLine
+  tokens: ThemedToken[] | null
+}) {
+  const gutterWidth = 48
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        background: LINE_BG[line.type],
+        fontFamily: 'var(--font-mono)',
+        fontSize: 13,
+        lineHeight: '20px',
+      }}
+    >
+      {/* Old line number */}
+      <span
+        style={{
+          width: gutterWidth,
+          minWidth: gutterWidth,
+          textAlign: 'right',
+          paddingRight: 8,
+          color: GUTTER_COLOR[line.type],
+          opacity: 0.6,
+          userSelect: 'none',
+          flexShrink: 0,
+        }}
+      >
+        {line.oldLineNumber ?? ''}
+      </span>
+      {/* New line number */}
+      <span
+        style={{
+          width: gutterWidth,
+          minWidth: gutterWidth,
+          textAlign: 'right',
+          paddingRight: 8,
+          color: GUTTER_COLOR[line.type],
+          opacity: 0.6,
+          userSelect: 'none',
+          flexShrink: 0,
+        }}
+      >
+        {line.newLineNumber ?? ''}
+      </span>
+      {/* +/- indicator */}
+      <span
+        style={{
+          width: 20,
+          minWidth: 20,
+          textAlign: 'center',
+          color: GUTTER_COLOR[line.type],
+          userSelect: 'none',
+          flexShrink: 0,
+        }}
+      >
+        {line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' '}
+      </span>
+      {/* Content */}
+      <span
+        style={{
+          flex: 1,
+          whiteSpace: 'pre',
+          overflowX: 'auto',
+          paddingRight: 16,
+        }}
+      >
+        {tokens ? <TokenizedLine tokens={tokens} /> : line.content}
+      </span>
+    </div>
+  )
+}
+
+function FileSection({
+  file,
+  defaultCollapsed,
+  tokensByLine,
+}: {
+  file: DiffFile
+  defaultCollapsed: boolean
+  tokensByLine: Map<number, ThemedToken[]> | null
+}) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed)
+
+  const toggle = useCallback(() => { setCollapsed((c) => !c) }, [])
+
+  // Compute a global line index across all hunks for token lookup
+  let globalLineIdx = 0
+
+  return (
+    <div
+      style={{
+        borderRadius: 6,
+        border: '1px solid var(--border-default)',
+        overflow: 'hidden',
+        marginBottom: 8,
+      }}
+    >
+      {/* File header */}
+      <button
+        onClick={toggle}
+        type="button"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          width: '100%',
+          padding: '8px 12px',
+          background: 'var(--bg-tertiary)',
+          border: 'none',
+          color: 'var(--text-primary)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 13,
+          cursor: 'pointer',
+          textAlign: 'left',
+        }}
+      >
+        <span style={{ transform: collapsed ? 'rotate(-90deg)' : 'rotate(0)', transition: 'transform 0.15s' }}>
+          ▼
+        </span>
+        <span style={{ flex: 1 }}>{file.newPath}</span>
+        <span style={{ color: '#4ADE80', fontSize: 12 }}>+{file.additions}</span>
+        <span style={{ color: '#F87171', fontSize: 12 }}>-{file.deletions}</span>
+      </button>
+
+      {/* Diff content */}
+      {!collapsed && (
+        <div style={{ background: 'var(--bg-secondary)', overflowX: 'auto' }}>
+          {file.hunks.map((hunk, hi) => (
+            <div key={hi}>
+              {/* Hunk header */}
+              <div
+                style={{
+                  padding: '4px 12px 4px 116px',
+                  background: 'rgba(59, 130, 246, 0.08)',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                }}
+              >
+                {hunk.header}
+              </div>
+              {/* Lines */}
+              {hunk.lines.map((line, li) => {
+                const idx = globalLineIdx++
+                return (
+                  <DiffLineRow
+                    key={`${String(hi)}-${String(li)}`}
+                    line={line}
+                    tokens={tokensByLine?.get(idx) ?? null}
+                  />
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// --- Main Component ---
+
+export function DiffViewer({ diff, defaultCollapsed = false }: DiffViewerProps) {
+  const files = useMemo(() => parseDiff(diff), [diff])
+  const [tokenMap, setTokenMap] = useState<Map<string, Map<number, ThemedToken[]>>>(new Map())
+
+  // Lazy-load Shiki and tokenize each file's content
+  useEffect(() => {
+    let cancelled = false
+
+    async function highlight() {
+      const newMap = new Map<string, Map<number, ThemedToken[]>>()
+
+      for (const file of files) {
+        const lang = detectLanguage(file.newPath)
+        if (!lang) continue
+
+        // Combine all line contents for the file (preserves cross-line token state)
+        const allLines: string[] = []
+        for (const hunk of file.hunks) {
+          for (const line of hunk.lines) {
+            allLines.push(line.content)
+          }
+        }
+
+        if (allLines.length === 0) continue
+
+        const code = allLines.join('\n')
+        const tokens = await tokenizeCode(code, lang)
+        if (cancelled) return
+
+        if (tokens) {
+          const lineMap = new Map<number, ThemedToken[]>()
+          tokens.forEach((lineTokens, idx) => {
+            lineMap.set(idx, lineTokens)
+          })
+          newMap.set(file.newPath, lineMap)
+        }
+      }
+
+      if (!cancelled) setTokenMap(newMap)
+    }
+
+    void highlight()
+    return () => { cancelled = true }
+  }, [files])
+
+  if (!diff.trim()) {
+    return (
+      <div
+        style={{
+          padding: 24,
+          color: 'var(--text-muted)',
+          textAlign: 'center',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 13,
+        }}
+      >
+        No changes to display
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+      {files.map((file) => (
+        <FileSection
+          key={file.newPath}
+          file={file}
+          defaultCollapsed={defaultCollapsed}
+          tokensByLine={tokenMap.get(file.newPath) ?? null}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/review/review-actions.tsx
+++ b/src/components/review/review-actions.tsx
@@ -1,0 +1,49 @@
+export interface ReviewActionsProps {
+  onApprove?: () => void
+  onReject?: () => void
+  disabled?: boolean
+}
+
+/** Placeholder approve/reject buttons for v0.1 — full pipeline integration in v0.2. */
+export function ReviewActions({ onApprove, onReject, disabled = false }: ReviewActionsProps) {
+  return (
+    <div style={{ display: 'flex', gap: 8, padding: '12px 0' }}>
+      <button
+        type="button"
+        onClick={onApprove}
+        disabled={disabled}
+        style={{
+          padding: '6px 16px',
+          borderRadius: 6,
+          border: '1px solid #4ADE80',
+          background: 'rgba(74, 222, 128, 0.1)',
+          color: '#4ADE80',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 13,
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        Approve
+      </button>
+      <button
+        type="button"
+        onClick={onReject}
+        disabled={disabled}
+        style={{
+          padding: '6px 16px',
+          borderRadius: 6,
+          border: '1px solid #F87171',
+          background: 'rgba(248, 113, 113, 0.1)',
+          color: '#F87171',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 13,
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        Reject
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **T005 — Git Branch Manager & Change Tracker**: Full git2-based backend for branch lifecycle (`create_task_branch`, `switch_branch`, `list_task_branches`, `delete_task_branch`), change tracking (`get_changes`, `get_diff`, `get_files_touched`), and cross-branch conflict detection (`get_conflict_matrix`). Auto-stash/restore on branch switch. All exposed as async Tauri commands via `tokio::spawn_blocking`.
- **T012 — Diff Viewer**: Inline diff viewer component that parses unified diff format, renders with per-line Shiki syntax highlighting (lazy-loaded), collapsible file sections, dual line numbers, and dark theme diff colors. Includes placeholder `ReviewActions` component for v0.2 pipeline integration.

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo test` — 5 slugify unit tests pass
- [x] `pnpm run type-check` — no errors
- [x] `pnpm run lint` — no errors
- [ ] Manual: verify branch create/switch/list/delete against a real git repo
- [ ] Manual: render diff viewer with sample unified diff data