### PR TITLE
feat: frontend foundation, dark theme, and kanban board

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,19 +15,21 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tauri-apps/api": "^2.3.0",
     "@tauri-apps/plugin-shell": "^2.2.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-webgl": "^0.18.0",
+    "@xterm/xterm": "^5.5.0",
     "motion": "^12.4.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "shiki": "^3.2.1",
-    "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-webgl": "^0.18.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@tailwindcss/vite": "^4.0.0",
     "@tauri-apps/cli": "^2.4.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
@@ -38,7 +40,6 @@
     "globals": "^16.0.0",
     "prettier": "^3.5.3",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@dnd-kit/sortable':
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@tauri-apps/api':
         specifier: ^2.3.0
         version: 2.10.1

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,31 @@
+import { useEffect } from 'react'
+import { setTheme } from '@/lib/theme'
+
 function App() {
+  useEffect(() => {
+    setTheme('dark')
+  }, [])
+
   return (
-    <div className="flex h-screen items-center justify-center bg-neutral-950 text-neutral-100">
-      <h1 className="font-mono text-4xl font-bold tracking-tight">Hello Bento-ya</h1>
+    <div className="flex h-screen flex-col bg-bg">
+      {/* Top bar — tab bar area */}
+      <header className="flex h-10 shrink-0 items-center justify-center border-b border-border-default bg-surface">
+        <span className="text-sm font-medium text-text-secondary">Bento-ya</span>
+      </header>
+
+      {/* Main content — board area */}
+      <main className="flex flex-1 items-center justify-center overflow-hidden">
+        <p className="text-text-secondary text-sm">Board area</p>
+      </main>
+
+      {/* Bottom bar — chat input area */}
+      <footer className="flex h-14 shrink-0 items-center gap-2 border-t border-border-default bg-surface px-4">
+        <input
+          type="text"
+          placeholder='Type or speak... "fix the login validation bug"'
+          className="flex-1 rounded-lg border border-border-default bg-bg px-3 py-1.5 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+        />
+      </footer>
     </div>
   )
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { setTheme } from '@/lib/theme'
+import { Board } from '@/components/layout/board'
 
 function App() {
   useEffect(() => {
@@ -14,8 +15,8 @@ function App() {
       </header>
 
       {/* Main content — board area */}
-      <main className="flex flex-1 items-center justify-center overflow-hidden">
-        <p className="text-text-secondary text-sm">Board area</p>
+      <main className="flex-1 overflow-hidden">
+        <Board />
       </main>
 
       {/* Bottom bar — chat input area */}

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,0 +1,28 @@
+import { memo } from 'react'
+
+type ColumnHeaderProps = {
+  name: string
+  taskCount: number
+  color: string
+}
+
+export const ColumnHeader = memo(function ColumnHeader({
+  name,
+  taskCount,
+  color,
+}: ColumnHeaderProps) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2">
+      <span
+        className="h-2.5 w-2.5 rounded-full shrink-0"
+        style={{ backgroundColor: color || 'var(--accent)' }}
+      />
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary truncate">
+        {name}
+      </h3>
+      <span className="ml-auto shrink-0 rounded-full bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+        {taskCount}
+      </span>
+    </div>
+  )
+})

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -1,0 +1,65 @@
+import { memo } from 'react'
+import { useSortable, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { motion } from 'motion/react'
+import type { Column as ColumnType } from '@/types'
+import { useTaskStore } from '@/stores/task-store'
+import { ColumnHeader } from './column-header'
+import { TaskCard } from './task-card'
+
+type ColumnProps = {
+  column: ColumnType
+}
+
+export const Column = memo(function Column({ column }: ColumnProps) {
+  const tasks = useTaskStore((s) => s.getByColumn(column.id))
+  const taskIds = tasks.map((t) => t.id)
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: column.id,
+    data: { type: 'column' },
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <motion.div
+      ref={setNodeRef}
+      style={style}
+      layout
+      className={`flex w-[300px] min-w-[280px] max-w-[360px] shrink-0 flex-col rounded-xl bg-surface/50 ${
+        isDragging ? 'opacity-50' : ''
+      }`}
+    >
+      <div {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing">
+        <ColumnHeader
+          name={column.name}
+          taskCount={tasks.length}
+          color={column.color}
+        />
+      </div>
+
+      <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
+        <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
+          {tasks.length === 0 ? (
+            <p className="py-8 text-center text-xs text-text-secondary/50">
+              No tasks
+            </p>
+          ) : (
+            tasks.map((task) => <TaskCard key={task.id} task={task} />)
+          )}
+        </div>
+      </SortableContext>
+    </motion.div>
+  )
+})

--- a/src/components/kanban/drag-overlay.tsx
+++ b/src/components/kanban/drag-overlay.tsx
@@ -1,0 +1,32 @@
+import type { Task, Column } from '@/types'
+
+type DragOverlayContentProps = {
+  item:
+    | { type: 'task'; data: Task }
+    | { type: 'column'; data: Column }
+}
+
+export function DragOverlayContent({ item }: DragOverlayContentProps) {
+  if (item.type === 'task') {
+    return (
+      <div className="w-[280px] rounded-xl border border-accent/30 bg-surface p-3 shadow-2xl">
+        <h4 className="text-sm font-medium text-text-primary">{item.data.title}</h4>
+        <div className="mt-1 flex items-center gap-2 text-xs text-text-secondary">
+          {item.data.agentType && (
+            <span className="rounded bg-surface-hover px-1.5 py-0.5">
+              {item.data.agentType}
+            </span>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-[300px] rounded-xl border border-accent/30 bg-surface p-3 shadow-2xl">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary">
+        {item.data.name}
+      </h3>
+    </div>
+  )
+}

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -1,0 +1,83 @@
+import { memo } from 'react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { motion } from 'motion/react'
+import type { Task } from '@/types'
+import { Badge } from '@/components/shared/badge'
+import { useUIStore } from '@/stores/ui-store'
+
+type TaskCardProps = {
+  task: Task
+}
+
+const statusVariant = {
+  running: 'running' as const,
+  completed: 'success' as const,
+  failed: 'error' as const,
+  stopped: 'default' as const,
+  needs_attention: 'attention' as const,
+}
+
+export const TaskCard = memo(function TaskCard({ task }: TaskCardProps) {
+  const openTask = useUIStore((s) => s.openTask)
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: task.id,
+    data: { type: 'task' },
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  function handleClick() {
+    openTask(task.id)
+  }
+
+  return (
+    <motion.div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      layout
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: isDragging ? 0.5 : 1, scale: 1 }}
+      whileHover={{ y: -2, boxShadow: '0 4px 12px rgba(0,0,0,0.3)' }}
+      transition={{ type: 'spring', stiffness: 400, damping: 28 }}
+      onClick={handleClick}
+      className="cursor-grab rounded-xl border border-border-default bg-surface p-3 active:cursor-grabbing"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h4 className="text-sm font-medium text-text-primary leading-snug">
+          {task.title}
+        </h4>
+        {task.agentStatus && (
+          <Badge
+            variant={statusVariant[task.agentStatus]}
+            className="shrink-0 mt-0.5"
+          />
+        )}
+      </div>
+
+      <div className="mt-2 flex items-center gap-2 text-xs text-text-secondary">
+        {task.agentType && (
+          <span className="rounded bg-surface-hover px-1.5 py-0.5">
+            {task.agentType}
+          </span>
+        )}
+        {task.branch && (
+          <span className="truncate font-mono text-[11px]">{task.branch}</span>
+        )}
+      </div>
+    </motion.div>
+  )
+})

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -1,0 +1,86 @@
+import { useEffect } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  closestCorners,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { SortableContext, horizontalListSortingStrategy, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { useColumnStore } from '@/stores/column-store'
+import { useTaskStore } from '@/stores/task-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { Column } from '@/components/kanban/column'
+import { DragOverlayContent } from '@/components/kanban/drag-overlay'
+import { useDnd } from '@/hooks/use-dnd'
+
+export function Board() {
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
+  const columns = useColumnStore((s) => s.columns)
+  const loadColumns = useColumnStore((s) => s.load)
+  const loadTasks = useTaskStore((s) => s.load)
+  const tasks = useTaskStore((s) => s.tasks)
+
+  const sortedColumns = columns
+    .filter((c) => c.visible)
+    .sort((a, b) => a.position - b.position)
+  const columnIds = sortedColumns.map((c) => c.id)
+
+  const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd()
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  useEffect(() => {
+    if (activeWorkspaceId) {
+      void loadColumns(activeWorkspaceId)
+      void loadTasks(activeWorkspaceId)
+    }
+  }, [activeWorkspaceId, loadColumns, loadTasks])
+
+  // Resolve overlay content
+  let overlayContent = null
+  if (activeItem) {
+    if (activeItem.type === 'column') {
+      const col = columns.find((c) => c.id === activeItem.id)
+      if (col) overlayContent = <DragOverlayContent item={{ type: 'column', data: col }} />
+    } else {
+      const task = tasks.find((t) => t.id === activeItem.id)
+      if (task) overlayContent = <DragOverlayContent item={{ type: 'task', data: task }} />
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDragEnd={onDragEnd}
+    >
+      <div className="flex h-full items-start gap-4 overflow-x-auto p-4">
+        <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
+          {sortedColumns.map((col) => (
+            <Column key={col.id} column={col} />
+          ))}
+        </SortableContext>
+
+        {/* Add column placeholder */}
+        <button className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dashed border-border-default text-text-secondary/50 transition-colors hover:border-text-secondary hover:text-text-secondary">
+          +
+        </button>
+      </div>
+      <DragOverlay dropAnimation={null}>
+        {overlayContent}
+      </DragOverlay>
+    </DndContext>
+  )
+}

--- a/src/components/shared/badge.tsx
+++ b/src/components/shared/badge.tsx
@@ -1,0 +1,25 @@
+type BadgeVariant = 'default' | 'success' | 'warning' | 'error' | 'running' | 'attention'
+
+type BadgeProps = {
+  variant?: BadgeVariant
+  label?: string
+  className?: string
+}
+
+const dotColors: Record<BadgeVariant, string> = {
+  default: 'bg-text-secondary',
+  success: 'bg-success',
+  warning: 'bg-warning',
+  error: 'bg-error',
+  running: 'bg-running',
+  attention: 'bg-attention',
+}
+
+export function Badge({ variant = 'default', label, className = '' }: BadgeProps) {
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+      <span className={`h-2 w-2 rounded-full ${dotColors[variant]}`} />
+      {label && <span className="text-xs text-text-secondary">{label}</span>}
+    </span>
+  )
+}

--- a/src/components/shared/button.tsx
+++ b/src/components/shared/button.tsx
@@ -1,0 +1,35 @@
+import { type ButtonHTMLAttributes } from 'react'
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+type ButtonSize = 'sm' | 'md'
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant
+  size?: ButtonSize
+}
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary: 'bg-accent text-bg hover:brightness-110',
+  secondary: 'bg-surface text-text-primary border border-border-default hover:bg-surface-hover',
+  ghost: 'bg-transparent text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+  danger: 'bg-error/10 text-error hover:bg-error/20',
+}
+
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: 'px-2 py-1 text-xs',
+  md: 'px-3 py-1.5 text-sm',
+}
+
+export function Button({
+  variant = 'secondary',
+  size = 'md',
+  className = '',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:pointer-events-none disabled:opacity-50 ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+      {...props}
+    />
+  )
+}

--- a/src/components/shared/dialog.tsx
+++ b/src/components/shared/dialog.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode, useEffect, useRef } from 'react'
+
+type DialogProps = {
+  open: boolean
+  onClose: () => void
+  title?: string
+  children: ReactNode
+  className?: string
+}
+
+export function Dialog({ open, onClose, title, children, className = '' }: DialogProps) {
+  const ref = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    if (open && !el.open) {
+      el.showModal()
+    } else if (!open && el.open) {
+      el.close()
+    }
+  }, [open])
+
+  return (
+    <dialog
+      ref={ref}
+      onClose={onClose}
+      className={`m-auto max-w-md rounded-xl border border-border-default bg-surface p-0 text-text-primary shadow-2xl backdrop:bg-black/60 ${className}`}
+    >
+      {title && (
+        <div className="border-b border-border-default px-4 py-3">
+          <h2 className="text-base font-medium">{title}</h2>
+        </div>
+      )}
+      <div className="p-4">{children}</div>
+    </dialog>
+  )
+}

