### PR TITLE
feat: appearance settings with theme, accent colors, and UI controls

### DIFF
--- a/src/components/settings/tabs/appearance-tab.tsx
+++ b/src/components/settings/tabs/appearance-tab.tsx
@@ -1,0 +1,104 @@
+import { useSettingsStore } from '@/stores/settings-store'
+import { useThemeStore } from '@/stores/theme-store'
+import type { ThemePreference } from '@/lib/theme'
+import type { AppearanceConfig } from '@/types/settings'
+import { SegmentedControl } from '@/components/shared/segmented-control'
+import { AccentColorPicker } from '@/components/shared/accent-color-picker'
+import { DensityPicker } from '@/components/shared/density-picker'
+import { LabeledSlider } from '@/components/shared/labeled-slider'
+
+const THEME_ICONS = {
+  system: (
+    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+    </svg>
+  ),
+  light: (
+    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+    </svg>
+  ),
+  dark: (
+    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+    </svg>
+  ),
+}
+
+const FONT_SIZE_LABELS = {
+  small: 'S',
+  medium: 'M',
+  large: 'L',
+}
+
+export function AppearanceTab() {
+  const global = useSettingsStore((s) => s.global)
+  const updateGlobal = useSettingsStore((s) => s.updateGlobal)
+  const themePreference = useThemeStore((s) => s.preference)
+  const setThemePreference = useThemeStore((s) => s.setPreference)
+
+  const appearance = global.appearance
+
+  const updateAppearance = (updates: Partial<AppearanceConfig>) => {
+    updateGlobal('appearance', { ...appearance, ...updates })
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Theme */}
+      <section>
+        <h3 className="mb-3 text-sm font-medium text-text-primary">Theme</h3>
+        <SegmentedControl
+          options={['system', 'light', 'dark'] as const}
+          value={themePreference}
+          onChange={(theme) => {
+            setThemePreference(theme as ThemePreference)
+            updateAppearance({ theme })
+          }}
+          icons={THEME_ICONS}
+          labels={{ system: 'System', light: 'Light', dark: 'Dark' }}
+        />
+      </section>
+
+      {/* Accent Color */}
+      <section>
+        <h3 className="mb-3 text-sm font-medium text-text-primary">Accent Color</h3>
+        <AccentColorPicker
+          value={appearance.accentColor}
+          onChange={(color) => updateAppearance({ accentColor: color })}
+        />
+      </section>
+
+      {/* Font Size */}
+      <section>
+        <h3 className="mb-3 text-sm font-medium text-text-primary">Font Size</h3>
+        <SegmentedControl
+          options={['small', 'medium', 'large'] as const}
+          value={appearance.fontSize}
+          onChange={(size) => updateAppearance({ fontSize: size })}
+          labels={FONT_SIZE_LABELS}
+        />
+      </section>
+
+      {/* Card Density */}
+      <section>
+        <h3 className="mb-3 text-sm font-medium text-text-primary">Card Density</h3>
+        <DensityPicker
+          value={appearance.cardDensity}
+          onChange={(density) => updateAppearance({ cardDensity: density })}
+        />
+      </section>
+
+      {/* Animation Speed */}
+      <section>
+        <h3 className="mb-3 text-sm font-medium text-text-primary">Animation Speed</h3>
+        <LabeledSlider
+          options={['none', 'reduced', 'normal'] as const}
+          value={appearance.animationSpeed}
+          onChange={(speed) => updateAppearance({ animationSpeed: speed })}
+          labels={{ none: 'None', reduced: 'Reduced', normal: 'Normal' }}
+        />
+      </section>
+    </div>
+  )
+}

