### PR TITLE
Add auto-batch queue for sequential task processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "ureq",
  "uuid",
 ]
 
@@ -276,8 +277,10 @@ name = "bento-ya"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "axum",
  "chrono",
  "cpal",
+ "dirs 5.0.1",
  "futures",
  "git2",
  "glob",
@@ -659,8 +662,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.13.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1029,6 +1051,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2438,6 +2469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3735,7 +3772,9 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5441,6 +5480,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5470,6 +5541,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5761,6 +5838,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -678,35 +678,20 @@ pub async fn queue_backlog(
     }
 
     // Move the first task to Plan and fire trigger
-    let first_task = &queued_tasks[0];
     let plan_column = columns.iter().find(|c| c.name == "Plan")
         .ok_or_else(|| AppError::InvalidInput("No 'Plan' column found".to_string()))?;
 
-    let max_pos: i64 = conn
-        .query_row(
-            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
-            rusqlite::params![plan_column.id],
-            |row| row.get(0),
-        )
-        .unwrap_or(-1);
-
-    conn.execute(
-        "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
-        rusqlite::params![plan_column.id, max_pos + 1, ts, first_task.id],
-    ).map_err(AppError::from)?;
-
-    let moved_task = db::get_task(&conn, &first_task.id)?;
+    let moved_task = db::append_task_to_column(&conn, &queued_tasks[0].id, &plan_column.id)
+        .map_err(AppError::from)?;
 
     pipeline::emit_tasks_changed(&app, &workspace_id, "batch_queue_started");
 
     // Fire the Plan trigger on the first task
-    let _ = pipeline::fire_trigger(&conn, &app, &moved_task, plan_column)?;
+    pipeline::fire_trigger(&conn, &app, &moved_task, plan_column)?;
 
-    // Return all queued tasks (refreshed)
-    let result: Vec<Task> = queued_tasks.iter()
-        .map(|t| db::get_task(&conn, &t.id))
-        .collect::<Result<Vec<_>, _>>()?;
-
+    // Return all queued tasks: first task with its new column, rest unchanged
+    let mut result = queued_tasks;
+    result[0] = moved_task;
     Ok(result)
 }
 

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -638,6 +638,78 @@ Return ONLY the JSON array, no other text."#,
     })
 }
 
+/// Queue N tasks from Backlog for sequential batch processing.
+/// Sets queued_at on the first N tasks, then moves the first one to Plan.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn queue_backlog(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    workspace_id: String,
+    count: i64,
+) -> Result<Vec<Task>, AppError> {
+    if count <= 0 {
+        return Err(AppError::InvalidInput("Count must be positive".to_string()));
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    // Find the Backlog column
+    let columns = db::list_columns(&conn, &workspace_id)?;
+    let backlog_column = columns.iter().find(|c| c.name == "Backlog")
+        .ok_or_else(|| AppError::InvalidInput("No 'Backlog' column found".to_string()))?;
+
+    // Get first N tasks from Backlog ordered by position
+    let backlog_tasks = db::list_tasks_by_column(&conn, &backlog_column.id)?;
+    let to_queue: Vec<&Task> = backlog_tasks.iter().take(count as usize).collect();
+
+    if to_queue.is_empty() {
+        return Err(AppError::InvalidInput("No tasks in Backlog to queue".to_string()));
+    }
+
+    // Set queued_at on each task
+    let ts = db::now();
+    let mut queued_tasks = Vec::new();
+    for task in &to_queue {
+        conn.execute(
+            "UPDATE tasks SET queued_at = ?1, updated_at = ?2 WHERE id = ?3",
+            rusqlite::params![ts, ts, task.id],
+        ).map_err(AppError::from)?;
+        queued_tasks.push(db::get_task(&conn, &task.id)?);
+    }
+
+    // Move the first task to Plan and fire trigger
+    let first_task = &queued_tasks[0];
+    let plan_column = columns.iter().find(|c| c.name == "Plan")
+        .ok_or_else(|| AppError::InvalidInput("No 'Plan' column found".to_string()))?;
+
+    let max_pos: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
+            rusqlite::params![plan_column.id],
+            |row| row.get(0),
+        )
+        .unwrap_or(-1);
+
+    conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![plan_column.id, max_pos + 1, ts, first_task.id],
+    ).map_err(AppError::from)?;
+
+    let moved_task = db::get_task(&conn, &first_task.id)?;
+
+    pipeline::emit_tasks_changed(&app, &workspace_id, "batch_queue_started");
+
+    // Fire the Plan trigger on the first task
+    let _ = pipeline::fire_trigger(&conn, &app, &moved_task, plan_column)?;
+
+    // Return all queued tasks (refreshed)
+    let result: Vec<Task> = queued_tasks.iter()
+        .map(|t| db::get_task(&conn, &t.id))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(result)
+}
+
 /// Validate that task dependencies won't create a cycle
 #[tauri::command]
 pub fn validate_task_dependencies(

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -381,6 +381,23 @@ pub fn mark_task_notification_sent(conn: &Connection, id: &str) -> SqlResult<Tas
     get_task(conn, id)
 }
 
