### PR TITLE
Add keyboard shortcut hint to column headers

### DIFF
--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -10,6 +10,8 @@ type ScriptTriggerInfo = {
 type ColumnHeaderProps = {
   name: string
   icon: string
+  columnIndex: number
+  columnCount: number
   taskCount: number
   color: string
   scriptTrigger?: ScriptTriggerInfo
@@ -78,6 +80,8 @@ function getIcon(icon: string) {
 export const ColumnHeader = memo(function ColumnHeader({
   name,
   icon,
+  columnIndex,
+  columnCount,
   taskCount,
   color,
   scriptTrigger,
@@ -87,6 +91,7 @@ export const ColumnHeader = memo(function ColumnHeader({
 }: ColumnHeaderProps) {
   const [showMenu, setShowMenu] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  const showShortcutHint = columnCount <= 6
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -108,8 +113,15 @@ export const ColumnHeader = memo(function ColumnHeader({
       >
         {getIcon(icon)}
       </span>
-      <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary truncate">
-        {name}
+      <h3 className="flex min-w-0 items-center text-xs font-semibold uppercase tracking-wider text-text-secondary">
+        <span className="truncate">
+          {name}
+        </span>
+        {showShortcutHint && (
+          <kbd className="ml-1 rounded bg-muted/30 px-1 font-mono text-xs text-muted-foreground opacity-50">
+            {columnIndex + 1}
+          </kbd>
+        )}
       </h3>
       <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
         {taskCount}

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { IconButton } from '@/components/shared/icon-button'
+import { shouldEnableColumnShortcuts } from './column-shortcuts'
 
 type ScriptTriggerInfo = {
   scriptName: string
@@ -91,7 +92,7 @@ export const ColumnHeader = memo(function ColumnHeader({
 }: ColumnHeaderProps) {
   const [showMenu, setShowMenu] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
-  const showShortcutHint = columnCount <= 6
+  const showShortcutHint = shouldEnableColumnShortcuts(columnCount)
 
   // Close menu when clicking outside
   useEffect(() => {

--- a/src/components/kanban/column-shortcuts.test.ts
+++ b/src/components/kanban/column-shortcuts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { Column } from '@/types'
+import {
+  getColumnShortcutIndex,
+  getVisibleColumnsForShortcuts,
+  MAX_COLUMN_SHORTCUTS,
+  shouldEnableColumnShortcuts,
+} from './column-shortcuts'
+
+const createMockColumn = (overrides: Partial<Column> = {}): Column => ({
+  id: 'col-1',
+  workspaceId: 'ws-1',
+  name: 'Test Column',
+  icon: 'list',
+  position: 0,
+  color: '#E8A87C',
+  visible: true,
+  triggers: undefined,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('column shortcuts', () => {
+  it('enables shortcuts only when the visible column count fits the hint UI', () => {
+    expect(shouldEnableColumnShortcuts(MAX_COLUMN_SHORTCUTS)).toBe(true)
+    expect(shouldEnableColumnShortcuts(MAX_COLUMN_SHORTCUTS + 1)).toBe(false)
+  })
+
+  it('maps number keys to zero-based visible column indices', () => {
+    expect(getColumnShortcutIndex('1', 3)).toBe(0)
+    expect(getColumnShortcutIndex('3', 3)).toBe(2)
+  })
+
+  it('ignores keys outside the visible column range', () => {
+    expect(getColumnShortcutIndex('0', 3)).toBeNull()
+    expect(getColumnShortcutIndex('4', 3)).toBeNull()
+    expect(getColumnShortcutIndex('x', 3)).toBeNull()
+  })
+
+  it('disables numeric shortcuts when hints are hidden', () => {
+    expect(getColumnShortcutIndex('1', MAX_COLUMN_SHORTCUTS + 1)).toBeNull()
+  })
+
+  it('sorts visible columns by position and filters hidden ones', () => {
+    const columns = [
+      createMockColumn({ id: 'col-3', position: 2 }),
+      createMockColumn({ id: 'col-1', position: 0 }),
+      createMockColumn({ id: 'col-2', position: 1, visible: false }),
+    ]
+
+    expect(getVisibleColumnsForShortcuts(columns).map((column) => column.id)).toEqual(['col-1', 'col-3'])
+  })
+})

--- a/src/components/kanban/column-shortcuts.ts
+++ b/src/components/kanban/column-shortcuts.ts
@@ -1,0 +1,21 @@
+import type { Column } from '@/types'
+
+export const MAX_COLUMN_SHORTCUTS = 6
+
+export function shouldEnableColumnShortcuts(columnCount: number) {
+  return columnCount <= MAX_COLUMN_SHORTCUTS
+}
+
+export function getColumnShortcutIndex(key: string, columnCount: number) {
+  if (!shouldEnableColumnShortcuts(columnCount)) return null
+  if (key < '1' || key > '9') return null
+
+  const index = Number.parseInt(key, 10) - 1
+  return index >= 0 && index < columnCount ? index : null
+}
+
+export function getVisibleColumnsForShortcuts(columns: Column[]) {
+  return columns
+    .filter((column) => column.visible)
+    .sort((a, b) => a.position - b.position)
+}

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -15,9 +15,11 @@ import { ColumnConfigDialog } from './column-config-dialog'
 
 type ColumnProps = {
   column: ColumnType
+  columnIndex: number
+  columnCount: number
 }
 
-export const Column = memo(function Column({ column }: ColumnProps) {
+export const Column = memo(function Column({ column, columnIndex, columnCount }: ColumnProps) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
   const allTasks = useTaskStore((s) => s.tasks)
   const addTask = useTaskStore((s) => s.add)
@@ -133,6 +135,8 @@ export const Column = memo(function Column({ column }: ColumnProps) {
           <ColumnHeader
             name={column.name}
             icon={column.icon || 'list'}
+            columnIndex={columnIndex}
+            columnCount={columnCount}
             taskCount={tasks.length}
             color={column.color}
             scriptTrigger={scriptTrigger}

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -20,6 +20,7 @@ import { PrStatusIndicator, SiegeBadge } from './task-card-badges'
 import { useTaskCardActions } from './use-task-card-actions'
 import { AttentionBanner, BlockedBanner, QualityGateBanner, PipelineErrorBanner } from './task-card-status'
 import { AgentActivityPreview } from './task-card-activity'
+import { getColumnShortcutIndex, getVisibleColumnsForShortcuts } from './column-shortcuts'
 
 export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const openTask = useUIStore((s) => s.openTask)
@@ -33,6 +34,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const [showSettings, setShowSettings] = useState(false)
   const [settingsTab, setSettingsTab] = useState<'triggers' | 'dependencies'>('triggers')
   const columns = useColumnStore((s) => s.columns)
+  const visibleColumns = useMemo(() => getVisibleColumnsForShortcuts(columns), [columns])
 
   // Get exit criteria type for this task's column
   const columnTriggers = useMemo(() => {
@@ -175,6 +177,17 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
       onContextMenu={handleContextMenu}
       onKeyDown={(e) => {
         if (e.metaKey || e.ctrlKey || e.altKey) return
+
+        const shortcutIndex = getColumnShortcutIndex(e.key, visibleColumns.length)
+        if (shortcutIndex !== null) {
+          e.preventDefault()
+          const targetColumn = visibleColumns[shortcutIndex]
+          if (targetColumn && targetColumn.id !== task.columnId) {
+            actions.handleMoveToColumn(targetColumn.id)
+          }
+          return
+        }
+
         switch (e.key) {
           case 'Enter':
           case ' ':

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -100,8 +100,13 @@ export function Board() {
           <div className="flex flex-1 flex-col overflow-hidden">
             <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
               <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
-                {sortedColumns.map((col) => (
-                  <Column key={col.id} column={col} />
+                {sortedColumns.map((col, index) => (
+                  <Column
+                    key={col.id}
+                    column={col}
+                    columnIndex={index}
+                    columnCount={sortedColumns.length}
+                  />
                 ))}
               </SortableContext>
 


### PR DESCRIPTION
Show a small keyboard shortcut hint (1-4) next to each column name in the kanban header. Users can press 1/2/3/4 to quickly filter or focus a column.

1. In src/components/board/column-header.tsx, add a <kbd> element after the column name showing the column's position+1 (e.g. '1' for Backlog, '2' for Working)
2. Style the kbd element: text-xs, text-muted-foreground, opacity-50, ml-1, font-mono, bg-muted/30 rounded px-1
3. Only show when column count <= 6 (don't clutter if too many columns)