--- a/src/components/shared/accent-color-picker.tsx
+++ b/src/components/shared/accent-color-picker.tsx
@@ -1,0 +1,77 @@
+import { useRef } from 'react'
+
+type AccentColorPickerProps = {
+  value: string
+  onChange: (color: string) => void
+}
+
+// Curated accent colors that work well in both light and dark themes
+const ACCENT_PRESETS = [
+  '#E8A87C', // Coral
+  '#E879A0', // Rose
+  '#A78BFA', // Violet
+  '#60A5FA', // Blue
+  '#22D3EE', // Cyan
+  '#2DD4BF', // Teal
+  '#4ADE80', // Green
+  '#A3E635', // Lime
+  '#FACC15', // Yellow
+  '#FB923C', // Orange
+] as const
+
+export function AccentColorPicker({ value, onChange }: AccentColorPickerProps) {
+  const colorInputRef = useRef<HTMLInputElement>(null)
+
+  // Check if current value is a preset or custom
+  const isCustomColor = !ACCENT_PRESETS.some(
+    (preset) => preset.toLowerCase() === value.toLowerCase()
+  )
+
+  const handleCustomClick = () => {
+    colorInputRef.current?.click()
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* Preset colors */}
+      {ACCENT_PRESETS.map((color) => (
+        <button
+          key={color}
+          onClick={() => onChange(color)}
+          className="h-7 w-7 rounded-full transition-transform hover:scale-110"
+          style={{ backgroundColor: color }}
+        />
+      ))}
+
+      {/* Custom color button */}
+      <button
+        onClick={handleCustomClick}
+        className="relative h-7 w-7 rounded-full transition-colors flex items-center justify-center"
+        style={{ backgroundColor: isCustomColor ? value : 'transparent' }}
+      >
+        {/* Dashed border ring - always visible as indicator this is custom slot */}
+        <div
+          className={`absolute inset-0 rounded-full border-2 border-dashed transition-colors ${
+            isCustomColor ? 'border-white/50' : 'border-text-secondary/40 hover:border-text-secondary'
+          }`}
+        />
+
+        {/* Plus icon - only when no custom color */}
+        {!isCustomColor && (
+          <svg className="h-3.5 w-3.5 text-text-secondary/60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+          </svg>
+        )}
+
+        {/* Hidden color input */}
+        <input
+          ref={colorInputRef}
+          type="color"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+        />
+      </button>
+    </div>
+  )
+}

