### PR TITLE
feat: T035 - History Replay Restore

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{State, Emitter};
 use crate::db::{
     self, AppState, SessionSnapshot,
 };
@@ -75,4 +75,40 @@ pub fn clear_session_history(
 ) -> Result<(), AppError> {
     let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::delete_session_snapshots(&conn, &session_id).map_err(AppError::from)
+}
+
+/// Restore a snapshot - creates a backup first, then returns the snapshot to restore
+#[tauri::command]
+pub fn restore_snapshot(
+    state: State<AppState>,
+    app: tauri::AppHandle,
+    snapshot_id: String,
+    current_session_id: String,
+    current_workspace_id: String,
+    current_task_id: Option<String>,
+    current_scrollback: Option<String>,
+    current_command_history: String,
+    current_files_modified: String,
+    current_duration_ms: i64,
+) -> Result<SessionSnapshot, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    // First, create a backup snapshot of current state
+    let backup = db::insert_session_snapshot(
+        &conn,
+        &current_session_id,
+        &current_workspace_id,
+        current_task_id.as_deref(),
+        "backup",
+        current_scrollback.as_deref(),
+        &current_command_history,
+        &current_files_modified,
+        current_duration_ms,
+    ).map_err(AppError::from)?;
+
+    // Emit event with backup ID so frontend can notify user
+    let _ = app.emit("history:backup-created", &backup.id);
+
+    // Return the snapshot to restore
+    db::get_session_snapshot(&conn, &snapshot_id).map_err(AppError::from)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,7 @@ pub fn run() {
             commands::history::get_workspace_history,
             commands::history::get_task_history,
             commands::history::clear_session_history,
+            commands::history::restore_snapshot,
             // CLI detection commands
             commands::cli_detect::detect_clis,
             commands::cli_detect::detect_single_cli,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -879,6 +879,21 @@ export async function clearSessionHistory(sessionId: string): Promise<void> {
   return invoke<void>('clear_session_history', { sessionId })
 }
 
+export type RestoreSnapshotParams = {
+  snapshotId: string
+  currentSessionId: string
+  currentWorkspaceId: string
+  currentTaskId?: string
+  currentScrollback?: string
+  currentCommandHistory: string
+  currentFilesModified: string
+  currentDurationMs: number
+}
+
+export async function restoreSnapshot(params: RestoreSnapshotParams): Promise<SessionSnapshot> {
+  return invoke<SessionSnapshot>('restore_snapshot', params)
+}
+
 // ─── Checklist commands ──────────────────────────────────────────────────────
 
 export type ChecklistItem = {


### PR DESCRIPTION
## Summary
- Add restore_snapshot Tauri command that creates backup before restoring
- Add restoreSnapshot IPC function for frontend
- Emits 'history:backup-created' event when backup is created

## Testing
- [x] cargo check passes
- [x] npm run type-check passes
- [x] Backend creates backup snapshot before restore

## Note
UI confirmation dialog is not included - can be added in follow-up.

## Ticket
T035 - History Replay Restore