+/// Get the next queued task in a workspace (oldest queued_at, idle, in Backlog column)
+pub fn get_next_queued_task(conn: &Connection, workspace_id: &str) -> SqlResult<Option<Task>> {
+    let result = conn.query_row(
+        &format!(
+            "SELECT {} FROM tasks WHERE workspace_id = ?1 AND queued_at IS NOT NULL AND pipeline_state = 'idle' AND column_id IN (SELECT id FROM columns WHERE name = 'Backlog' AND workspace_id = ?1) ORDER BY position LIMIT 1",
+            TASK_COLUMNS
+        ),
+        params![workspace_id],
+        map_task_row,
+    );
+    match result {
+        Ok(task) => Ok(Some(task)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 /// Clear the notification sent timestamp
 pub fn clear_task_notification_sent(conn: &Connection, id: &str) -> SqlResult<Task> {
     let ts = now();

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -81,6 +81,23 @@ pub fn insert_task(
     get_task(conn, &id)
 }
 
+/// Move a task to the end of a column, resetting its pipeline state to idle.
+pub fn append_task_to_column(conn: &Connection, task_id: &str, column_id: &str) -> SqlResult<Task> {
+    let max_pos: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
+            params![column_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(-1);
+    let ts = now();
+    conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
+        params![column_id, max_pos + 1, ts, task_id],
+    )?;
+    get_task(conn, task_id)
+}
+
 pub fn get_task(conn: &Connection, id: &str) -> SqlResult<Task> {
     conn.query_row(
         &format!("SELECT {} FROM tasks WHERE id = ?1", TASK_COLUMNS),
@@ -381,7 +398,7 @@ pub fn mark_task_notification_sent(conn: &Connection, id: &str) -> SqlResult<Tas
     get_task(conn, id)
 }
 
-/// Get the next queued task in a workspace (oldest queued_at, idle, in Backlog column)
+/// Get the next queued task in a workspace (lowest position, idle, in Backlog column)
 pub fn get_next_queued_task(conn: &Connection, workspace_id: &str) -> SqlResult<Option<Task>> {
     let result = conn.query_row(
         &format!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,6 +143,7 @@ pub fn run() {
             commands::task::generate_test_checklist,
             commands::task::retry_pipeline,
             commands::task::validate_task_dependencies,
+            commands::task::queue_backlog,
             commands::task::create_task_worktree,
             commands::task::remove_task_worktree,
             // Git commands

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -495,6 +495,10 @@ pub fn mark_complete(
 
             // Try to auto-advance
             if let Some(advanced_task) = try_auto_advance(conn, app, &task, &column)? {
+                // Task advanced — check if we should start next queued task
+                if advanced_task.queued_at.is_some() {
+                    let _ = start_next_queued_task(conn, app, &task.workspace_id);
+                }
                 return Ok(advanced_task);
             }
 
@@ -503,6 +507,10 @@ pub fn mark_complete(
                 conn, task_id, PipelineState::Idle.as_str(), None, None,
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, true);
+            // Task completed pipeline — start next queued if this was a batch task
+            if task.queued_at.is_some() {
+                let _ = start_next_queued_task(conn, app, &task.workspace_id);
+            }
             Ok(updated_task)
         }
         CompletionAction::Complete => {
@@ -535,9 +543,69 @@ pub fn mark_complete(
                 conn, task_id, PipelineState::Idle.as_str(), None, Some("Execution failed"),
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, false);
+            // Task permanently failed — start next queued if this was a batch task
+            if task.queued_at.is_some() {
+                let _ = start_next_queued_task(conn, app, &task.workspace_id);
+            }
             Ok(updated_task)
         }
     }
+}
+
+/// Start the next queued task from the batch queue.
+/// Finds the next task with queued_at set in the Backlog column,
+/// moves it to the Plan column, and fires the Plan trigger.
+pub fn start_next_queued_task(
+    conn: &Connection,
+    app: &AppHandle,
+    workspace_id: &str,
+) -> Result<Option<Task>, AppError> {
+    let next_task = db::get_next_queued_task(conn, workspace_id)?;
+    let next_task = match next_task {
+        Some(t) => t,
+        None => {
+            log::info!("[pipeline] Batch queue complete — no more queued tasks in workspace {}", workspace_id);
+            return Ok(None);
+        }
+    };
+
+    // Find the Plan column
+    let columns = db::list_columns(conn, workspace_id)?;
+    let plan_column = columns.iter().find(|c| c.name == "Plan");
+    let plan_column = match plan_column {
+        Some(c) => c.clone(),
+        None => {
+            log::warn!("[pipeline] No 'Plan' column found in workspace {} — cannot auto-start next queued task", workspace_id);
+            return Ok(None);
+        }
+    };
+
+    // Get next position in the Plan column
+    let max_pos: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
+            rusqlite::params![plan_column.id],
+            |row| row.get(0),
+        )
+        .unwrap_or(-1);
+
+    // Move task to Plan column
+    let ts = db::now();
+    conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![plan_column.id, max_pos + 1, ts, next_task.id],
+    ).map_err(AppError::from)?;
+
+    let moved_task = db::get_task(conn, &next_task.id)?;
+
+    log::info!("[pipeline] Auto-starting queued task '{}' ({})", moved_task.title, moved_task.id);
+
+    emit_tasks_changed(app, workspace_id, "batch_queue_advance");
+
+    // Fire the Plan column trigger
+    let task = fire_trigger(conn, app, &moved_task, &plan_column)?;
+
+    Ok(Some(task))
 }
 
 fn emit_completion_event(app: &AppHandle, task_id: &str, column_id: &str, workspace_id: &str, success: bool) {

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -590,23 +590,8 @@ pub fn start_next_queued_task(
         }
     };
 
-    // Get next position in the Plan column
-    let max_pos: i64 = conn
-        .query_row(
-            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
-            rusqlite::params![plan_column.id],
-            |row| row.get(0),
-        )
-        .unwrap_or(-1);
-
-    // Move task to Plan column
-    let ts = db::now();
-    conn.execute(
-        "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
-        rusqlite::params![plan_column.id, max_pos + 1, ts, next_task.id],
-    ).map_err(AppError::from)?;
-
-    let moved_task = db::get_task(conn, &next_task.id)?;
+    // Move task to end of Plan column
+    let moved_task = db::append_task_to_column(conn, &next_task.id, &plan_column.id)?;
 
     log::info!("[pipeline] Auto-starting queued task '{}' ({})", moved_task.title, moved_task.id);
 

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -495,9 +495,16 @@ pub fn mark_complete(
 
             // Try to auto-advance
             if let Some(advanced_task) = try_auto_advance(conn, app, &task, &column)? {
-                // Task advanced — check if we should start next queued task
-                if advanced_task.queued_at.is_some() {
-                    let _ = start_next_queued_task(conn, app, &task.workspace_id);
+                // Task advanced — start next queued task only when task reaches the PR
+                // column (or the final non-advancing column), not on every intermediate hop.
+                if task.queued_at.is_some() {
+                    if let Ok(new_col) = db::get_column(conn, &advanced_task.column_id) {
+                        let new_col_auto_advance = parse_trigger_field_bool(new_col.triggers.as_deref(), "auto_advance");
+                        if !new_col_auto_advance {
+                            // Task has reached a resting column (e.g. PR waiting for review)
+                            let _ = start_next_queued_task(conn, app, &task.workspace_id);
+                        }
+                    }
                 }
                 return Ok(advanced_task);
             }
@@ -527,6 +534,9 @@ pub fn mark_complete(
                 conn, task_id, PipelineState::Idle.as_str(), None, None,
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, true);
+            if task.queued_at.is_some() {
+                let _ = start_next_queued_task(conn, app, &task.workspace_id);
+            }
             Ok(updated_task)
         }
         CompletionAction::Retry { attempt, max } => {


### PR DESCRIPTION
Add a queue system that automatically moves the next Backlog task to Plan when the current task reaches PR or fails permanently.

## Scope
- `src-tauri/src/pipeline/mod.rs` — add auto-queue check after mark_complete_with_error
- `src-tauri/src/commands/task.rs` — new `queue_backlog` command to start the batch
- `src-tauri/src/db/task.rs` — helper to get next queued task
- `src-tauri/src/api.rs` — new `/api/queue_backlog` endpoint

## What exists
- `mark_complete_with_error` in pipeline/mod.rs — called when pipeline finishes (success or failure)
- `CompletionAction::Advance` moves to next column, `CompletionAction::Failed` stops pipeline
- Tasks have `position` field for ordering and `queued_at` field (currently unused)
- `try_auto_advance` function shows how to move tasks between columns and fire triggers

## Implementation
1. Add `get_next_queued_task(conn, workspace_id)` to db/task.rs:
   - Query: SELECT from tasks WHERE workspace_id=? AND queued_at IS NOT NULL AND pipeline_state='idle' AND column_id IN (SELECT id FROM columns WHERE name='Backlog' AND workspace_id=?) ORDER BY position LIMIT 1
   - Return Option<Task>

2. Add `queue_backlog(workspace_id, count)` Tauri command:
   - Get first N tasks from Backlog ordered by position
   - Set queued_at = datetime('now') on each
   - Move the first task to Plan column via existing move logic
   - Fire the Plan trigger on first task

3. Add `start_next_queued_task(conn, app, workspace_id)` helper in pipeline/mod.rs:
   - Call get_next_queued_task
   - If found: get Plan column, move task there, fire_trigger
   - If none: log "batch complete"

4. In `mark_complete_with_error`, after CompletionAction::Advance succeeds and task reaches PR column (check column name or position), call start_next_queued_task
5. In CompletionAction::Failed, also call start_next_queued_task (skip failed, continue batch)

## Acceptance criteria
- [ ] queue_backlog(ws, 5) marks 5 tasks as queued and moves first to Plan
- [ ] When task reaches PR, next queued task auto-starts in Plan
- [ ] When task permanently fails, next queued task still starts
- [ ] Batch stops when no queued tasks remain
- [ ] queued_at timestamp tracks when each task was queued
- [ ] cargo check passes
- [ ] cargo test passes

## Patterns to follow
- Look at try_auto_advance() in mod.rs for column advancement pattern
- Look at fire_trigger() call pattern
- Use the same db:: functions for task queries
- The queue check should happen AFTER the current task's completion is fully processed