### PR TITLE
Add task count badge to workspace tab

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -11,14 +11,23 @@ pub fn create_workspace(
     repo_path: String,
 ) -> Result<Workspace, AppError> {
     if name.trim().is_empty() {
-        return Err(AppError::InvalidInput("Workspace name cannot be empty".to_string()));
+        return Err(AppError::InvalidInput(
+            "Workspace name cannot be empty".to_string(),
+        ));
     }
     if repo_path.trim().is_empty() {
-        return Err(AppError::InvalidInput("Repository path cannot be empty".to_string()));
+        return Err(AppError::InvalidInput(
+            "Repository path cannot be empty".to_string(),
+        ));
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     let ws = db::insert_workspace(&conn, name.trim(), repo_path.trim())?;
 
@@ -27,19 +36,26 @@ pub fn create_workspace(
         db::insert_column(&conn, &ws.id, col_name, i as i64)?;
     }
 
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(ws)
 }
 
 #[tauri::command]
 pub fn get_workspace(state: State<AppState>, id: String) -> Result<Workspace, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::get_workspace(&conn, &id)?)
 }
 
 #[tauri::command]
 pub fn list_workspaces(state: State<AppState>) -> Result<Vec<Workspace>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_workspaces(&conn)?)
 }
 
@@ -55,11 +71,16 @@ pub fn update_workspace(
 ) -> Result<Workspace, AppError> {
     if let Some(ref n) = name {
         if n.trim().is_empty() {
-            return Err(AppError::InvalidInput("Workspace name cannot be empty".to_string()));
+            return Err(AppError::InvalidInput(
+                "Workspace name cannot be empty".to_string(),
+            ));
         }
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::update_workspace(
         &conn,
         &id,
@@ -73,7 +94,10 @@ pub fn update_workspace(
 
 #[tauri::command]
 pub fn delete_workspace(state: State<AppState>, id: String) -> Result<(), AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     // CASCADE handles associated columns/tasks
     db::delete_workspace(&conn, &id)?;
     Ok(())
@@ -84,7 +108,10 @@ pub fn get_default_columns(
     state: &State<AppState>,
     workspace_id: &str,
 ) -> Result<Vec<Column>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_columns(&conn, workspace_id)?)
 }
 
@@ -96,11 +123,18 @@ pub fn clone_workspace(
     new_name: String,
 ) -> Result<Workspace, AppError> {
     if new_name.trim().is_empty() {
-        return Err(AppError::InvalidInput("New workspace name cannot be empty".to_string()));
+        return Err(AppError::InvalidInput(
+            "New workspace name cannot be empty".to_string(),
+        ));
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Get source workspace
     let source = db::get_workspace(&conn, &source_id)?;
@@ -155,29 +189,41 @@ pub fn clone_workspace(
         }
     }
 
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    Ok(new_ws)
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::get_workspace(&conn, &new_ws.id)?)
 }
 
 /// Reorder workspaces by updating their tab_order
 #[tauri::command]
 pub fn reorder_workspaces(state: State<AppState>, ids: Vec<String>) -> Result<(), AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     for (i, id) in ids.iter().enumerate() {
         db::update_workspace(&conn, id, None, None, Some(i as i64), None, None)?;
     }
 
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(())
 }
 
 /// Seed demo workspace with sample tasks for testing
 #[tauri::command]
 pub fn seed_demo_data(state: State<AppState>, repo_path: String) -> Result<Workspace, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Create demo workspace
     let ws = db::insert_workspace(&conn, "Demo Workspace", &repo_path)?;
@@ -191,41 +237,150 @@ pub fn seed_demo_data(state: State<AppState>, repo_path: String) -> Result<Works
 
     // Sample tasks for Backlog
     let backlog_id = &columns[0].id;
-    db::insert_task(&conn, &ws.id, backlog_id, "Add dark mode toggle", Some("Implement theme switching in settings"))?;
-    db::insert_task(&conn, &ws.id, backlog_id, "Refactor auth flow", Some("Simplify the authentication logic"))?;
+    db::insert_task(
+        &conn,
+        &ws.id,
+        backlog_id,
+        "Add dark mode toggle",
+        Some("Implement theme switching in settings"),
+    )?;
+    db::insert_task(
+        &conn,
+        &ws.id,
+        backlog_id,
+        "Refactor auth flow",
+        Some("Simplify the authentication logic"),
+    )?;
 
     // Task with draft PR
-    let draft_task = db::insert_task(&conn, &ws.id, backlog_id, "Write unit tests", Some("Add tests for core utilities - WIP draft PR"))?;
+    let draft_task = db::insert_task(
+        &conn,
+        &ws.id,
+        backlog_id,
+        "Write unit tests",
+        Some("Add tests for core utilities - WIP draft PR"),
+    )?;
     db::update_task_branch(&conn, &draft_task.id, Some("feat/unit-tests"))?;
-    db::update_task_pr_info(&conn, &draft_task.id, Some(101), Some("https://github.com/demo/repo/pull/101"))?;
-    db::update_task_pr_status(&conn, &draft_task.id, Some("unknown"), Some("pending"), None, Some(0), Some(true), Some("[]"), Some("abc123"))?;
+    db::update_task_pr_info(
+        &conn,
+        &draft_task.id,
+        Some(101),
+        Some("https://github.com/demo/repo/pull/101"),
+    )?;
+    db::update_task_pr_status(
+        &conn,
+        &draft_task.id,
+        Some("unknown"),
+        Some("pending"),
+        None,
+        Some(0),
+        Some(true),
+        Some("[]"),
+        Some("abc123"),
+    )?;
 
     // Sample tasks for Working - with CI failure and merge conflict
     let working_id = &columns[1].id;
-    let ci_fail_task = db::insert_task(&conn, &ws.id, working_id, "Implement CLI agent spawning", Some("Wire up settings to spawn correct CLI - CI failing"))?;
+    let ci_fail_task = db::insert_task(
+        &conn,
+        &ws.id,
+        working_id,
+        "Implement CLI agent spawning",
+        Some("Wire up settings to spawn correct CLI - CI failing"),
+    )?;
     db::update_task_branch(&conn, &ci_fail_task.id, Some("feat/cli-agent"))?;
-    db::update_task_pr_info(&conn, &ci_fail_task.id, Some(102), Some("https://github.com/demo/repo/pull/102"))?;
-    db::update_task_pr_status(&conn, &ci_fail_task.id, Some("conflicted"), Some("failure"), Some("changes_requested"), Some(5), Some(false), Some("[\"bug\",\"needs-work\"]"), Some("def456"))?;
+    db::update_task_pr_info(
+        &conn,
+        &ci_fail_task.id,
+        Some(102),
+        Some("https://github.com/demo/repo/pull/102"),
+    )?;
+    db::update_task_pr_status(
+        &conn,
+        &ci_fail_task.id,
+        Some("conflicted"),
+        Some("failure"),
+        Some("changes_requested"),
+        Some(5),
+        Some(false),
+        Some("[\"bug\",\"needs-work\"]"),
+        Some("def456"),
+    )?;
 
-    let working_task = db::insert_task(&conn, &ws.id, working_id, "Fix terminal scrolling", Some("Terminal output should auto-scroll"))?;
+    let working_task = db::insert_task(
+        &conn,
+        &ws.id,
+        working_id,
+        "Fix terminal scrolling",
+        Some("Terminal output should auto-scroll"),
+    )?;
     db::update_task_branch(&conn, &working_task.id, Some("fix/terminal-scroll"))?;
 
     // Sample tasks for Review - with approved PR
     let review_id = &columns[2].id;
-    let approved_task = db::insert_task(&conn, &ws.id, review_id, "PR: Add keyboard shortcuts", Some("Review PR #12 for hotkey support - ready to merge!"))?;
+    let approved_task = db::insert_task(
+        &conn,
+        &ws.id,
+        review_id,
+        "PR: Add keyboard shortcuts",
+        Some("Review PR #12 for hotkey support - ready to merge!"),
+    )?;
     db::update_task_branch(&conn, &approved_task.id, Some("feat/keyboard-shortcuts"))?;
