### PR TITLE
feat(kanban): Siege Loop UI Integration (T051)

### DIFF
--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -10,6 +10,7 @@ import { useColumnStore } from '@/stores/column-store'
 import { useTaskStore } from '@/stores/task-store'
 import { TaskContextMenu } from './task-context-menu'
 import { TaskQuickActions } from './task-quick-actions'
+import * as ipc from '@/lib/ipc'
 
 type TaskCardProps = {
   task: Task
@@ -164,6 +165,26 @@ function PrStatusIndicator({ task, settings }: { task: Task; settings: typeof DE
   )
 }
 
+// Siege loop badge indicator
+function SiegeBadge({ task }: { task: Task }) {
+  if (!task.siegeActive) return null
+
+  return (
+    <span className="inline-flex items-center gap-1 text-accent">
+      <span className="relative flex h-1.5 w-1.5">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-75" />
+        <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-accent" />
+      </span>
+      <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
+        <path fillRule="evenodd" d="M8 1a3.5 3.5 0 0 0-3.5 3.5c0 1.57.75 2.4 1.5 2.8V8h.75v2.25H5v1.5h1.75V15h2.5v-3.25H11v-1.5H9.25V8h.75v-.7c.75-.4 1.5-1.23 1.5-2.8A3.5 3.5 0 0 0 8 1Zm0 1.5a2 2 0 0 0-2 2c0 .94.5 1.5 1 1.75V7h2v-.75c.5-.25 1-.81 1-1.75a2 2 0 0 0-2-2Z" clipRule="evenodd" />
+      </svg>
+      <span className="text-[11px] font-medium">
+        {task.siegeIteration}/{task.siegeMaxIterations}
+      </span>
+    </span>
+  )
+}
+
 export const TaskCard = memo(function TaskCard({ task }: TaskCardProps) {
   const openTask = useUIStore((s) => s.openTask)
   const hasAttention = useAttentionStore((s) => s.hasAttention(task.id))
@@ -236,6 +257,31 @@ export const TaskCard = memo(function TaskCard({ task }: TaskCardProps) {
     updateTask(task.id, { agentStatus: 'stopped' })
   }, [task.id, updateTask])
 
+  const handleStartSiege = useCallback(async () => {
+    try {
+      const result = await ipc.startSiege(task.id)
+      updateTask(task.id, {
+        siegeActive: result.task.siegeActive,
+        siegeIteration: result.task.siegeIteration,
+        siegeMaxIterations: result.task.siegeMaxIterations,
+      })
+    } catch (err) {
+      console.error('Failed to start siege:', err)
+    }
+  }, [task.id, updateTask])
+
+  const handleStopSiege = useCallback(async () => {
+    try {
+      const result = await ipc.stopSiege(task.id)
+      updateTask(task.id, {
+        siegeActive: result.siegeActive,
+        siegeIteration: result.siegeIteration,
+      })
+    } catch (err) {
+      console.error('Failed to stop siege:', err)
+    }
+  }, [task.id, updateTask])
+
   const handleArchiveTask = useCallback(() => {
     // For now, just remove - could add archive column later
     void removeTask(task.id)
@@ -273,6 +319,7 @@ export const TaskCard = memo(function TaskCard({ task }: TaskCardProps) {
     (cardSettings.showAgentType && task.agentType) ||
     (cardSettings.showTimestamp && !isPipelineActive) ||
     isPipelineActive ||
+    task.siegeActive ||
     (cardSettings.showPrBadge && task.prNumber) ||
     (cardSettings.showCommentCount && task.prCommentCount > 0) ||
     (cardSettings.showLabels && labels.length > 0)
@@ -422,6 +469,9 @@ export const TaskCard = memo(function TaskCard({ task }: TaskCardProps) {
               </span>
             )}
 
+            {/* Siege loop badge */}
+            <SiegeBadge task={task} />
+
             {/* PR badge with status */}
             {cardSettings.showPrBadge && task.prNumber && (
               <button
@@ -493,7 +543,7 @@ export const TaskCard = memo(function TaskCard({ task }: TaskCardProps) {
         task={task}
         columns={columns}
         position={contextMenu}
-        onClose={() => setContextMenu(null)}
+        onClose={() => { setContextMenu(null) }}
         onMoveToColumn={handleMoveToColumn}
         onOpenTask={handleClick}
         onDuplicateTask={handleDuplicateTask}
@@ -501,6 +551,8 @@ export const TaskCard = memo(function TaskCard({ task }: TaskCardProps) {
         onDeleteTask={handleDeleteTask}
         onRunAgent={handleRunAgent}
         onStopAgent={handleStopAgent}
+        onStartSiege={handleStartSiege}
+        onStopSiege={handleStopSiege}
       />
     )}
     </>

--- a/src/components/kanban/task-context-menu.tsx
+++ b/src/components/kanban/task-context-menu.tsx
@@ -33,6 +33,8 @@ type TaskContextMenuProps = {
   onDeleteTask: () => void
   onRunAgent: () => void
   onStopAgent: () => void
+  onStartSiege: () => void
+  onStopSiege: () => void
 }
 
 // Icons
@@ -51,6 +53,11 @@ const Icons = {
   stop: (
     <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
       <path d="M5.75 3A2.75 2.75 0 0 0 3 5.75v8.5A2.75 2.75 0 0 0 5.75 17h8.5A2.75 2.75 0 0 0 17 14.25v-8.5A2.75 2.75 0 0 0 14.25 3h-8.5Z" />
+    </svg>
+  ),
+  siege: (
+    <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+      <path fillRule="evenodd" d="M10 2a4 4 0 0 0-4 4c0 1.8.86 2.76 1.72 3.22V10h.86v2.57H7v1.72h1.58V18h2.84v-3.71H13v-1.72h-1.58V10h.86v-.78c.86-.46 1.72-1.42 1.72-3.22a4 4 0 0 0-4-4Zm0 1.72a2.28 2.28 0 0 0-2.28 2.28c0 1.08.57 1.72 1.14 2V9h2.28V8c.57-.28 1.14-.92 1.14-2A2.28 2.28 0 0 0 10 3.72Z" clipRule="evenodd" />
     </svg>
   ),
   move: (
@@ -165,6 +172,8 @@ export function TaskContextMenu({
   onDeleteTask,
   onRunAgent,
   onStopAgent,
+  onStartSiege,
+  onStopSiege,
 }: TaskContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -209,6 +218,7 @@ export function TaskContextMenu({
   const pos = adjustedPosition()
 
   const isRunning = task.agentStatus === 'running'
+  const hasPr = !!task.prNumber
   const otherColumns = columns.filter((c) => c.id !== task.columnId && c.visible)
 
   const menuItems: MenuItemType[] = [
@@ -217,6 +227,12 @@ export function TaskContextMenu({
     isRunning
       ? { label: 'Stop agent', icon: Icons.stop, onClick: onStopAgent }
       : { label: 'Run agent', icon: Icons.play, shortcut: 'Space', onClick: onRunAgent },
+    // Siege loop option - only show if task has a PR
+    ...(hasPr ? [
+      task.siegeActive
+        ? { label: 'Stop siege loop', icon: Icons.stop, onClick: onStopSiege }
+        : { label: 'Start siege loop', icon: Icons.siege, onClick: onStartSiege },
+    ] : []),
     { type: 'divider' },
     {
       label: 'Move to...',


### PR DESCRIPTION
## Summary
- Add siege loop badge component showing iteration count (e.g., "2/5") with pulsing accent-color animation when active
- Add Start/Stop siege loop menu items to task context menu (only visible when task has a PR)
- Wire siege handlers to IPC calls for `startSiege`/`stopSiege`
- Include `task.siegeActive` in hasMetadata check so metadata row shows when siege is active

## Test plan
- [ ] Open task context menu on a task with a PR - should show "Start siege loop" option
- [ ] Click "Start siege loop" - badge should appear with pulsing animation
- [ ] Open context menu again - should show "Stop siege loop" option
- [ ] Tasks without PRs should not show siege option in context menu
- [ ] Verify type-check passes