--- a/src/components/shared/density-picker.tsx
+++ b/src/components/shared/density-picker.tsx
@@ -1,0 +1,57 @@
+import type { AppearanceConfig } from '@/types/settings'
+
+type DensityPickerProps = {
+  value: AppearanceConfig['cardDensity']
+  onChange: (value: AppearanceConfig['cardDensity']) => void
+}
+
+const DENSITIES: {
+  id: AppearanceConfig['cardDensity']
+  label: string
+  scale: number
+}[] = [
+  { id: 'compact', label: 'Compact', scale: 0.7 },
+  { id: 'comfortable', label: 'Comfortable', scale: 1 },
+  { id: 'spacious', label: 'Spacious', scale: 1.3 },
+]
+
+export function DensityPicker({ value, onChange }: DensityPickerProps) {
+  return (
+    <div className="inline-flex gap-2 rounded-lg border border-border-default bg-surface p-1">
+      {DENSITIES.map((density) => {
+        const isSelected = value === density.id
+
+        return (
+          <button
+            key={density.id}
+            onClick={() => onChange(density.id)}
+            className={`flex flex-col items-center gap-1.5 rounded-md px-3 py-2 transition-all ${
+              isSelected
+                ? 'bg-accent text-bg'
+                : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+            }`}
+          >
+            {/* Mini card stack icon */}
+            <div className="flex flex-col items-center" style={{ gap: `${2 * density.scale}px` }}>
+              <div
+                className={`rounded ${isSelected ? 'bg-bg/30' : 'bg-text-secondary/20'}`}
+                style={{
+                  width: `${28 * density.scale}px`,
+                  height: `${8 * density.scale}px`
+                }}
+              />
+              <div
+                className={`rounded ${isSelected ? 'bg-bg/30' : 'bg-text-secondary/20'}`}
+                style={{
+                  width: `${28 * density.scale}px`,
+                  height: `${8 * density.scale}px`
+                }}
+              />
+            </div>
+            <span className="text-xs font-medium">{density.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/shared/labeled-slider.tsx
+++ b/src/components/shared/labeled-slider.tsx
@@ -1,0 +1,117 @@
+import { useRef, useState, useCallback, useEffect } from 'react'
+
+type LabeledSliderProps<T extends string> = {
+  options: readonly T[]
+  value: T
+  onChange: (value: T) => void
+  labels?: Partial<Record<T, string>>
+}
+
+export function LabeledSlider<T extends string>({
+  options,
+  value,
+  onChange,
+  labels,
+}: LabeledSliderProps<T>) {
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const selectedIndex = options.indexOf(value)
+
+  const updateValue = useCallback((clientX: number) => {
+    if (!trackRef.current) return
+    const rect = trackRef.current.getBoundingClientRect()
+    const x = Math.max(0, Math.min(clientX - rect.left, rect.width))
+    const index = Math.round((x / rect.width) * (options.length - 1))
+    const option = options[index]
+    if (option !== undefined) onChange(option)
+  }, [options, onChange])
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    setIsDragging(true)
+    updateValue(e.clientX)
+  }, [updateValue])
+
+  useEffect(() => {
+    if (!isDragging) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      updateValue(e.clientX)
+    }
+
+    const handleMouseUp = () => {
+      setIsDragging(false)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isDragging, updateValue])
+
+  const thumbPosition = (selectedIndex / (options.length - 1)) * 100
+  const fillWidth = thumbPosition
+
+  return (
+    <div className="w-56">
+      {/* Track */}
+      <div
+        ref={trackRef}
+        onMouseDown={handleMouseDown}
+        className="relative h-2 cursor-pointer rounded-full bg-surface"
+      >
+        {/* Fill */}
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-accent"
+          style={{ width: `${fillWidth}%` }}
+        />
+
+        {/* Thumb */}
+        <div
+          className="absolute top-1/2 h-4 w-4 rounded-full border-2 border-accent bg-bg shadow-sm"
+          style={{
+            left: `${thumbPosition}%`,
+            transform: `translateX(-50%) translateY(-50%) scale(${isDragging ? 1.1 : 1})`,
+          }}
+        />
+
+        {/* Tick marks */}
+        {options.map((_, index) => (
+          <div
+            key={index}
+            className="absolute top-1/2 h-1 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-text-secondary/30"
+            style={{ left: `${(index / (options.length - 1)) * 100}%` }}
+          />
+        ))}
+      </div>
+
+      {/* Labels - positioned to align with tick marks */}
+      <div className="relative mt-2 h-5">
+        {options.map((option, index) => {
+          const isSelected = option === value
+          const label = labels?.[option] ?? option
+          const position = (index / (options.length - 1)) * 100
+
+          return (
+            <button
+              key={option}
+              onClick={() => onChange(option)}
+              className={`absolute text-xs capitalize transition-colors ${
+                isSelected
+                  ? 'font-medium text-accent'
+                  : 'text-text-secondary hover:text-text-primary'
+              }`}
+              style={{
+                left: `${position}%`,
+                transform: 'translateX(-50%)',
+              }}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/shared/segmented-control.tsx
+++ b/src/components/shared/segmented-control.tsx
@@ -1,0 +1,52 @@
+type SegmentedControlProps<T extends string> = {
+  options: readonly T[]
+  value: T
+  onChange: (value: T) => void
+  labels?: Partial<Record<T, string>>
+  icons?: Partial<Record<T, React.ReactNode>>
+  size?: 'sm' | 'md'
+}
+
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  labels,
+  icons,
+  size = 'md',
+}: SegmentedControlProps<T>) {
+  const sizeClasses = {
+    sm: 'text-xs',
+    md: 'text-sm',
+  }
+
+  const buttonPadding = {
+    sm: 'px-3 py-1.5',
+    md: 'px-4 py-2',
+  }
+
+  return (
+    <div className="inline-flex rounded-lg border border-border-default bg-surface p-1">
+      {options.map((option) => {
+        const isSelected = option === value
+        const label = labels?.[option] ?? option
+        const icon = icons?.[option]
+
+        return (
+          <button
+            key={option}
+            onClick={() => onChange(option)}
+            className={`relative flex items-center justify-center gap-1.5 rounded-md font-medium capitalize transition-all ${buttonPadding[size]} ${sizeClasses[size]} ${
+              isSelected
+                ? 'bg-accent text-bg'
+                : 'text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+            }`}
+          >
+            {icon}
+            <span>{label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@
   --font-sans: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
-  /* Dark theme colors mapped to Tailwind utilities */
+  /* Theme colors mapped to Tailwind utilities */
   --color-bg: var(--bg);
   --color-surface: var(--surface);
   --color-surface-hover: var(--surface-hover);
@@ -33,6 +33,28 @@
   --color-error: var(--error);
   --color-running: var(--running);
   --color-attention: var(--attention);
+}
+
+/* Default values (dark theme fallback) - MUST come before theme selectors */
+:root {
+  --bg: #0D0D0D;
+  --surface: #1A1A1A;
+  --surface-hover: #242424;
+  --border: #2A2A2A;
+  --text-primary: #E5E5E5;
+  --text-secondary: #888888;
+  --accent: #E8A87C;
+  --success: #4ADE80;
+  --warning: #FBBF24;
+  --error: #F87171;
+  --running: #60A5FA;
+  --attention: #F59E0B;
+
+  /* Appearance defaults */
+  --base-font-size: 14px;
+  --card-padding: 0.75rem;
+  --card-gap: 0.5rem;
+  --transition-duration: 150ms;
 }
 
 [data-theme='dark'] {
@@ -65,6 +87,62 @@
   --attention: #D97706;
 }
 
+/* Attention pulse animation */
+@keyframes attention-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(245, 158, 11, 0);
+  }
+  50% {
+    box-shadow: 0 0 8px 2px rgba(245, 158, 11, 0.4);
+  }
+}
+
+.animate-attention-pulse {
+  animation: attention-pulse 2s ease-in-out infinite;
+}
+
+/* Font Size Settings */
+[data-font-size='small'] {
+  --base-font-size: 12px;
+}
+
+[data-font-size='medium'] {
+  --base-font-size: 14px;
+}
+
+[data-font-size='large'] {
+  --base-font-size: 16px;
+}
+
+/* Card Density Settings */
+[data-card-density='compact'] {
+  --card-padding: 0.5rem;
+  --card-gap: 0.25rem;
+}
+
+[data-card-density='comfortable'] {
+  --card-padding: 0.75rem;
+  --card-gap: 0.5rem;
+}
+
+[data-card-density='spacious'] {
+  --card-padding: 1rem;
+  --card-gap: 0.75rem;
+}
+
+/* Animation Speed Settings */
+[data-animation-speed='none'] {
+  --transition-duration: 0ms;
+}
+
+[data-animation-speed='reduced'] {
+  --transition-duration: 75ms;
+}
+
+[data-animation-speed='normal'] {
+  --transition-duration: 150ms;
+}
+
 html,
 body,
 #root {
@@ -75,6 +153,20 @@ body,
   background-color: var(--bg);
   color: var(--text-primary);
   font-family: var(--font-sans);
-  font-size: 14px;
+  font-size: var(--base-font-size);
   line-height: 1.5;
+}
+
+/* Card styles using appearance variables */
+.card-padding {
+  padding: var(--card-padding);
+}
+
+.card-gap {
+  gap: var(--card-gap);
+}
+
+/* Transitions using appearance variables */
+.transition-appearance {
+  transition-duration: var(--transition-duration);
 }

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -1,0 +1,71 @@
+import type { AppearanceConfig } from '@/types/settings'
+
+// Default appearance config
+export const DEFAULT_APPEARANCE: AppearanceConfig = {
+  theme: 'system',
+  accentColor: '#E8A87C',
+  fontSize: 'medium',
+  cardDensity: 'comfortable',
+  animationSpeed: 'normal',
+}
+
+// Get stored appearance config from Zustand's persisted state
+export function getAppearanceConfig(): AppearanceConfig {
+  try {
+    // Read from Zustand's persisted storage key
+    const stored = localStorage.getItem('bento-settings')
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      // Zustand stores state in { state: { global: { appearance: ... } } }
+      const appearance = parsed?.state?.global?.appearance
+      if (appearance) {
+        return { ...DEFAULT_APPEARANCE, ...appearance }
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return DEFAULT_APPEARANCE
+}
+
+// Apply accent color to CSS variable
+export function setAccentColor(color: string): void {
+  document.documentElement.style.setProperty('--accent', color)
+}
+
+// Apply font size via data attribute
+export function setFontSize(size: AppearanceConfig['fontSize']): void {
+  document.documentElement.dataset['fontSize'] = size
+}
+
+// Apply card density via data attribute
+export function setCardDensity(density: AppearanceConfig['cardDensity']): void {
+  document.documentElement.dataset['cardDensity'] = density
+}
+
+// Apply animation speed via data attribute
+export function setAnimationSpeed(speed: AppearanceConfig['animationSpeed']): void {
+  document.documentElement.dataset['animationSpeed'] = speed
+}
+
+// Apply all appearance settings to the DOM
+export function applyAppearance(config: Partial<AppearanceConfig>): void {
+  if (config.accentColor) {
+    setAccentColor(config.accentColor)
+  }
+  if (config.fontSize) {
+    setFontSize(config.fontSize)
+  }
+  if (config.cardDensity) {
+    setCardDensity(config.cardDensity)
+  }
+  if (config.animationSpeed) {
+    setAnimationSpeed(config.animationSpeed)
+  }
+}
+
+// Initialize appearance on app start
+export function initializeAppearance(): void {
+  const config = getAppearanceConfig()
+  applyAppearance(config)
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,9 +1,58 @@
 export type Theme = 'dark' | 'light'
+export type ThemePreference = Theme | 'system'
 
+const STORAGE_KEY = 'bento-theme-preference'
+
+// Get the resolved theme (what's actually applied)
 export function getTheme(): Theme {
   return (document.documentElement.dataset['theme'] as Theme | undefined) ?? 'dark'
 }
 
+// Get user's stored preference
+export function getThemePreference(): ThemePreference {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'dark' || stored === 'light' || stored === 'system') {
+    return stored
+  }
+  return 'system'
+}
+
+// Resolve 'system' to actual theme based on OS preference
+export function resolveTheme(preference: ThemePreference): Theme {
+  if (preference === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return preference
+}
+
+// Apply theme to document
 export function setTheme(theme: Theme): void {
   document.documentElement.dataset['theme'] = theme
+}
+
+// Save preference and apply
+export function setThemePreference(preference: ThemePreference): void {
+  localStorage.setItem(STORAGE_KEY, preference)
+  setTheme(resolveTheme(preference))
+}
+
+// Initialize theme on app start
+export function initializeTheme(): () => void {
+  const preference = getThemePreference()
+  setTheme(resolveTheme(preference))
+
+  // Watch for system theme changes
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  const handleChange = () => {
+    if (getThemePreference() === 'system') {
+      setTheme(resolveTheme('system'))
+    }
+  }
+
+  mediaQuery.addEventListener('change', handleChange)
+
+  // Return cleanup function
+  return () => {
+    mediaQuery.removeEventListener('change', handleChange)
+  }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './app'
 import './index.css'
+import { initializeAppearance } from './lib/appearance'
+import { initializeTheme } from './lib/theme'
+
+// Apply saved theme and appearance settings before render
+initializeTheme()
+initializeAppearance()
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 createRoot(document.getElementById('root')!).render(

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,0 +1,91 @@
+import { create } from 'zustand'
+import { devtools, persist } from 'zustand/middleware'
+import type { Settings, WorkspaceSettings } from '@/types/settings'
+import { DEFAULT_SETTINGS } from '@/types/settings'
+import { applyAppearance } from '@/lib/appearance'
+
+type SettingsState = {
+  global: Settings
+  workspaceOverrides: Record<string, WorkspaceSettings>
+  isOpen: boolean
+  activeTab: string
+
+  // Actions
+  openSettings: () => void
+  closeSettings: () => void
+  setActiveTab: (tab: string) => void
+  updateGlobal: <K extends keyof Settings>(key: K, value: Settings[K]) => void
+  updateWorkspace: (workspaceId: string, settings: WorkspaceSettings) => void
+  getEffective: (workspaceId: string | null) => Settings
+  resetToDefaults: () => void
+}
+
+export const useSettingsStore = create<SettingsState>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        global: DEFAULT_SETTINGS,
+        workspaceOverrides: {},
+        isOpen: false,
+        activeTab: 'appearance',
+
+        openSettings: () => set({ isOpen: true }),
+        closeSettings: () => set({ isOpen: false }),
+        setActiveTab: (tab) => set({ activeTab: tab }),
+
+        updateGlobal: (key, value) => {
+          set((state) => ({
+            global: { ...state.global, [key]: value },
+          }))
+          // Apply appearance changes to DOM immediately
+          if (key === 'appearance') {
+            applyAppearance(value as Settings['appearance'])
+          }
+        },
+
+        updateWorkspace: (workspaceId, settings) => {
+          set((state) => ({
+            workspaceOverrides: {
+              ...state.workspaceOverrides,
+              [workspaceId]: {
+                ...state.workspaceOverrides[workspaceId],
+                ...settings,
+              },
+            },
+          }))
+        },
+
+        getEffective: (workspaceId) => {
+          const { global, workspaceOverrides } = get()
+          if (!workspaceId) return global
+
+          const overrides = workspaceOverrides[workspaceId]
+          if (!overrides) return global
+
+          // Deep merge global with workspace overrides
+          return {
+            ...global,
+            ...overrides,
+            agent: { ...global.agent, ...overrides.agent },
+            model: { ...global.model, ...overrides.model },
+            voice: { ...global.voice, ...overrides.voice },
+            git: { ...global.git, ...overrides.git },
+            appearance: { ...global.appearance, ...overrides.appearance },
+          } as Settings
+        },
+
+        resetToDefaults: () => {
+          set({ global: DEFAULT_SETTINGS, workspaceOverrides: {} })
+        },
+      }),
+      {
+        name: 'bento-settings',
+        partialize: (state) => ({
+          global: state.global,
+          workspaceOverrides: state.workspaceOverrides,
+        }),
+      },
+    ),
+    { name: 'settings-store' },
+  ),
+)

--- a/src/stores/theme-store.ts
+++ b/src/stores/theme-store.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import {
+  type Theme,
+  type ThemePreference,
+  getTheme,
+  getThemePreference,
+  setThemePreference,
+  resolveTheme,
+} from '@/lib/theme'
+
+type ThemeState = {
+  preference: ThemePreference
+  resolved: Theme
+
+  setPreference: (preference: ThemePreference) => void
+  cycleTheme: () => void
+}
+
+export const useThemeStore = create<ThemeState>()(
+  devtools(
+    (set) => ({
+      preference: getThemePreference(),
+      resolved: getTheme(),
+
+      setPreference: (preference) => {
+        setThemePreference(preference)
+        set({ preference, resolved: resolveTheme(preference) })
+      },
+
+      cycleTheme: () => {
+        set((state) => {
+          const cycle: ThemePreference[] = ['system', 'light', 'dark']
+          const currentIndex = cycle.indexOf(state.preference)
+          const nextIndex = (currentIndex + 1) % cycle.length
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const nextPreference = cycle[nextIndex]!
+          setThemePreference(nextPreference)
+          return { preference: nextPreference, resolved: resolveTheme(nextPreference) }
+        })
+      },
+    }),
+    { name: 'theme-store' },
+  ),
+)

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,163 @@
+// Settings types for global and per-workspace configuration
+
+export type ProviderConfig = {
+  id: string
+  name: string
+  apiKeyEnvVar: string
+  enabled: boolean
+  connectionMode: 'api' | 'cli'
+  cliPath?: string
+  defaultModel: string
+}
+
+export type AgentConfig = {
+  maxConcurrentAgents: number
+  envVars: Record<string, string>
+  instructionsFile: string
+  modelSelection: 'auto' | string // 'auto' = orchestrator decides, or specific model ID
+}
+
+export type AgentMode = {
+  id: string
+  name: string
+  icon: string
+  prompt: string
+  tools: string[]
+  isBuiltIn: boolean
+}
+
+export type ModelConfig = {
+  showCostEstimates: boolean
+  providers: ProviderConfig[]
+}
+
+export type McpServer = {
+  id: string
+  name: string
+  command: string
+  args: string[]
+  env: Record<string, string>
+  autoStart: boolean
+  status: 'connected' | 'disconnected' | 'error'
+}
+
+export type Skill = {
+  id: string
+  name: string
+  description: string
+  trigger: string
+  script: string
+}
+
+export type VoiceConfig = {
+  enabled: boolean
+  model: 'tiny' | 'base' | 'small' | 'medium' | 'large'
+  language: string
+  hotkey: string
+  sensitivity: number
+  pushToTalk: boolean
+}
+
+export type GitConfig = {
+  branchPrefix: string
+  autoPr: boolean
+  prTemplate: string
+  mergeStrategy: 'merge' | 'squash' | 'rebase'
+  baseBranch: string
+}
+
+export type AppearanceConfig = {
+  theme: 'dark' | 'light' | 'system'
+  accentColor: string
+  fontSize: 'small' | 'medium' | 'large'
+  cardDensity: 'compact' | 'comfortable' | 'spacious'
+  animationSpeed: 'none' | 'reduced' | 'normal'
+}
+
+export type ShortcutConfig = {
+  id: string
+  action: string
+  keys: string
+  enabled: boolean
+}
+
+export type Settings = {
+  agent: AgentConfig
+  modes: AgentMode[]
+  model: ModelConfig
+  mcpServers: McpServer[]
+  skills: Skill[]
+  voice: VoiceConfig
+  git: GitConfig
+  appearance: AppearanceConfig
+  shortcuts: ShortcutConfig[]
+}
+
+export type WorkspaceSettings = Partial<Settings>
+
+export const DEFAULT_SETTINGS: Settings = {
+  agent: {
+    maxConcurrentAgents: 3,
+    envVars: {},
+    instructionsFile: '',
+    modelSelection: 'auto',
+  },
+  modes: [
+    { id: 'code', name: 'Code', icon: 'code', prompt: 'Write clean, maintainable code', tools: ['read', 'write', 'bash'], isBuiltIn: true },
+    { id: 'plan', name: 'Plan', icon: 'plan', prompt: 'Create detailed implementation plans', tools: ['read', 'search'], isBuiltIn: true },
+    { id: 'review', name: 'Review', icon: 'review', prompt: 'Review code for issues and improvements', tools: ['read', 'search'], isBuiltIn: true },
+  ],
+  model: {
+    showCostEstimates: true,
+    providers: [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        apiKeyEnvVar: 'ANTHROPIC_API_KEY',
+        enabled: true,
+        connectionMode: 'cli',
+        cliPath: 'claude',
+        defaultModel: 'claude-sonnet-4-6-20260217',
+      },
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        apiKeyEnvVar: 'OPENAI_API_KEY',
+        enabled: false,
+        connectionMode: 'cli',
+        cliPath: 'codex',
+        defaultModel: 'codex-5.3',
+      },
+    ],
+  },
+  mcpServers: [],
+  skills: [],
+  voice: {
+    enabled: false,
+    model: 'tiny',
+    language: 'en',
+    hotkey: 'Cmd+Shift+V',
+    sensitivity: 0.5,
+    pushToTalk: true,
+  },
+  git: {
+    branchPrefix: 'feat/',
+    autoPr: false,
+    prTemplate: '',
+    mergeStrategy: 'squash',
+    baseBranch: 'main',
+  },
+  appearance: {
+    theme: 'system',
+    accentColor: '#E8A87C',
+    fontSize: 'medium',
+    cardDensity: 'comfortable',
+    animationSpeed: 'normal',
+  },
+  shortcuts: [
+    { id: 'new-task', action: 'Create New Task', keys: 'Cmd+N', enabled: true },
+    { id: 'search', action: 'Search', keys: 'Cmd+K', enabled: true },
+    { id: 'toggle-theme', action: 'Toggle Theme', keys: 'Cmd+Shift+T', enabled: true },
+    { id: 'settings', action: 'Open Settings', keys: 'Cmd+,', enabled: true },
+  ],
+}


### PR DESCRIPTION
## Summary

Wire up appearance settings to actually affect the UI with polished custom components.

**Features:**
- Theme switching (system/light/dark) 
- Accent color picker with 10 curated presets + custom color
- Card density selector with visual previews
- Animation speed slider
- Font size control
- All settings persist to localStorage

## New Components

| Component | Purpose |
|-----------|---------|
| `AccentColorPicker` | Color swatches + custom picker with dashed border indicator |
| `DensityPicker` | Card density with mini-card icons |
| `LabeledSlider` | Draggable slider with centered labels |
| `SegmentedControl` | Reusable button group |

## Bug Fixes

- Fix light mode not applying (CSS `:root` was overriding `[data-theme='light']`)

## Test plan

- [ ] Toggle between System/Light/Dark themes
- [ ] Select accent colors from presets  
- [ ] Pick custom color via native color picker
- [ ] Change font size S/M/L
- [ ] Change card density (Compact/Comfortable/Spacious)
- [ ] Adjust animation speed
- [ ] Refresh page - settings persist