-    db::update_task_pr_info(&conn, &approved_task.id, Some(103), Some("https://github.com/demo/repo/pull/103"))?;
-    db::update_task_pr_status(&conn, &approved_task.id, Some("mergeable"), Some("success"), Some("approved"), Some(3), Some(false), Some("[\"enhancement\",\"ready\"]"), Some("ghi789"))?;
+    db::update_task_pr_info(
+        &conn,
+        &approved_task.id,
+        Some(103),
+        Some("https://github.com/demo/repo/pull/103"),
+    )?;
+    db::update_task_pr_status(
+        &conn,
+        &approved_task.id,
+        Some("mergeable"),
+        Some("success"),
+        Some("approved"),
+        Some(3),
+        Some(false),
+        Some("[\"enhancement\",\"ready\"]"),
+        Some("ghi789"),
+    )?;
 
     // Sample tasks for Done
     let done_id = &columns[3].id;
-    let done_task1 = db::insert_task(&conn, &ws.id, done_id, "Setup project structure", Some("Initial Tauri + React setup complete"))?;
+    let done_task1 = db::insert_task(
+        &conn,
+        &ws.id,
+        done_id,
+        "Setup project structure",
+        Some("Initial Tauri + React setup complete"),
+    )?;
     db::update_task_branch(&conn, &done_task1.id, Some("feat/initial-setup"))?;
-    db::update_task_pr_info(&conn, &done_task1.id, Some(99), Some("https://github.com/demo/repo/pull/99"))?;
-    db::update_task_pr_status(&conn, &done_task1.id, Some("mergeable"), Some("success"), Some("approved"), Some(2), Some(false), Some("[\"merged\"]"), Some("xyz000"))?;
+    db::update_task_pr_info(
+        &conn,
+        &done_task1.id,
+        Some(99),
+        Some("https://github.com/demo/repo/pull/99"),
+    )?;
+    db::update_task_pr_status(
+        &conn,
+        &done_task1.id,
+        Some("mergeable"),
+        Some("success"),
+        Some("approved"),
+        Some(2),
+        Some(false),
+        Some("[\"merged\"]"),
+        Some("xyz000"),
+    )?;
 
-    db::insert_task(&conn, &ws.id, done_id, "Design settings UI", Some("Settings panel with tabs working"))?;
+    db::insert_task(
+        &conn,
+        &ws.id,
+        done_id,
+        "Design settings UI",
+        Some("Settings panel with tabs working"),
+    )?;
 
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    Ok(ws)
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::get_workspace(&conn, &ws.id)?)
 }

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -16,6 +16,7 @@ pub struct Workspace {
     pub repo_path: String,
     pub tab_order: i64,
     pub is_active: bool,
+    pub active_task_count: i64,
     pub config: String,
     pub created_at: String,
     pub updated_at: String,
@@ -287,4 +288,3 @@ pub struct SessionSnapshot {
     pub duration_ms: i64,
     pub created_at: String,
 }
-

--- a/src-tauri/src/db/workspace.rs
+++ b/src-tauri/src/db/workspace.rs
@@ -4,7 +4,7 @@ use super::models::Workspace;
 use super::{new_id, now};
 
 /// Shared SELECT columns for workspaces.
-const WORKSPACE_COLUMNS: &str = "id, name, repo_path, tab_order, is_active, config, created_at, updated_at, discord_guild_id, discord_category_id, discord_chef_channel_id, discord_notifications_channel_id, discord_enabled";
+const WORKSPACE_COLUMNS: &str = "id, name, repo_path, tab_order, is_active, COALESCE((SELECT COUNT(*) FROM tasks WHERE workspace_id = workspaces.id AND column_id != (SELECT id FROM columns WHERE workspace_id = workspaces.id ORDER BY position DESC LIMIT 1)), 0) AS active_task_count, config, created_at, updated_at, discord_guild_id, discord_category_id, discord_chef_channel_id, discord_notifications_channel_id, discord_enabled";
 
 /// Map a database row to a Workspace struct.
 fn map_workspace_row(row: &rusqlite::Row) -> rusqlite::Result<Workspace> {
@@ -14,14 +14,17 @@ fn map_workspace_row(row: &rusqlite::Row) -> rusqlite::Result<Workspace> {
         repo_path: row.get(2)?,
         tab_order: row.get(3)?,
         is_active: row.get::<_, i64>(4)? != 0,
-        config: row.get::<_, Option<String>>(5)?.unwrap_or_else(|| "{}".to_string()),
-        created_at: row.get(6)?,
-        updated_at: row.get(7)?,
-        discord_guild_id: row.get(8)?,
-        discord_category_id: row.get(9)?,
-        discord_chef_channel_id: row.get(10)?,
-        discord_notifications_channel_id: row.get(11)?,
-        discord_enabled: row.get(12)?,
+        active_task_count: row.get(5)?,
+        config: row
+            .get::<_, Option<String>>(6)?
+            .unwrap_or_else(|| "{}".to_string()),
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+        discord_guild_id: row.get(9)?,
+        discord_category_id: row.get(10)?,
+        discord_chef_channel_id: row.get(11)?,
+        discord_notifications_channel_id: row.get(12)?,
+        discord_enabled: row.get(13)?,
     })
 }
 
@@ -44,9 +47,10 @@ pub fn get_workspace(conn: &Connection, id: &str) -> SqlResult<Workspace> {
 }
 
 pub fn list_workspaces(conn: &Connection) -> SqlResult<Vec<Workspace>> {
-    let mut stmt = conn.prepare(
-        &format!("SELECT {} FROM workspaces ORDER BY tab_order", WORKSPACE_COLUMNS),
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {} FROM workspaces ORDER BY tab_order",
+        WORKSPACE_COLUMNS
+    ))?;
     let rows = stmt.query_map([], map_workspace_row)?;
     rows.collect()
 }

--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -30,6 +30,7 @@ import type { Workspace } from '@/types'
 type TabProps = {
   workspace: Workspace
   isActive: boolean
+  activeTaskCount?: number
   notificationCount?: number
   onSelect: () => void
   onClose: () => void
@@ -40,17 +41,13 @@ type TabProps = {
 function SortableTab({
   workspace,
   isActive,
+  activeTaskCount = 0,
   notificationCount = 0,
   onSelect,
 }: Omit<TabProps, 'onClose'>) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: workspace.id })
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: workspace.id,
+  })
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -74,17 +71,27 @@ function SortableTab({
         role="button"
         tabIndex={0}
         onClick={onSelect}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect() }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') onSelect()
+        }}
         className={`
           group flex h-8 cursor-pointer items-center justify-center px-3 text-sm
           transition-colors duration-150
-          ${isActive
-            ? 'font-medium text-text-primary'
-            : 'font-normal text-text-secondary hover:text-text-primary'
+          ${
+            isActive
+              ? 'font-medium text-text-primary'
+              : 'font-normal text-text-secondary hover:text-text-primary'
           }
         `}
       >