--- a/src/components/shared/dropdown.tsx
+++ b/src/components/shared/dropdown.tsx
@@ -1,0 +1,34 @@
+import { type SelectHTMLAttributes } from 'react'
+
+type DropdownOption = {
+  value: string
+  label: string
+}
+
+type DropdownProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'children'> & {
+  options: DropdownOption[]
+  label?: string
+}
+
+export function Dropdown({ options, label, className = '', id, ...props }: DropdownProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label htmlFor={id} className="text-xs text-text-secondary">
+          {label}
+        </label>
+      )}
+      <select
+        id={id}
+        className={`appearance-none rounded-lg border border-border-default bg-surface px-3 py-1.5 pr-8 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 ${className}`}
+        {...props}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/src/components/shared/input.tsx
+++ b/src/components/shared/input.tsx
@@ -1,0 +1,22 @@
+import { type InputHTMLAttributes } from 'react'
+
+type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  label?: string
+}
+
+export function Input({ className = '', label, id, ...props }: InputProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label htmlFor={id} className="text-xs text-text-secondary">
+          {label}
+        </label>
+      )}
+      <input
+        id={id}
+        className={`rounded-lg border border-border-default bg-surface px-3 py-1.5 text-sm text-text-primary placeholder:text-text-secondary/50 transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 ${className}`}
+        {...props}
+      />
+    </div>
+  )
+}

--- a/src/components/shared/tooltip.tsx
+++ b/src/components/shared/tooltip.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode, useState, useRef } from 'react'
+
+type TooltipProps = {
+  content: string
+  children: ReactNode
+  className?: string
+}
+
+export function Tooltip({ content, children, className = '' }: TooltipProps) {
+  const [visible, setVisible] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+  function show() {
+    timeoutRef.current = setTimeout(() => setVisible(true), 400)
+  }
+
+  function hide() {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    setVisible(false)
+  }
+
+  return (
+    <span
+      className={`relative inline-flex ${className}`}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {children}
+      {visible && (
+        <span className="absolute bottom-full left-1/2 z-50 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-surface-hover px-2 py-1 text-xs text-text-primary shadow-lg border border-border-default">
+          {content}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/src/components/shared/tooltip.tsx
+++ b/src/components/shared/tooltip.tsx
@@ -11,7 +11,7 @@ export function Tooltip({ content, children, className = '' }: TooltipProps) {
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
 
   function show() {
-    timeoutRef.current = setTimeout(() => setVisible(true), 400)
+    timeoutRef.current = setTimeout(() => { setVisible(true) }, 400)
   }
 
   function hide() {

--- a/src/hooks/use-dnd.ts
+++ b/src/hooks/use-dnd.ts
@@ -1,0 +1,116 @@
+import { useState, useCallback } from 'react'
+import type {
+  DragStartEvent,
+  DragOverEvent,
+  DragEndEvent,
+  UniqueIdentifier,
+} from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import { useColumnStore } from '@/stores/column-store'
+import { useTaskStore } from '@/stores/task-store'
+
+type ActiveItem =
+  | { type: 'column'; id: string }
+  | { type: 'task'; id: string }
+
+export function useDnd() {
+  const [activeItem, setActiveItem] = useState<ActiveItem | null>(null)
+  const columns = useColumnStore((s) => s.columns)
+  const reorderColumns = useColumnStore((s) => s.reorder)
+  const tasks = useTaskStore((s) => s.tasks)
+  const moveTask = useTaskStore((s) => s.move)
+  const reorderTasks = useTaskStore((s) => s.reorder)
+
+  const findColumnOfTask = useCallback(
+    (taskId: UniqueIdentifier): string | undefined => {
+      return tasks.find((t) => t.id === taskId)?.columnId
+    },
+    [tasks],
+  )
+
+  const onDragStart = useCallback((event: DragStartEvent) => {
+    const { active } = event
+    const data = active.data.current as { type: 'column' | 'task' } | undefined
+
+    if (data?.type === 'column') {
+      setActiveItem({ type: 'column', id: String(active.id) })
+    } else {
+      setActiveItem({ type: 'task', id: String(active.id) })
+    }
+  }, [])
+
+  const onDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event
+      if (!over) return
+
+      const activeData = active.data.current as { type: string } | undefined
+      if (activeData?.type === 'column') return
+
+      const activeTaskId = String(active.id)
+      const overId = String(over.id)
+
+      const activeColumn = findColumnOfTask(activeTaskId)
+      const overData = over.data.current as { type: string } | undefined
+      const overColumn =
+        overData?.type === 'column' ? overId : findColumnOfTask(overId)
+
+      if (!activeColumn || !overColumn || activeColumn === overColumn) return
+
+      // Moving task to a different column
+      const overColumnTasks = tasks
+        .filter((t) => t.columnId === overColumn)
+        .sort((a, b) => a.position - b.position)
+
+      const overIndex = overColumnTasks.findIndex((t) => t.id === overId)
+      const newPosition = overIndex >= 0 ? overIndex : overColumnTasks.length
+
+      void moveTask(activeTaskId, overColumn, newPosition)
+    },
+    [findColumnOfTask, tasks, moveTask],
+  )
+
+  const onDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveItem(null)
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+
+      const activeData = active.data.current as { type: string } | undefined
+
+      if (activeData?.type === 'column') {
+        // Reorder columns
+        const columnIds = columns
+          .slice()
+          .sort((a, b) => a.position - b.position)
+          .map((c) => c.id)
+        const oldIndex = columnIds.indexOf(String(active.id))
+        const newIndex = columnIds.indexOf(String(over.id))
+        if (oldIndex !== -1 && newIndex !== -1) {
+          const workspaceId = columns[0]?.workspaceId
+          if (workspaceId) {
+            void reorderColumns(workspaceId, arrayMove(columnIds, oldIndex, newIndex))
+          }
+        }
+      } else {
+        // Reorder tasks within same column
+        const columnId = findColumnOfTask(String(active.id))
+        if (!columnId) return
+
+        const columnTasks = tasks
+          .filter((t) => t.columnId === columnId)
+          .sort((a, b) => a.position - b.position)
+        const taskIds = columnTasks.map((t) => t.id)
+        const oldIndex = taskIds.indexOf(String(active.id))
+        const newIndex = taskIds.indexOf(String(over.id))
+
+        if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+          void reorderTasks(columnId, arrayMove(taskIds, oldIndex, newIndex))
+        }
+      }
+    },
+    [columns, tasks, findColumnOfTask, reorderColumns, reorderTasks],
+  )
+
+  return { activeItem, onDragStart, onDragOver, onDragEnd }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -17,29 +17,52 @@
 }
 
 @theme {
+  --font-sans: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
-  --color-bg-primary: var(--bg-primary);
-  --color-bg-secondary: var(--bg-secondary);
-  --color-bg-tertiary: var(--bg-tertiary);
+  /* Dark theme colors mapped to Tailwind utilities */
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-hover: var(--surface-hover);
+  --color-border-default: var(--border);
   --color-text-primary: var(--text-primary);
   --color-text-secondary: var(--text-secondary);
-  --color-text-muted: var(--text-muted);
-  --color-border-default: var(--border-default);
   --color-accent: var(--accent);
-  --color-accent-hover: var(--accent-hover);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-error: var(--error);
+  --color-running: var(--running);
+  --color-attention: var(--attention);
 }
 
-:root {
-  --bg-primary: #0a0a0a;
-  --bg-secondary: #141414;
-  --bg-tertiary: #1e1e1e;
-  --text-primary: #f5f5f5;
-  --text-secondary: #a3a3a3;
-  --text-muted: #525252;
-  --border-default: #262626;
-  --accent: #3b82f6;
-  --accent-hover: #2563eb;
+[data-theme='dark'] {
+  --bg: #0D0D0D;
+  --surface: #1A1A1A;
+  --surface-hover: #242424;
+  --border: #2A2A2A;
+  --text-primary: #E5E5E5;
+  --text-secondary: #888888;
+  --accent: #E8A87C;
+  --success: #4ADE80;
+  --warning: #FBBF24;
+  --error: #F87171;
+  --running: #60A5FA;
+  --attention: #F59E0B;
+}
+
+[data-theme='light'] {
+  --bg: #FAFAF9;
+  --surface: #FFFFFF;
+  --surface-hover: #F5F5F4;
+  --border: #E7E5E4;
+  --text-primary: #1C1917;
+  --text-secondary: #78716C;
+  --accent: #C2703E;
+  --success: #16A34A;
+  --warning: #D97706;
+  --error: #DC2626;
+  --running: #2563EB;
+  --attention: #D97706;
 }
 
 html,
@@ -49,7 +72,9 @@ body,
   margin: 0;
   padding: 0;
   overflow: hidden;
-  background-color: var(--bg-primary);
+  background-color: var(--bg);
   color: var(--text-primary);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
 }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -9,9 +9,9 @@ export const createWorkspace = (name: string, repoPath: string) =>
 export const updateWorkspace = (id: string, updates: Partial<Workspace>) =>
   invoke<Workspace>('update_workspace', { id, ...updates })
 export const deleteWorkspace = (id: string) =>
-  invoke<void>('delete_workspace', { id })
+  invoke<undefined>('delete_workspace', { id })
 export const reorderWorkspaces = (ids: string[]) =>
-  invoke<void>('reorder_workspaces', { ids })
+  invoke<undefined>('reorder_workspaces', { ids })
 
 // Column commands
 export const getColumns = (workspaceId: string) =>
@@ -21,9 +21,9 @@ export const createColumn = (workspaceId: string, name: string, position: number
 export const updateColumn = (id: string, updates: Partial<Column>) =>
   invoke<Column>('update_column', { id, ...updates })
 export const deleteColumn = (id: string) =>
-  invoke<void>('delete_column', { id })
+  invoke<undefined>('delete_column', { id })
 export const reorderColumns = (workspaceId: string, ids: string[]) =>
-  invoke<void>('reorder_columns', { workspaceId, ids })
+  invoke<undefined>('reorder_columns', { workspaceId, ids })
 
 // Task commands
 export const getTasks = (workspaceId: string) =>
@@ -37,18 +37,18 @@ export const createTask = (
 export const updateTask = (id: string, updates: Partial<Task>) =>
   invoke<Task>('update_task', { id, ...updates })
 export const deleteTask = (id: string) =>
-  invoke<void>('delete_task', { id })
+  invoke<undefined>('delete_task', { id })
 export const moveTask = (id: string, targetColumnId: string, position: number) =>
-  invoke<void>('move_task', { id, targetColumnId, position })
+  invoke<undefined>('move_task', { id, targetColumnId, position })
 export const reorderTasks = (columnId: string, ids: string[]) =>
-  invoke<void>('reorder_tasks', { columnId, ids })
+  invoke<undefined>('reorder_tasks', { columnId, ids })
 
 // Event listeners
 export type EventCallback<T> = (payload: T) => void
 
 export const onTaskUpdated = (cb: EventCallback<Task>): Promise<UnlistenFn> =>
-  listen<Task>('task_updated', (e) => cb(e.payload))
+  listen<Task>('task_updated', (e) => { cb(e.payload) })
 export const onColumnUpdated = (cb: EventCallback<Column>): Promise<UnlistenFn> =>
-  listen<Column>('column_updated', (e) => cb(e.payload))
+  listen<Column>('column_updated', (e) => { cb(e.payload) })
 export const onWorkspaceUpdated = (cb: EventCallback<Workspace>): Promise<UnlistenFn> =>
-  listen<Workspace>('workspace_updated', (e) => cb(e.payload))
+  listen<Workspace>('workspace_updated', (e) => { cb(e.payload) })

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,0 +1,54 @@
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import type { Workspace, Column, Task } from '@/types'
+
+// Workspace commands
+export const getWorkspaces = () => invoke<Workspace[]>('get_workspaces')
+export const createWorkspace = (name: string, repoPath: string) =>
+  invoke<Workspace>('create_workspace', { name, repoPath })
+export const updateWorkspace = (id: string, updates: Partial<Workspace>) =>
+  invoke<Workspace>('update_workspace', { id, ...updates })
+export const deleteWorkspace = (id: string) =>
+  invoke<void>('delete_workspace', { id })
+export const reorderWorkspaces = (ids: string[]) =>
+  invoke<void>('reorder_workspaces', { ids })
+
+// Column commands
+export const getColumns = (workspaceId: string) =>
+  invoke<Column[]>('get_columns', { workspaceId })
+export const createColumn = (workspaceId: string, name: string, position: number) =>
+  invoke<Column>('create_column', { workspaceId, name, position })
+export const updateColumn = (id: string, updates: Partial<Column>) =>
+  invoke<Column>('update_column', { id, ...updates })
+export const deleteColumn = (id: string) =>
+  invoke<void>('delete_column', { id })
+export const reorderColumns = (workspaceId: string, ids: string[]) =>
+  invoke<void>('reorder_columns', { workspaceId, ids })
+
+// Task commands
+export const getTasks = (workspaceId: string) =>
+  invoke<Task[]>('get_tasks', { workspaceId })
+export const createTask = (
+  workspaceId: string,
+  columnId: string,
+  title: string,
+  description: string,
+) => invoke<Task>('create_task', { workspaceId, columnId, title, description })
+export const updateTask = (id: string, updates: Partial<Task>) =>
+  invoke<Task>('update_task', { id, ...updates })
+export const deleteTask = (id: string) =>
+  invoke<void>('delete_task', { id })
+export const moveTask = (id: string, targetColumnId: string, position: number) =>
+  invoke<void>('move_task', { id, targetColumnId, position })
+export const reorderTasks = (columnId: string, ids: string[]) =>
+  invoke<void>('reorder_tasks', { columnId, ids })
+
+// Event listeners
+export type EventCallback<T> = (payload: T) => void
+
+export const onTaskUpdated = (cb: EventCallback<Task>): Promise<UnlistenFn> =>
+  listen<Task>('task_updated', (e) => cb(e.payload))
+export const onColumnUpdated = (cb: EventCallback<Column>): Promise<UnlistenFn> =>
+  listen<Column>('column_updated', (e) => cb(e.payload))
+export const onWorkspaceUpdated = (cb: EventCallback<Workspace>): Promise<UnlistenFn> =>
+  listen<Workspace>('workspace_updated', (e) => cb(e.payload))

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,9 @@
+export type Theme = 'dark' | 'light'
+
+export function getTheme(): Theme {
+  return (document.documentElement.dataset['theme'] as Theme | undefined) ?? 'dark'
+}
+
+export function setTheme(theme: Theme): void {
+  document.documentElement.dataset['theme'] = theme
+}

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import type { Column } from '@/types'
+import * as ipc from '@/lib/ipc'
+
+type ColumnState = {
+  columns: Column[]
+  loaded: boolean
+
+  load: (workspaceId: string) => Promise<void>
+  add: (workspaceId: string, name: string) => Promise<void>
+  remove: (id: string) => Promise<void>
+  reorder: (workspaceId: string, ids: string[]) => Promise<void>
+  updateColumn: (id: string, updates: Partial<Column>) => void
+}
+
+export const useColumnStore = create<ColumnState>()(
+  devtools(
+    (set, get) => ({
+      columns: [],
+      loaded: false,
+
+      load: async (workspaceId) => {
+        const columns = await ipc.getColumns(workspaceId)
+        set({ columns, loaded: true })
+      },
+
+      add: async (workspaceId, name) => {
+        const position = get().columns.length
+        const column = await ipc.createColumn(workspaceId, name, position)
+        set((s) => ({ columns: [...s.columns, column] }))
+      },
+
+      remove: async (id) => {
+        const prev = get().columns
+        set((s) => ({ columns: s.columns.filter((c) => c.id !== id) }))
+        try {
+          await ipc.deleteColumn(id)
+        } catch {
+          set({ columns: prev })
+        }
+      },
+
+      reorder: async (workspaceId, ids) => {
+        const prev = get().columns
+        set((s) => ({
+          columns: ids
+            .map((id, i) => {
+              const c = s.columns.find((col) => col.id === id)
+              return c ? { ...c, position: i } : undefined
+            })
+            .filter((c): c is Column => c !== undefined),
+        }))
+        try {
+          await ipc.reorderColumns(workspaceId, ids)
+        } catch {
+          set({ columns: prev })
+        }
+      },
+
+      updateColumn: (id, updates) => {
+        set((s) => ({
+          columns: s.columns.map((c) => (c.id === id ? { ...c, ...updates } : c)),
+        }))
+      },
+    }),
+    { name: 'column-store' },
+  ),
+)

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import type { Task } from '@/types'
+import * as ipc from '@/lib/ipc'
+
+type TaskState = {
+  tasks: Task[]
+  loaded: boolean
+
+  load: (workspaceId: string) => Promise<void>
+  add: (workspaceId: string, columnId: string, title: string, description: string) => Promise<void>
+  remove: (id: string) => Promise<void>
+  move: (id: string, targetColumnId: string, position: number) => Promise<void>
+  reorder: (columnId: string, ids: string[]) => Promise<void>
+  updateTask: (id: string, updates: Partial<Task>) => void
+  getByColumn: (columnId: string) => Task[]
+}
+
+export const useTaskStore = create<TaskState>()(
+  devtools(
+    (set, get) => ({
+      tasks: [],
+      loaded: false,
+
+      load: async (workspaceId) => {
+        const tasks = await ipc.getTasks(workspaceId)
+        set({ tasks, loaded: true })
+      },
+
+      add: async (workspaceId, columnId, title, description) => {
+        const task = await ipc.createTask(workspaceId, columnId, title, description)
+        set((s) => ({ tasks: [...s.tasks, task] }))
+      },
+
+      remove: async (id) => {
+        const prev = get().tasks
+        set((s) => ({ tasks: s.tasks.filter((t) => t.id !== id) }))
+        try {
+          await ipc.deleteTask(id)
+        } catch {
+          set({ tasks: prev })
+        }
+      },
+
+      move: async (id, targetColumnId, position) => {
+        const prev = get().tasks
+        set((s) => ({
+          tasks: s.tasks.map((t) =>
+            t.id === id ? { ...t, columnId: targetColumnId, position } : t,
+          ),
+        }))
+        try {
+          await ipc.moveTask(id, targetColumnId, position)
+        } catch {
+          set({ tasks: prev })
+        }
+      },
+
+      reorder: async (columnId, ids) => {
+        const prev = get().tasks
+        set((s) => ({
+          tasks: s.tasks.map((t) => {
+            if (t.columnId !== columnId) return t
+            const idx = ids.indexOf(t.id)
+            return idx >= 0 ? { ...t, position: idx } : t
+          }),
+        }))
+        try {
+          await ipc.reorderTasks(columnId, ids)
+        } catch {
+          set({ tasks: prev })
+        }
+      },
+
+      updateTask: (id, updates) => {
+        set((s) => ({
+          tasks: s.tasks.map((t) => (t.id === id ? { ...t, ...updates } : t)),
+        }))
+      },
+
+      getByColumn: (columnId) => {
+        return get()
+          .tasks.filter((t) => t.columnId === columnId)
+          .sort((a, b) => a.position - b.position)
+      },
+    }),
+    { name: 'task-store' },
+  ),
+)

--- a/src/stores/terminal-store.ts
+++ b/src/stores/terminal-store.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+type TerminalInstance = {
+  taskId: string
+  alive: boolean
+}
+
+type TerminalState = {
+  activeTaskId: string | null
+  instances: Map<string, TerminalInstance>
+
+  setActive: (taskId: string | null) => void
+  register: (taskId: string) => void
+  unregister: (taskId: string) => void
+  setAlive: (taskId: string, alive: boolean) => void
+  isAlive: (taskId: string) => boolean
+}
+
+export const useTerminalStore = create<TerminalState>()(
+  devtools(
+    (set, get) => ({
+      activeTaskId: null,
+      instances: new Map(),
+
+      setActive: (taskId) => {
+        set({ activeTaskId: taskId })
+      },
+
+      register: (taskId) => {
+        set((s) => {
+          const next = new Map(s.instances)
+          next.set(taskId, { taskId, alive: true })
+          return { instances: next }
+        })
+      },
+
+      unregister: (taskId) => {
+        set((s) => {
+          const next = new Map(s.instances)
+          next.delete(taskId)
+          return {
+            instances: next,
+            activeTaskId: s.activeTaskId === taskId ? null : s.activeTaskId,
+          }
+        })
+      },
+
+      setAlive: (taskId, alive) => {
+        set((s) => {
+          const next = new Map(s.instances)
+          const inst = next.get(taskId)
+          if (inst) next.set(taskId, { ...inst, alive })
+          return { instances: next }
+        })
+      },
+
+      isAlive: (taskId) => {
+        return get().instances.get(taskId)?.alive ?? false
+      },
+    }),
+    { name: 'terminal-store' },
+  ),
+)

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+type ViewMode = 'board' | 'split'
+
+type ModalState = {
+  type: string
+  props?: Record<string, unknown>
+} | null
+
+type UIState = {
+  viewMode: ViewMode
+  activeTaskId: string | null
+  modal: ModalState
+
+  setViewMode: (mode: ViewMode) => void
+  openTask: (taskId: string) => void
+  closeTask: () => void
+  openModal: (type: string, props?: Record<string, unknown>) => void
+  closeModal: () => void
+}
+
+export const useUIStore = create<UIState>()(
+  devtools(
+    (set) => ({
+      viewMode: 'board',
+      activeTaskId: null,
+      modal: null,
+
+      setViewMode: (mode) => {
+        set({ viewMode: mode })
+      },
+
+      openTask: (taskId) => {
+        set({ viewMode: 'split', activeTaskId: taskId })
+      },
+
+      closeTask: () => {
+        set({ viewMode: 'board', activeTaskId: null })
+      },
+
+      openModal: (type, props) => {
+        set({ modal: { type, props } })
+      },
+
+      closeModal: () => {
+        set({ modal: null })
+      },
+    }),
+    { name: 'ui-store' },
+  ),
+)

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import type { Workspace } from '@/types'
+import * as ipc from '@/lib/ipc'
+
+type WorkspaceState = {
+  workspaces: Workspace[]
+  activeWorkspaceId: string | null
+  loaded: boolean
+
+  load: () => Promise<void>
+  setActive: (id: string) => void
+  add: (name: string, repoPath: string) => Promise<void>
+  remove: (id: string) => Promise<void>
+  reorder: (ids: string[]) => Promise<void>
+}
+
+export const useWorkspaceStore = create<WorkspaceState>()(
+  devtools(
+    (set, get) => ({
+      workspaces: [],
+      activeWorkspaceId: null,
+      loaded: false,
+
+      load: async () => {
+        const workspaces = await ipc.getWorkspaces()
+        const active = workspaces.find((w) => w.isActive) ?? workspaces[0]
+        set({ workspaces, activeWorkspaceId: active?.id ?? null, loaded: true })
+      },
+
+      setActive: (id) => {
+        set({ activeWorkspaceId: id })
+      },
+
+      add: async (name, repoPath) => {
+        const workspace = await ipc.createWorkspace(name, repoPath)
+        set((s) => ({ workspaces: [...s.workspaces, workspace] }))
+      },
+
+      remove: async (id) => {
+        const prev = get().workspaces
+        set((s) => ({
+          workspaces: s.workspaces.filter((w) => w.id !== id),
+          activeWorkspaceId:
+            s.activeWorkspaceId === id
+              ? (s.workspaces.find((w) => w.id !== id)?.id ?? null)
+              : s.activeWorkspaceId,
+        }))
+        try {
+          await ipc.deleteWorkspace(id)
+        } catch {
+          set({ workspaces: prev })
+        }
+      },
+
+      reorder: async (ids) => {
+        const prev = get().workspaces
+        set((s) => ({
+          workspaces: ids
+            .map((id, i) => {
+              const w = s.workspaces.find((ws) => ws.id === id)
+              return w ? { ...w, tabOrder: i } : undefined
+            })
+            .filter((w): w is Workspace => w !== undefined),
+        }))
+        try {
+          await ipc.reorderWorkspaces(ids)
+        } catch {
+          set({ workspaces: prev })
+        }
+      },
+    }),
+    { name: 'workspace-store' },
+  ),
+)

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,0 +1,25 @@
+export type AgentStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'stopped'
+  | 'needs_attention'
+
+export type AgentMode =
+  | 'code'
+  | 'architect'
+  | 'debug'
+  | 'ask'
+  | 'plan'
+  | 'review'
+
+export type AgentSession = {
+  id: string
+  taskId: string
+  agentType: string
+  pid: number | null
+  status: AgentStatus
+  startedAt: string
+  endedAt: string | null
+  tokenUsage: number
+}

--- a/src/types/column.ts
+++ b/src/types/column.ts
@@ -1,0 +1,43 @@
+export type TriggerType = 'none' | 'agent' | 'skill' | 'script' | 'webhook'
+
+export type ExitType =
+  | 'manual'
+  | 'agent_complete'
+  | 'script_success'
+  | 'checklist_done'
+  | 'pr_approved'
+
+export type TriggerConfig = {
+  type: TriggerType
+  config: {
+    agent?: string
+    skill?: string
+    script?: string
+    webhook?: string
+    flags?: string[]
+  }
+}
+
+export type ExitConfig = {
+  type: ExitType
+  config: {
+    timeout?: number
+    retry?: boolean
+    maxRetry?: number
+  }
+}
+
+export type Column = {
+  id: string
+  workspaceId: string
+  name: string
+  icon: string
+  position: number
+  color: string
+  visible: boolean
+  trigger: TriggerConfig
+  exitCriteria: ExitConfig
+  autoAdvance: boolean
+  createdAt: string
+  updatedAt: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+export type { Workspace } from './workspace'
+export type { Column, TriggerConfig, ExitConfig, TriggerType, ExitType } from './column'
+export type { Task } from './task'
+export type { AgentSession, AgentStatus, AgentMode } from './agent'

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,16 @@
+import type { AgentMode, AgentStatus } from './agent'
+
+export type Task = {
+  id: string
+  workspaceId: string
+  columnId: string
+  title: string
+  description: string
+  branch: string | null
+  agentType: string | null
+  agentMode: AgentMode | null
+  agentStatus: AgentStatus | null
+  position: number
+  createdAt: string
+  updatedAt: string
+}

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,0 +1,9 @@
+export type Workspace = {
+  id: string
+  name: string
+  repoPath: string
+  tabOrder: number
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
## Summary
- **T007**: TypeScript types (`Workspace`, `Column`, `Task`, `AgentSession`), 5 Zustand stores with optimistic updates, and typed Tauri IPC wrappers
- **T008**: Dark theme CSS variables matching PRODUCT.md palette, three-zone layout shell, 6 shared components (Button, Input, Badge, Tooltip, Dropdown, Dialog)
- **T009**: Kanban board with @dnd-kit drag-and-drop (cross-column card moves + column reordering), Motion spring animations, and memoized task cards

## Test plan
- [ ] `pnpm type-check` passes cleanly
- [ ] `pnpm lint` passes cleanly
- [ ] `pnpm dev` renders dark-themed layout shell with board area
- [ ] Verify CSS variables apply correctly under `[data-theme="dark"]`
- [ ] Shared components render with correct variants (Button primary/secondary/ghost/danger)
- [ ] Board renders empty columns with "No tasks" placeholder
- [ ] DnD activates on pointer drag (8px threshold) and keyboard (Space + arrows)