-        <span className="max-w-[120px] truncate text-center">{workspace.name}</span>
+        <span className="flex items-center">
+          <span className="max-w-[120px] truncate text-center">{workspace.name}</span>
+          {activeTaskCount > 0 && (
+            <span className="ml-1 rounded-full bg-primary/20 px-1.5 text-xs text-primary">
+              {activeTaskCount}
+            </span>
+          )}
+        </span>
 
         {/* Notification badge */}
         {notificationCount > 0 && (
@@ -134,7 +141,11 @@ function AddTabButton({ onClick }: { onClick: () => void }) {
           fill="currentColor"
           className="h-4 w-4"
         >
-          <path fillRule="evenodd" d="M3.75 3A1.75 1.75 0 0 0 2 4.75v10.5c0 .966.784 1.75 1.75 1.75h12.5A1.75 1.75 0 0 0 18 15.25v-8.5A1.75 1.75 0 0 0 16.25 5h-4.836a.25.25 0 0 1-.177-.073L9.823 3.513A1.75 1.75 0 0 0 8.586 3H3.75ZM10 8a.75.75 0 0 1 .75.75v1.5h1.5a.75.75 0 0 1 0 1.5h-1.5v1.5a.75.75 0 0 1-1.5 0v-1.5h-1.5a.75.75 0 0 1 0-1.5h1.5v-1.5A.75.75 0 0 1 10 8Z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M3.75 3A1.75 1.75 0 0 0 2 4.75v10.5c0 .966.784 1.75 1.75 1.75h12.5A1.75 1.75 0 0 0 18 15.25v-8.5A1.75 1.75 0 0 0 16.25 5h-4.836a.25.25 0 0 1-.177-.073L9.823 3.513A1.75 1.75 0 0 0 8.586 3H3.75ZM10 8a.75.75 0 0 1 .75.75v1.5h1.5a.75.75 0 0 1 0 1.5h-1.5v1.5a.75.75 0 0 1-1.5 0v-1.5h-1.5a.75.75 0 0 1 0-1.5h1.5v-1.5A.75.75 0 0 1 10 8Z"
+            clipRule="evenodd"
+          />
         </svg>
       </motion.button>
     </Tooltip>
@@ -160,7 +171,11 @@ function SettingsButton() {
           fill="currentColor"
           className="h-4 w-4"
         >
-          <path fillRule="evenodd" d="M8.34 1.804A1 1 0 0 1 9.32 1h1.36a1 1 0 0 1 .98.804l.295 1.473c.497.144.971.342 1.416.587l1.25-.834a1 1 0 0 1 1.262.125l.962.962a1 1 0 0 1 .125 1.262l-.834 1.25c.245.445.443.919.587 1.416l1.473.295a1 1 0 0 1 .804.98v1.36a1 1 0 0 1-.804.98l-1.473.295a6.95 6.95 0 0 1-.587 1.416l.834 1.25a1 1 0 0 1-.125 1.262l-.962.962a1 1 0 0 1-1.262.125l-1.25-.834a6.953 6.953 0 0 1-1.416.587l-.295 1.473a1 1 0 0 1-.98.804H9.32a1 1 0 0 1-.98-.804l-.295-1.473a6.957 6.957 0 0 1-1.416-.587l-1.25.834a1 1 0 0 1-1.262-.125l-.962-.962a1 1 0 0 1-.125-1.262l.834-1.25a6.957 6.957 0 0 1-.587-1.416l-1.473-.295A1 1 0 0 1 1 10.68V9.32a1 1 0 0 1 .804-.98l1.473-.295c.144-.497.342-.971.587-1.416l-.834-1.25a1 1 0 0 1 .125-1.262l.962-.962A1 1 0 0 1 5.38 3.03l1.25.834a6.957 6.957 0 0 1 1.416-.587l.295-1.473ZM13 10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M8.34 1.804A1 1 0 0 1 9.32 1h1.36a1 1 0 0 1 .98.804l.295 1.473c.497.144.971.342 1.416.587l1.25-.834a1 1 0 0 1 1.262.125l.962.962a1 1 0 0 1 .125 1.262l-.834 1.25c.245.445.443.919.587 1.416l1.473.295a1 1 0 0 1 .804.98v1.36a1 1 0 0 1-.804.98l-1.473.295a6.95 6.95 0 0 1-.587 1.416l.834 1.25a1 1 0 0 1-.125 1.262l-.962.962a1 1 0 0 1-1.262.125l-1.25-.834a6.953 6.953 0 0 1-1.416.587l-.295 1.473a1 1 0 0 1-.98.804H9.32a1 1 0 0 1-.98-.804l-.295-1.473a6.957 6.957 0 0 1-1.416-.587l-1.25.834a1 1 0 0 1-1.262-.125l-.962-.962a1 1 0 0 1-.125-1.262l.834-1.25a6.957 6.957 0 0 1-.587-1.416l-1.473-.295A1 1 0 0 1 1 10.68V9.32a1 1 0 0 1 .804-.98l1.473-.295c.144-.497.342-.971.587-1.416l-.834-1.25a1 1 0 0 1 .125-1.262l.962-.962A1 1 0 0 1 5.38 3.03l1.25.834a6.957 6.957 0 0 1 1.416-.587l.295-1.473ZM13 10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+            clipRule="evenodd"
+          />
         </svg>
       </motion.button>
     </Tooltip>
@@ -191,7 +206,11 @@ function ChecklistButton() {
           fill="currentColor"
           className={`h-4 w-4 ${allComplete ? 'text-success' : ''}`}
         >
-          <path fillRule="evenodd" d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z"
+            clipRule="evenodd"
+          />
         </svg>
         {hasItems && !allComplete && (
           <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-accent text-[8px] font-bold text-bg">
@@ -207,7 +226,6 @@ function ChecklistButton() {
     </Tooltip>
   )
 }
-
 
 // ─── TabBar ─────────────────────────────────────────────────────────────────
 
@@ -308,7 +326,9 @@ export function TabBar() {
     }
 
     window.addEventListener('keydown', handleKeyDown)
-    return () => { window.removeEventListener('keydown', handleKeyDown); }
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
   }, [selectByIndex, selectPrev, selectNext, closeCurrentTab])
 
   // ─── Drag Handlers ──────────────────────────────────────────────────────────
@@ -329,9 +349,7 @@ export function TabBar() {
     void reorder(newOrder)
   }
 
-  const draggingWorkspace = draggingId
-    ? sortedWorkspaces.find((w) => w.id === draggingId)
-    : null
+  const draggingWorkspace = draggingId ? sortedWorkspaces.find((w) => w.id === draggingId) : null
 
   // Only show tabs if there are workspaces
   if (sortedWorkspaces.length === 0) {
@@ -360,8 +378,11 @@ export function TabBar() {
                     key={workspace.id}
                     workspace={workspace}
                     isActive={workspace.id === activeWorkspaceId}
+                    activeTaskCount={workspace.activeTaskCount}
                     notificationCount={getUnviewedCount(workspace.id)}
-                    onSelect={() => { setActive(workspace.id); }}
+                    onSelect={() => {
+                      setActive(workspace.id)
+                    }}
                   />
                 ))}
               </AnimatePresence>
@@ -375,7 +396,11 @@ export function TabBar() {
 
         {/* Right: add workspace + checklist + settings */}
         <div className="ml-auto flex items-center gap-1">
-          <AddTabButton onClick={() => { setShowAddDialog(true); }} />
+          <AddTabButton
+            onClick={() => {
+              setShowAddDialog(true)
+            }}
+          />
           <ChecklistButton />
           <SettingsButton />
         </div>
@@ -383,7 +408,11 @@ export function TabBar() {
 
       {/* Add workspace dialog - simple placeholder for now */}
       {showAddDialog && (
-        <AddWorkspaceDialog onClose={() => { setShowAddDialog(false); }} />
+        <AddWorkspaceDialog
+          onClose={() => {
+            setShowAddDialog(false)
+          }}
+        />
       )}
     </>
   )
@@ -426,19 +455,28 @@ function AddWorkspaceDialog({ onClose }: { onClose: () => void }) {
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.95 }}
-        onClick={(e) => { e.stopPropagation(); }}
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
         className="w-full max-w-md rounded-xl border border-border-default bg-surface p-6 shadow-xl"
       >
         <h2 className="mb-4 text-lg font-semibold text-text-primary">Add Workspace</h2>
 
-        <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
+        <form
+          onSubmit={(e) => {
+            void handleSubmit(e)
+          }}
+          className="space-y-4"
+        >
           <div>
             <label className="mb-1 block text-sm text-text-secondary">Name</label>
             <input
               ref={inputRef}
               type="text"
               value={name}
-              onChange={(e) => { setName(e.target.value); }}
+              onChange={(e) => {
+                setName(e.target.value)
+              }}
               placeholder="My Project"
               className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none"
             />
@@ -449,7 +487,9 @@ function AddWorkspaceDialog({ onClose }: { onClose: () => void }) {
             <input
               type="text"
               value={repoPath}
-              onChange={(e) => { setRepoPath(e.target.value); }}
+              onChange={(e) => {
+                setRepoPath(e.target.value)
+              }}
               placeholder="/path/to/repo"
               className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none"
             />

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -12,7 +12,10 @@ import { DEFAULT_TRIGGERS } from '@/types/column'
 export const isTauri = (): boolean => {
   // In Vitest, we want to use the mocked @tauri-apps/api, not our browser mocks
   // Check for import.meta.env which Vite uses
-  if (typeof import.meta !== 'undefined' && (import.meta as { env?: { MODE?: string } }).env?.MODE === 'test') {
+  if (
+    typeof import.meta !== 'undefined' &&
+    (import.meta as { env?: { MODE?: string } }).env?.MODE === 'test'
+  ) {
     return true // Let Vitest mocks handle it
   }
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
@@ -27,6 +30,7 @@ let mockWorkspaces: Workspace[] = [
     repoPath: '/tmp/demo-repo',
     tabOrder: 0,
     isActive: true,
+    activeTaskCount: 0,
     config: '{}',
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -34,10 +38,54 @@ let mockWorkspaces: Workspace[] = [
 ]
 
 let mockColumns: Column[] = [
-  { id: 'col-1', workspaceId: 'ws-demo', name: 'Backlog', icon: 'inbox', position: 0, color: '', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
-  { id: 'col-2', workspaceId: 'ws-demo', name: 'Working', icon: 'code', position: 1, color: '', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
-  { id: 'col-3', workspaceId: 'ws-demo', name: 'Review', icon: 'eye', position: 2, color: '', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
-  { id: 'col-4', workspaceId: 'ws-demo', name: 'Done', icon: 'check', position: 3, color: '#4ADE80', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+  {
+    id: 'col-1',
+    workspaceId: 'ws-demo',
+    name: 'Backlog',
+    icon: 'inbox',
+    position: 0,
+    color: '',
+    visible: true,
+    triggers: DEFAULT_TRIGGERS,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 'col-2',
+    workspaceId: 'ws-demo',
+    name: 'Working',
+    icon: 'code',
+    position: 1,
+    color: '',
+    visible: true,
+    triggers: DEFAULT_TRIGGERS,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 'col-3',
+    workspaceId: 'ws-demo',
+    name: 'Review',
+    icon: 'eye',
+    position: 2,
+    color: '',
+    visible: true,
+    triggers: DEFAULT_TRIGGERS,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 'col-4',
+    workspaceId: 'ws-demo',
+    name: 'Done',
+    icon: 'check',
+    position: 3,
+    color: '#4ADE80',
+    visible: true,
+    triggers: DEFAULT_TRIGGERS,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
 ]
 
 let mockTasks: Task[] = [
@@ -92,30 +140,56 @@ let idCounter = 100
 
 const generateId = (prefix: string) => `${prefix}-${String(++idCounter)}`
 
+const getLastColumnId = (workspaceId: string) => {
+  const columns = mockColumns
+    .filter((column) => column.workspaceId === workspaceId)
+    .sort((a, b) => a.position - b.position)
+
+  return columns.length > 0 ? (columns[columns.length - 1]?.id ?? null) : null
+}
+
+const getActiveTaskCount = (workspaceId: string) => {
+  const lastColumnId = getLastColumnId(workspaceId)
+  if (!lastColumnId) return 0
+
+  return mockTasks.filter(
+    (task) => task.workspaceId === workspaceId && task.columnId !== lastColumnId,
+  ).length
+}
+
+const withActiveTaskCount = (workspace: Workspace): Workspace => ({
+  ...workspace,
+  activeTaskCount: getActiveTaskCount(workspace.id),
+})
+
 // ─── Mock Command Handlers ──────────────────────────────────────────────────
 
 type CommandHandler = (args?: Record<string, unknown>) => unknown
 
 const mockCommands: Record<string, CommandHandler> = {
   // Workspace commands
-  list_workspaces: () => mockWorkspaces,
-  get_workspace: (args) => mockWorkspaces.find(w => w.id === args?.id),
+  list_workspaces: () => mockWorkspaces.map(withActiveTaskCount),
+  get_workspace: (args) => {
+    const workspace = mockWorkspaces.find((w) => w.id === args?.id)
+    return workspace ? withActiveTaskCount(workspace) : undefined
+  },
   create_workspace: (args) => {
     const ws: Workspace = {
       id: generateId('ws'),
-      name: args?.name as string || 'New Workspace',
-      repoPath: args?.repoPath as string || '/tmp/repo',
+      name: (args?.name as string) || 'New Workspace',
+      repoPath: (args?.repoPath as string) || '/tmp/repo',
       tabOrder: mockWorkspaces.length,
       isActive: false,
+      activeTaskCount: 0,
       config: '{}',
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }
     mockWorkspaces.push(ws)
-    return ws
+    return withActiveTaskCount(ws)
   },
   update_workspace: (args) => {
-    const existing = mockWorkspaces.find(w => w.id === args?.id)
+    const existing = mockWorkspaces.find((w) => w.id === args?.id)
     if (existing) {
       existing.name = (args?.name as string) ?? existing.name
       existing.repoPath = (args?.repoPath as string) ?? existing.repoPath
@@ -123,32 +197,32 @@ const mockCommands: Record<string, CommandHandler> = {
       existing.isActive = (args?.isActive as boolean) ?? existing.isActive
       existing.config = (args?.config as string) ?? existing.config
       existing.updatedAt = new Date().toISOString()
-      return existing
+      return withActiveTaskCount(existing)
     }
     throw new Error('Workspace not found')
   },
   delete_workspace: (args) => {
-    mockWorkspaces = mockWorkspaces.filter(w => w.id !== args?.id)
-    mockColumns = mockColumns.filter(c => c.workspaceId !== args?.id)
-    mockTasks = mockTasks.filter(t => t.workspaceId !== args?.id)
+    mockWorkspaces = mockWorkspaces.filter((w) => w.id !== args?.id)
+    mockColumns = mockColumns.filter((c) => c.workspaceId !== args?.id)
+    mockTasks = mockTasks.filter((t) => t.workspaceId !== args?.id)
   },
   reorder_workspaces: (args) => {
     const ids = args?.ids as string[]
     ids.forEach((id, idx) => {
-      const ws = mockWorkspaces.find(w => w.id === id)
+      const ws = mockWorkspaces.find((w) => w.id === id)
       if (ws) ws.tabOrder = idx
     })
   },
 
   // Column commands
-  list_columns: (args) => mockColumns.filter(c => c.workspaceId === args?.workspaceId),
+  list_columns: (args) => mockColumns.filter((c) => c.workspaceId === args?.workspaceId),
   create_column: (args) => {
     const col: Column = {
       id: generateId('col'),
       workspaceId: args?.workspaceId as string,
-      name: args?.name as string || 'New Column',
+      name: (args?.name as string) || 'New Column',
       icon: 'list',
-      position: args?.position as number || mockColumns.length,
+      position: (args?.position as number) || mockColumns.length,
       color: '',
       visible: true,
       triggers: DEFAULT_TRIGGERS,
@@ -159,7 +233,7 @@ const mockCommands: Record<string, CommandHandler> = {
     return col
   },
   update_column: (args) => {
-    const existing = mockColumns.find(c => c.id === args?.id)
+    const existing = mockColumns.find((c) => c.id === args?.id)
     if (existing) {
       existing.name = (args?.name as string) ?? existing.name
       existing.icon = (args?.icon as string) ?? existing.icon
@@ -174,28 +248,28 @@ const mockCommands: Record<string, CommandHandler> = {
     throw new Error('Column not found')
   },
   delete_column: (args) => {
-    mockColumns = mockColumns.filter(c => c.id !== args?.id)
-    mockTasks = mockTasks.filter(t => t.columnId !== args?.id)
+    mockColumns = mockColumns.filter((c) => c.id !== args?.id)
+    mockTasks = mockTasks.filter((t) => t.columnId !== args?.id)
   },
   reorder_columns: (args) => {
     const columnIds = args?.columnIds as string[]
     columnIds.forEach((id, idx) => {
-      const col = mockColumns.find(c => c.id === id)
+      const col = mockColumns.find((c) => c.id === id)
       if (col) col.position = idx
     })
-    return mockColumns.filter(c => c.workspaceId === args?.workspaceId)
+    return mockColumns.filter((c) => c.workspaceId === args?.workspaceId)
   },
 
   // Task commands
-  list_tasks: (args) => mockTasks.filter(t => t.workspaceId === args?.workspaceId),
-  get_task: (args) => mockTasks.find(t => t.id === args?.id),
+  list_tasks: (args) => mockTasks.filter((t) => t.workspaceId === args?.workspaceId),
+  get_task: (args) => mockTasks.find((t) => t.id === args?.id),
   create_task: (args) => {
     const task: Task = {
       id: generateId('task'),
       workspaceId: args?.workspaceId as string,
       columnId: args?.columnId as string,
-      title: args?.title as string || 'New Task',
-      description: args?.description as string || '',
+      title: (args?.title as string) || 'New Task',
+      description: (args?.description as string) || '',
       branch: null,
       agentType: null,
       agentMode: null,
@@ -231,7 +305,7 @@ const mockCommands: Record<string, CommandHandler> = {
       blocked: false,
       worktreePath: null,
       queuedAt: null,
-      position: mockTasks.filter(t => t.columnId === args?.columnId).length,
+      position: mockTasks.filter((t) => t.columnId === args?.columnId).length,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }
@@ -239,7 +313,7 @@ const mockCommands: Record<string, CommandHandler> = {
     return task
   },
   update_task: (args) => {
-    const existing = mockTasks.find(t => t.id === args?.id)
+    const existing = mockTasks.find((t) => t.id === args?.id)
     if (existing) {
       existing.title = (args?.title as string) ?? existing.title
       existing.description = (args?.description as string) ?? existing.description
@@ -249,7 +323,8 @@ const mockCommands: Record<string, CommandHandler> = {
       existing.agentMode = (args?.agentMode as AgentMode | null) ?? existing.agentMode
       existing.agentStatus = (args?.agentStatus as AgentStatus | null) ?? existing.agentStatus
       existing.pipelineState = (args?.pipelineState as PipelineState) ?? existing.pipelineState
-      existing.pipelineTriggeredAt = (args?.pipelineTriggeredAt as string | null) ?? existing.pipelineTriggeredAt
+      existing.pipelineTriggeredAt =
+        (args?.pipelineTriggeredAt as string | null) ?? existing.pipelineTriggeredAt
       existing.pipelineError = (args?.pipelineError as string | null) ?? existing.pipelineError
       existing.position = (args?.position as number) ?? existing.position
       existing.updatedAt = new Date().toISOString()
@@ -258,7 +333,7 @@ const mockCommands: Record<string, CommandHandler> = {
     throw new Error('Task not found')
   },
   move_task: (args) => {
-    const task = mockTasks.find(t => t.id === args?.id)
+    const task = mockTasks.find((t) => t.id === args?.id)
     if (task) {
       task.columnId = args?.targetColumnId as string
       task.position = args?.position as number
@@ -268,15 +343,15 @@ const mockCommands: Record<string, CommandHandler> = {
     throw new Error('Task not found')
   },
   delete_task: (args) => {
-    mockTasks = mockTasks.filter(t => t.id !== args?.id)
+    mockTasks = mockTasks.filter((t) => t.id !== args?.id)
   },
   reorder_tasks: (args) => {
     const taskIds = args?.taskIds as string[]
     taskIds.forEach((id, idx) => {
-      const task = mockTasks.find(t => t.id === id)
+      const task = mockTasks.find((t) => t.id === id)
       if (task) task.position = idx
     })
-    return mockTasks.filter(t => t.columnId === args?.columnId)
+    return mockTasks.filter((t) => t.columnId === args?.columnId)
   },
 
   // Settings
@@ -285,7 +360,7 @@ const mockCommands: Record<string, CommandHandler> = {
 
   // PR creation (stub)
   create_pr: (args) => {
-    const task = mockTasks.find(t => t.id === args?.taskId)
+    const task = mockTasks.find((t) => t.id === args?.taskId)
     if (task) {
       task.prNumber = 123
       task.prUrl = 'https://github.com/owner/repo/pull/123'
@@ -297,7 +372,7 @@ const mockCommands: Record<string, CommandHandler> = {
 
   // Notification commands
   update_task_stakeholders: (args) => {
-    const task = mockTasks.find(t => t.id === args?.id)
+    const task = mockTasks.find((t) => t.id === args?.id)
     if (task) {
       task.notifyStakeholders = (args?.stakeholders as string | null) ?? null
       task.updatedAt = new Date().toISOString()
@@ -306,7 +381,7 @@ const mockCommands: Record<string, CommandHandler> = {
     throw new Error('Task not found')
   },
   mark_task_notification_sent: (args) => {
-    const task = mockTasks.find(t => t.id === args?.id)
+    const task = mockTasks.find((t) => t.id === args?.id)
     if (task) {
       task.notificationSentAt = new Date().toISOString()
       task.updatedAt = new Date().toISOString()
@@ -315,7 +390,7 @@ const mockCommands: Record<string, CommandHandler> = {
     throw new Error('Task not found')
   },
   clear_task_notification_sent: (args) => {
-    const task = mockTasks.find(t => t.id === args?.id)
+    const task = mockTasks.find((t) => t.id === args?.id)
     if (task) {
       task.notificationSentAt = null
       task.updatedAt = new Date().toISOString()
@@ -338,7 +413,13 @@ const mockCommands: Record<string, CommandHandler> = {
   // Agent commands (stubs)
   start_agent: () => ({ taskId: '', agentType: '', status: 'idle', pid: null, workingDir: '' }),
   stop_agent: () => undefined,
-  get_agent_status: () => ({ taskId: '', agentType: '', status: 'idle', pid: null, workingDir: '' }),
+  get_agent_status: () => ({
+    taskId: '',
+    agentType: '',
+    status: 'idle',
+    pid: null,
+    workingDir: '',
+  }),
 
   // Agent message commands
   save_agent_message: (args) => ({
@@ -356,24 +437,66 @@ const mockCommands: Record<string, CommandHandler> = {
   clear_agent_messages: () => undefined,
 
   // Pipeline commands (stubs)
-  mark_pipeline_complete: (args) => mockTasks.find(t => t.id === args?.taskId),
+  mark_pipeline_complete: (args) => mockTasks.find((t) => t.id === args?.taskId),
   get_pipeline_state: () => 'idle',
   try_advance_task: () => null,
-  set_pipeline_error: (args) => mockTasks.find(t => t.id === args?.taskId),
+  set_pipeline_error: (args) => mockTasks.find((t) => t.id === args?.taskId),
 
   // Orchestrator commands (stubs)
-  get_orchestrator_context: () => ({ workspaceId: '', workspaceName: '', columns: [], tasks: [], recentMessages: [] }),
-  get_orchestrator_session: () => ({ id: '', workspaceId: '', status: 'idle', lastError: null, createdAt: '', updatedAt: '' }),
-  send_orchestrator_message: () => ({ id: '', workspaceId: '', sessionId: null, role: 'user', content: '', createdAt: '' }),
+  get_orchestrator_context: () => ({
+    workspaceId: '',
+    workspaceName: '',
+    columns: [],
+    tasks: [],
+    recentMessages: [],
+  }),
+  get_orchestrator_session: () => ({
+    id: '',
+    workspaceId: '',
+    status: 'idle',
+    lastError: null,
+    createdAt: '',
+    updatedAt: '',
+  }),
+  send_orchestrator_message: () => ({
+    id: '',
+    workspaceId: '',
+    sessionId: null,
+    role: 'user',
+    content: '',
+    createdAt: '',
+  }),
   list_chat_sessions: () => [],
-  get_active_chat_session: () => ({ id: 'mock-session', workspaceId: '', title: 'New Chat', createdAt: '', updatedAt: '' }),
-  create_chat_session: () => ({ id: 'mock-session', workspaceId: '', title: 'New Chat', createdAt: '', updatedAt: '' }),
+  get_active_chat_session: () => ({
+    id: 'mock-session',
+    workspaceId: '',
+    title: 'New Chat',
+    createdAt: '',
+    updatedAt: '',
+  }),
+  create_chat_session: () => ({
+    id: 'mock-session',
+    workspaceId: '',
+    title: 'New Chat',
+    createdAt: '',
+    updatedAt: '',
+  }),
   delete_chat_session: () => undefined,
   get_chat_history: () => [],
   clear_chat_history: () => undefined,
   process_orchestrator_response: () => ({ message: '', actions: [], tasksCreated: [] }),
-  set_orchestrator_error: () => ({ id: '', workspaceId: '', status: 'error', lastError: '', createdAt: '', updatedAt: '' }),
-  stream_orchestrator_chat: () => { console.warn('[Browser Mock] stream_orchestrator_chat not available in browser mode'); return undefined },
+  set_orchestrator_error: () => ({
+    id: '',
+    workspaceId: '',
+    status: 'error',
+    lastError: '',
+    createdAt: '',
+    updatedAt: '',
+  }),
+  stream_orchestrator_chat: () => {
+    console.warn('[Browser Mock] stream_orchestrator_chat not available in browser mode')
+    return undefined
+  },
 
   // Voice commands (stubs)
   is_voice_available: () => false,
@@ -381,16 +504,59 @@ const mockCommands: Record<string, CommandHandler> = {
   transcribe_audio: () => ({ text: '', durationMs: 0 }),
 
   // Usage tracking (stubs)
-  record_usage: () => ({ id: '', workspaceId: '', taskId: null, sessionId: null, provider: '', model: '', inputTokens: 0, outputTokens: 0, costUsd: 0, createdAt: '' }),
+  record_usage: () => ({
+    id: '',
+    workspaceId: '',
+    taskId: null,
+    sessionId: null,
+    provider: '',
+    model: '',
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    createdAt: '',
+  }),
   get_workspace_usage: () => [],
   get_task_usage: () => [],
-  get_workspace_usage_summary: () => ({ totalInputTokens: 0, totalOutputTokens: 0, totalCostUsd: 0, recordCount: 0 }),
-  get_task_usage_summary: () => ({ totalInputTokens: 0, totalOutputTokens: 0, totalCostUsd: 0, recordCount: 0 }),
+  get_workspace_usage_summary: () => ({
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCostUsd: 0,
+    recordCount: 0,
+  }),
+  get_task_usage_summary: () => ({
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCostUsd: 0,
+    recordCount: 0,
+  }),
   clear_workspace_usage: () => undefined,
 
   // Session history (stubs)
-  create_snapshot: () => ({ id: '', sessionId: '', workspaceId: '', taskId: null, snapshotType: 'checkpoint', scrollbackSnapshot: null, commandHistory: '', filesModified: '', durationMs: 0, createdAt: '' }),
-  get_snapshot: () => ({ id: '', sessionId: '', workspaceId: '', taskId: null, snapshotType: 'checkpoint', scrollbackSnapshot: null, commandHistory: '', filesModified: '', durationMs: 0, createdAt: '' }),
+  create_snapshot: () => ({
+    id: '',
+    sessionId: '',
+    workspaceId: '',
+    taskId: null,
+    snapshotType: 'checkpoint',
+    scrollbackSnapshot: null,
+    commandHistory: '',
+    filesModified: '',
+    durationMs: 0,
+    createdAt: '',
+  }),
+  get_snapshot: () => ({
+    id: '',
+    sessionId: '',
+    workspaceId: '',
+    taskId: null,
+    snapshotType: 'checkpoint',
+    scrollbackSnapshot: null,
+    commandHistory: '',
+    filesModified: '',
+    durationMs: 0,
+    createdAt: '',
+  }),
   get_session_history: () => [],
   get_workspace_history: () => [],
   get_task_history: () => [],
@@ -400,23 +566,66 @@ const mockCommands: Record<string, CommandHandler> = {
   get_workspace_checklist: () => ({ checklist: null, categories: [], items: [] }),
   update_checklist_item: () => undefined,
   update_checklist_category: () => undefined,
-  create_workspace_checklist: () => ({ id: 'mock-checklist', workspaceId: '', name: 'Mock Checklist', description: '', createdAt: '', updatedAt: '' }),
+  create_workspace_checklist: () => ({
+    id: 'mock-checklist',
+    workspaceId: '',
+    name: 'Mock Checklist',
+    description: '',
+    createdAt: '',
+    updatedAt: '',
+  }),
   delete_workspace_checklist: () => undefined,
   update_checklist_item_auto_detect: () => undefined,
   link_checklist_item_to_task: () => undefined,
 
   // CLI detection / capabilities (stubs)
   detect_clis: () => [],
-  detect_single_cli: () => ({ id: 'claude', name: 'Claude Code', path: '', version: null, isAvailable: false }),
-  verify_cli_path: () => ({ id: 'custom', name: 'Custom CLI', path: '', version: null, isAvailable: false }),
+  detect_single_cli: () => ({
+    id: 'claude',
+    name: 'Claude Code',
+    path: '',
+    version: null,
+    isAvailable: false,
+  }),
+  verify_cli_path: () => ({
+    id: 'custom',
+    name: 'Custom CLI',
+    path: '',
+    version: null,
+    isAvailable: false,
+  }),
   get_cli_capabilities: () => ({
     cliId: 'claude',
     cliVersion: null,
     detected: false,
     models: [
-      { id: 'opus', name: 'Opus', description: 'Most powerful', supportsExtendedContext: true, contextWindow: '200k', maxEffort: 'high', available: true },
-      { id: 'sonnet', name: 'Sonnet', description: 'Fast & capable', supportsExtendedContext: false, contextWindow: '200k', maxEffort: 'high', available: true },
-      { id: 'haiku', name: 'Haiku', description: 'Quick & light', supportsExtendedContext: false, contextWindow: '200k', maxEffort: 'low', available: true },
+      {
+        id: 'opus',
+        name: 'Opus',
+        description: 'Most powerful',
+        supportsExtendedContext: true,
+        contextWindow: '200k',
+        maxEffort: 'high',
+        available: true,
+      },
+      {
+        id: 'sonnet',
+        name: 'Sonnet',
+        description: 'Fast & capable',
+        supportsExtendedContext: false,
+        contextWindow: '200k',
+        maxEffort: 'high',
+        available: true,
+      },
+      {
+        id: 'haiku',
+        name: 'Haiku',
+        description: 'Quick & light',
+        supportsExtendedContext: false,
+        contextWindow: '200k',
+        maxEffort: 'low',
+        available: true,
+      },
     ],
   }),
 }
@@ -425,7 +634,7 @@ const mockCommands: Record<string, CommandHandler> = {
 
 export async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 10))
+  await new Promise((resolve) => setTimeout(resolve, 10))
 
   const handler = mockCommands[cmd]
   if (handler) {
@@ -441,10 +650,7 @@ export async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>)
 type UnlistenFn = () => void
 
 /* eslint-disable @typescript-eslint/no-unnecessary-type-parameters, @typescript-eslint/no-unused-vars -- Mock function signature matches real listen for type compatibility */
-export function mockListen<T>(
-  _event: string,
-  _handler: (payload: T) => void
-): Promise<UnlistenFn> {
+export function mockListen<T>(_event: string, _handler: (payload: T) => void): Promise<UnlistenFn> {
   /* eslint-enable @typescript-eslint/no-unnecessary-type-parameters, @typescript-eslint/no-unused-vars */
   // In browser mode, events are not supported
   return Promise.resolve(() => {})
@@ -460,6 +666,7 @@ export function resetMockData() {
       repoPath: '/tmp/demo-repo',
       tabOrder: 0,
       isActive: true,
+      activeTaskCount: 0,
       config: '{}',
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -467,10 +674,54 @@ export function resetMockData() {
   ]
 
   mockColumns = [
-    { id: 'col-1', workspaceId: 'ws-demo', name: 'Backlog', icon: 'inbox', position: 0, color: '', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
-    { id: 'col-2', workspaceId: 'ws-demo', name: 'Working', icon: 'code', position: 1, color: '', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
-    { id: 'col-3', workspaceId: 'ws-demo', name: 'Review', icon: 'eye', position: 2, color: '', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
-    { id: 'col-4', workspaceId: 'ws-demo', name: 'Done', icon: 'check', position: 3, color: '#4ADE80', visible: true, triggers: DEFAULT_TRIGGERS, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    {
+      id: 'col-1',
+      workspaceId: 'ws-demo',
+      name: 'Backlog',
+      icon: 'inbox',
+      position: 0,
+      color: '',
+      visible: true,
+      triggers: DEFAULT_TRIGGERS,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: 'col-2',
+      workspaceId: 'ws-demo',
+      name: 'Working',
+      icon: 'code',
+      position: 1,
+      color: '',
+      visible: true,
+      triggers: DEFAULT_TRIGGERS,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: 'col-3',
+      workspaceId: 'ws-demo',
+      name: 'Review',
+      icon: 'eye',
+      position: 2,
+      color: '',
+      visible: true,
+      triggers: DEFAULT_TRIGGERS,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: 'col-4',
+      workspaceId: 'ws-demo',
+      name: 'Done',
+      icon: 'check',
+      position: 3,
+      color: '#4ADE80',
+      visible: true,
+      triggers: DEFAULT_TRIGGERS,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
   ]
 
   mockTasks = [

--- a/src/stores/column-store.test.ts
+++ b/src/stores/column-store.test.ts
@@ -3,6 +3,16 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useColumnStore } from './column-store'
 import type { Column } from '@/types'
 
+const refreshWorkspace = vi.fn()
+
+vi.mock('./workspace-store', () => ({
+  useWorkspaceStore: {
+    getState: () => ({
+      refreshWorkspace,
+    }),
+  },
+}))
+
 // Mock IPC module
 vi.mock('@/lib/ipc', () => ({
   getColumns: vi.fn(),
@@ -24,7 +34,11 @@ const createMockColumn = (overrides: Partial<Column> = {}): Column => ({
   position: 0,
   color: '#E8A87C',
   visible: true,
-  triggers: { on_entry: { type: 'none' }, on_exit: { type: 'none' }, exit_criteria: { type: 'manual', auto_advance: false } },
+  triggers: {
+    on_entry: { type: 'none' },
+    on_exit: { type: 'none' },
+    exit_criteria: { type: 'manual', auto_advance: false },
+  },
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
   ...overrides,
@@ -33,6 +47,7 @@ const createMockColumn = (overrides: Partial<Column> = {}): Column => ({
 describe('column-store', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    refreshWorkspace.mockReset()
     useColumnStore.setState({
       columns: [],
       loaded: false,
@@ -60,6 +75,7 @@ describe('column-store', () => {
     it('should add a new column', async () => {
       const newColumn = createMockColumn({ id: 'col-new', name: 'New Column', position: 0 })
       mockIpc.createColumn.mockResolvedValueOnce(newColumn)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useColumnStore.getState().add('ws-1', 'New Column')
 
@@ -67,6 +83,7 @@ describe('column-store', () => {
       expect(state.columns).toHaveLength(1)
       expect(state.columns[0]!.name).toBe('New Column')
       expect(mockIpc.createColumn).toHaveBeenCalledWith('ws-1', 'New Column', 0)
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
     it('should use correct position based on existing columns', async () => {
@@ -80,36 +97,34 @@ describe('column-store', () => {
 
       const newColumn = createMockColumn({ id: 'col-3', name: 'Third', position: 2 })
       mockIpc.createColumn.mockResolvedValueOnce(newColumn)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useColumnStore.getState().add('ws-1', 'Third')
 
       expect(mockIpc.createColumn).toHaveBeenCalledWith('ws-1', 'Third', 2)
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
   })
 
   describe('remove', () => {
     it('should remove a column optimistically', async () => {
       useColumnStore.setState({
-        columns: [
-          createMockColumn({ id: 'col-1' }),
-          createMockColumn({ id: 'col-2' }),
-        ],
+        columns: [createMockColumn({ id: 'col-1' }), createMockColumn({ id: 'col-2' })],
         loaded: true,
       })
       mockIpc.deleteColumn.mockResolvedValueOnce(undefined)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useColumnStore.getState().remove('col-1')
 
       const state = useColumnStore.getState()
       expect(state.columns).toHaveLength(1)
       expect(state.columns[0]!.id).toBe('col-2')
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
     it('should revert on IPC error', async () => {
-      const original = [
-        createMockColumn({ id: 'col-1' }),
-        createMockColumn({ id: 'col-2' }),
-      ]
+      const original = [createMockColumn({ id: 'col-1' }), createMockColumn({ id: 'col-2' })]
       useColumnStore.setState({
         columns: original,
         loaded: true,
@@ -134,6 +149,7 @@ describe('column-store', () => {
         loaded: true,
       })
       mockIpc.reorderColumns.mockResolvedValueOnce(undefined as unknown as Column[])
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useColumnStore.getState().reorder('ws-1', ['col-3', 'col-1', 'col-2'])
 
@@ -144,6 +160,7 @@ describe('column-store', () => {
       expect(state.columns[1]!.position).toBe(1)
       expect(state.columns[2]!.id).toBe('col-2')
       expect(state.columns[2]!.position).toBe(2)
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
     it('should revert on IPC error', async () => {

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import type { Column } from '@/types'
 import * as ipc from '@/lib/ipc'
+import { useWorkspaceStore } from './workspace-store'
 
 type ColumnUpdates = {
   name?: string
@@ -44,13 +45,18 @@ export const useColumnStore = create<ColumnState>()(
         const position = get().columns.length
         const column = await ipc.createColumn(workspaceId, name, position)
         set((s) => ({ columns: [...s.columns, column] }))
+        await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
       },
 
       remove: async (id) => {
         const prev = get().columns
+        const column = prev.find((c) => c.id === id)
         set((s) => ({ columns: s.columns.filter((c) => c.id !== id) }))
         try {
           await ipc.deleteColumn(id)
+          if (column) {
+            await useWorkspaceStore.getState().refreshWorkspace(column.workspaceId)
+          }
         } catch {
           set({ columns: prev })
         }
@@ -68,6 +74,7 @@ export const useColumnStore = create<ColumnState>()(
         }))
         try {
           await ipc.reorderColumns(workspaceId, ids)
+          await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
         } catch {
           set({ columns: prev })
         }
@@ -91,9 +98,11 @@ export const useColumnStore = create<ColumnState>()(
                   ...(updates.icon !== undefined && { icon: updates.icon }),
                   ...(updates.color !== undefined && { color: updates.color ?? '' }),
                   ...(updates.visible !== undefined && { visible: updates.visible }),
-                  ...(updates.triggers !== undefined && { triggers: JSON.parse(updates.triggers) as import('@/types').ColumnTriggers }),
+                  ...(updates.triggers !== undefined && {
+                    triggers: JSON.parse(updates.triggers) as import('@/types').ColumnTriggers,
+                  }),
                 }
-              : c
+              : c,
           ),
         }))
         try {

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useTaskStore } from './task-store'
 import type { Task } from '@/types'
 
+const refreshWorkspace = vi.fn()
+
+vi.mock('./workspace-store', () => ({
+  useWorkspaceStore: {
+    getState: () => ({
+      refreshWorkspace,
+    }),
+  },
+}))
+
 // Mock IPC module
 vi.mock('@/lib/ipc', () => ({
   getTasks: vi.fn(),
@@ -65,6 +75,7 @@ const createMockTask = (overrides: Partial<Task> = {}): Task => ({
 describe('task-store', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    refreshWorkspace.mockReset()
     useTaskStore.setState({
       tasks: [],
       loaded: false,
@@ -92,27 +103,27 @@ describe('task-store', () => {
     it('should create task via IPC and add to store', async () => {
       const newTask = createMockTask({ id: 'task-new', title: 'New Task' })
       mockIpc.createTask.mockResolvedValueOnce(newTask)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useTaskStore.getState().add('ws-1', 'col-1', 'New Task', 'Description')
 
       const state = useTaskStore.getState()
       expect(state.tasks).toContainEqual(newTask)
       expect(mockIpc.createTask).toHaveBeenCalledWith('ws-1', 'col-1', 'New Task', 'Description')
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
   })
 
   describe('remove', () => {
     beforeEach(() => {
       useTaskStore.setState({
-        tasks: [
-          createMockTask({ id: 'task-1' }),
-          createMockTask({ id: 'task-2', position: 1 }),
-        ],
+        tasks: [createMockTask({ id: 'task-1' }), createMockTask({ id: 'task-2', position: 1 })],
       })
     })
 
     it('should optimistically remove task', async () => {
       mockIpc.deleteTask.mockResolvedValueOnce(undefined)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useTaskStore.getState().remove('task-1')
 
@@ -123,10 +134,12 @@ describe('task-store', () => {
 
     it('should call IPC to delete task', async () => {
       mockIpc.deleteTask.mockResolvedValueOnce(undefined)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useTaskStore.getState().remove('task-1')
 
       expect(mockIpc.deleteTask).toHaveBeenCalledWith('task-1')
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
     it('should revert on IPC error', async () => {
@@ -142,14 +155,15 @@ describe('task-store', () => {
   describe('move', () => {
     beforeEach(() => {
       useTaskStore.setState({
-        tasks: [
-          createMockTask({ id: 'task-1', columnId: 'col-1', position: 0 }),
-        ],
+        tasks: [createMockTask({ id: 'task-1', columnId: 'col-1', position: 0 })],
       })
     })
 
     it('should optimistically update task column and position', async () => {
-      mockIpc.moveTask.mockResolvedValueOnce(createMockTask({ id: 'task-1', columnId: 'col-2', position: 0 }))
+      mockIpc.moveTask.mockResolvedValueOnce(
+        createMockTask({ id: 'task-1', columnId: 'col-2', position: 0 }),
+      )
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useTaskStore.getState().move('task-1', 'col-2', 0)
 
@@ -159,10 +173,12 @@ describe('task-store', () => {
 
     it('should call IPC to persist move', async () => {
       mockIpc.moveTask.mockResolvedValueOnce(createMockTask())
+      refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useTaskStore.getState().move('task-1', 'col-2', 0)
 
       expect(mockIpc.moveTask).toHaveBeenCalledWith('task-1', 'col-2', 0)
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
     it('should revert on IPC error', async () => {
@@ -265,18 +281,29 @@ describe('task-store', () => {
   describe('duplicate', () => {
     beforeEach(() => {
       useTaskStore.setState({
-        tasks: [createMockTask({ id: 'task-1', title: 'Original Task', description: 'Some description' })],
+        tasks: [
+          createMockTask({ id: 'task-1', title: 'Original Task', description: 'Some description' }),
+        ],
       })
     })
 
     it('should create a copy of the task with "(Copy)" suffix', async () => {
-      const duplicatedTask = createMockTask({ id: 'task-dup', title: 'Original Task (Copy)', description: 'Some description' })
+      const duplicatedTask = createMockTask({
+        id: 'task-dup',
+        title: 'Original Task (Copy)',
+        description: 'Some description',
+      })
       mockIpc.createTask.mockResolvedValueOnce(duplicatedTask)
 
       const result = await useTaskStore.getState().duplicate('task-1')
 
       expect(result).toEqual(duplicatedTask)
-      expect(mockIpc.createTask).toHaveBeenCalledWith('ws-1', 'col-1', 'Original Task (Copy)', 'Some description')
+      expect(mockIpc.createTask).toHaveBeenCalledWith(
+        'ws-1',
+        'col-1',
+        'Original Task (Copy)',
+        'Some description',
+      )
     })
 
     it('should add duplicated task to store', async () => {

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import type { Task } from '@/types'
 import * as ipc from '@/lib/ipc'
+import { useWorkspaceStore } from './workspace-store'
 
 type TaskState = {
   tasks: Task[]
@@ -31,13 +32,18 @@ export const useTaskStore = create<TaskState>()(
       add: async (workspaceId, columnId, title, description) => {
         const task = await ipc.createTask(workspaceId, columnId, title, description)
         set((s) => ({ tasks: [...s.tasks, task] }))
+        await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
       },
 
       remove: async (id) => {
         const prev = get().tasks
+        const task = prev.find((t) => t.id === id)
         set((s) => ({ tasks: s.tasks.filter((t) => t.id !== id) }))
         try {
           await ipc.deleteTask(id)
+          if (task) {
+            await useWorkspaceStore.getState().refreshWorkspace(task.workspaceId)
+          }
         } catch {
           set({ tasks: prev })
         }
@@ -45,6 +51,7 @@ export const useTaskStore = create<TaskState>()(
 
       move: async (id, targetColumnId, position) => {
         const prev = get().tasks
+        const task = prev.find((t) => t.id === id)
         set((s) => ({
           tasks: s.tasks.map((t) =>
             t.id === id ? { ...t, columnId: targetColumnId, position } : t,
@@ -52,6 +59,9 @@ export const useTaskStore = create<TaskState>()(
         }))
         try {
           await ipc.moveTask(id, targetColumnId, position)
+          if (task) {
+            await useWorkspaceStore.getState().refreshWorkspace(task.workspaceId)
+          }
         } catch {
           set({ tasks: prev })
         }
@@ -98,6 +108,7 @@ export const useTaskStore = create<TaskState>()(
           original.description,
         )
         set((s) => ({ tasks: [...s.tasks, task] }))
+        await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
         return task
       },
     }),

--- a/src/stores/workspace-store.test.ts
+++ b/src/stores/workspace-store.test.ts
@@ -84,6 +84,28 @@ describe('workspace-store', () => {
     })
   })
 
+  describe('refreshWorkspace', () => {
+    it('should replace the matching workspace with backend data', async () => {
+      useWorkspaceStore.setState({
+        workspaces: [
+          mockWorkspace,
+          { ...mockWorkspace, id: 'ws-2', name: 'Other Workspace', activeTaskCount: 1 },
+        ],
+        activeWorkspaceId: 'ws-1',
+      })
+      const refreshed = { ...mockWorkspace, name: 'Updated Workspace', activeTaskCount: 3 }
+      vi.mocked(invoke).mockResolvedValueOnce(refreshed)
+
+      await useWorkspaceStore.getState().refreshWorkspace('ws-1')
+
+      expect(vi.mocked(invoke)).toHaveBeenCalledWith('get_workspace', { id: 'ws-1' })
+      expect(useWorkspaceStore.getState().workspaces).toEqual([
+        refreshed,
+        { ...mockWorkspace, id: 'ws-2', name: 'Other Workspace', activeTaskCount: 1 },
+      ])
+    })
+  })
+
   describe('remove', () => {
     it('should delete workspace and remove from store', async () => {
       useWorkspaceStore.setState({

--- a/src/stores/workspace-store.test.ts
+++ b/src/stores/workspace-store.test.ts
@@ -11,6 +11,7 @@ const mockWorkspace: Workspace = {
   repoPath: '/path/to/repo',
   tabOrder: 0,
   isActive: true,
+  activeTaskCount: 0,
   config: '{}',
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -9,6 +9,7 @@ type WorkspaceState = {
   loaded: boolean
 
   load: () => Promise<void>
+  refreshWorkspace: (id: string) => Promise<void>
   setActive: (id: string) => void
   add: (name: string, repoPath: string) => Promise<void>
   clone: (sourceId: string, newName: string) => Promise<void>
@@ -28,6 +29,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         const workspaces = await ipc.getWorkspaces()
         const active = workspaces.find((w) => w.isActive) ?? workspaces[0]
         set({ workspaces, activeWorkspaceId: active?.id ?? null, loaded: true })
+      },
+
+      refreshWorkspace: async (id) => {
+        const workspace = await ipc.getWorkspace(id)
+        set((s) => ({
+          workspaces: s.workspaces.map((w) => (w.id === id ? workspace : w)),
+        }))
       },
 
       setActive: (id) => {

--- a/src/test/mocks/tauri.ts
+++ b/src/test/mocks/tauri.ts
@@ -9,6 +9,7 @@ export const mockWorkspace = (overrides: Partial<Workspace> = {}): Workspace => 
   repoPath: '/path/to/repo',
   tabOrder: 0,
   isActive: true,
+  activeTaskCount: 0,
   config: '{}',
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -4,6 +4,7 @@ export type Workspace = {
   repoPath: string
   tabOrder: number
   isActive: boolean
+  activeTaskCount: number
   config: string
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
Show a small count badge on the workspace tab showing total number of active tasks (not in Done). This helps users see at a glance how much work is in progress.

1. In src/components/workspace-tabs.tsx (or wherever the tab component is), add a badge element next to the workspace name
2. Badge shows count of tasks where column is NOT the last column (Done)
3. Style: text-xs, bg-primary/20, text-primary, rounded-full, px-1.5, ml-1
4. Hide badge if count is 0