### PR TITLE
Add siege loop to Verify column — unbounded retry with time cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "ureq",
  "uuid",
 ]
 
@@ -276,8 +277,10 @@ name = "bento-ya"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "axum",
  "chrono",
  "cpal",
+ "dirs 5.0.1",
  "futures",
  "git2",
  "glob",
@@ -659,8 +662,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.13.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1029,6 +1051,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2438,6 +2469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3735,7 +3772,9 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5441,6 +5480,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5470,6 +5541,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5761,6 +5838,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -220,35 +220,38 @@ pub fn check_exit_met(task: &Task, exit_type: &str) -> Option<bool> {
     }
 }
 
-/// Parse the exit_criteria type from a column's triggers JSON.
-pub fn parse_exit_type(triggers_json: Option<&str>) -> String {
+/// Extract a single field from the `exit_criteria` object in a triggers JSON blob.
+fn get_exit_criteria_field(triggers_json: Option<&str>, field: &str) -> Option<serde_json::Value> {
     triggers_json
         .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
-        .and_then(|v| v.get("exit_criteria")?.get("type")?.as_str().map(|s| s.to_string()))
+        .and_then(|v| v.get("exit_criteria")?.get(field).cloned())
+}
+
+/// Parse the exit_criteria type from a column's triggers JSON.
+pub fn parse_exit_type(triggers_json: Option<&str>) -> String {
+    get_exit_criteria_field(triggers_json, "type")
+        .and_then(|v| v.as_str().map(str::to_string))
         .unwrap_or_else(|| "manual".to_string())
 }
 
 /// Parse a boolean field from exit_criteria in triggers JSON.
 fn parse_trigger_field_bool(triggers_json: Option<&str>, field: &str) -> bool {
-    triggers_json
-        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
-        .and_then(|v| v.get("exit_criteria")?.get(field)?.as_bool())
+    get_exit_criteria_field(triggers_json, field)
+        .and_then(|v| v.as_bool())
         .unwrap_or(false)
 }
 
 /// Parse a u64 field from exit_criteria in triggers JSON.
 fn parse_trigger_field_u64(triggers_json: Option<&str>, field: &str) -> u64 {
-    triggers_json
-        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
-        .and_then(|v| v.get("exit_criteria")?.get(field)?.as_u64())
+    get_exit_criteria_field(triggers_json, field)
+        .and_then(|v| v.as_u64())
         .unwrap_or(0)
 }
 
 /// Parse an i64 field from exit_criteria in triggers JSON.
 fn parse_trigger_field_i64(triggers_json: Option<&str>, field: &str) -> Option<i64> {
-    triggers_json
-        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
-        .and_then(|v| v.get("exit_criteria")?.get(field)?.as_i64())
+    get_exit_criteria_field(triggers_json, field)
+        .and_then(|v| v.as_i64())
 }
 
 /// Check if a siege retry has exceeded the time cap.
@@ -261,8 +264,7 @@ fn is_siege_timed_out(triggered_at: Option<&str>) -> bool {
     let Ok(started) = chrono::DateTime::parse_from_rfc3339(ts) else {
         return false;
     };
-    let elapsed = chrono::Utc::now().signed_duration_since(started);
-    elapsed.num_seconds() >= SIEGE_TIMEOUT_SECS
+    chrono::Utc::now().signed_duration_since(started) >= chrono::Duration::seconds(SIEGE_TIMEOUT_SECS)
 }
 
 // ─── Pipeline Engine ────────────────────────────────────────────────────────

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -14,6 +14,9 @@ use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 
+/// Maximum duration (in seconds) for unbounded siege retry (max_retries = -1).
+const SIEGE_TIMEOUT_SECS: i64 = 1800; // 30 minutes
+
 // ─── Pipeline State ─────────────────────────────────────────────────────────
 
 /// Pipeline execution states for a task
@@ -155,7 +158,19 @@ pub fn decide_completion(
     }
 
     // Failure path
-    let max_retries = parse_trigger_field_u64(triggers_json, "max_retries") as i64;
+    let max_retries = parse_trigger_field_i64(triggers_json, "max_retries").unwrap_or(0);
+
+    if max_retries == -1 {
+        // Unbounded siege mode: retry until time cap reached
+        if is_siege_timed_out(task.pipeline_triggered_at.as_deref()) {
+            return CompletionAction::Failed;
+        }
+        return CompletionAction::Retry {
+            attempt: task.retry_count + 1,
+            max: -1,
+        };
+    }
+
     if max_retries > 0 && task.retry_count < max_retries {
         CompletionAction::Retry {
             attempt: task.retry_count + 1,
@@ -227,6 +242,27 @@ fn parse_trigger_field_u64(triggers_json: Option<&str>, field: &str) -> u64 {
         .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
         .and_then(|v| v.get("exit_criteria")?.get(field)?.as_u64())
         .unwrap_or(0)
+}
+
+/// Parse an i64 field from exit_criteria in triggers JSON.
+fn parse_trigger_field_i64(triggers_json: Option<&str>, field: &str) -> Option<i64> {
+    triggers_json
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
+        .and_then(|v| v.get("exit_criteria")?.get(field)?.as_i64())
+}
+
+/// Check if a siege retry has exceeded the time cap.
+/// Returns true if `pipeline_triggered_at` is older than `SIEGE_TIMEOUT_SECS`.
+fn is_siege_timed_out(triggered_at: Option<&str>) -> bool {
+    let Some(ts) = triggered_at else {
+        // No timestamp means we can't measure — allow retry
+        return false;
+    };
+    let Ok(started) = chrono::DateTime::parse_from_rfc3339(ts) else {
+        return false;
+    };
+    let elapsed = chrono::Utc::now().signed_duration_since(started);
+    elapsed.num_seconds() >= SIEGE_TIMEOUT_SECS
 }
 
 // ─── Pipeline Engine ────────────────────────────────────────────────────────
@@ -523,9 +559,14 @@ pub fn mark_complete(
         }
         CompletionAction::Retry { attempt, max } => {
             increment_retry_count(conn, task_id)?;
-            log::info!("[pipeline] Auto-retrying task {} (attempt {}/{})", task_id, attempt, max);
+            let msg = if max == -1 {
+                format!("Siege retry #{}", attempt)
+            } else {
+                format!("Retrying ({}/{})", attempt, max)
+            };
+            log::info!("[pipeline] {} task {}", msg, task_id);
 
-            emit_pipeline(app, "pipeline:error", task_id, &column.id, PipelineState::Idle, Some(format!("Retrying ({}/{})", attempt, max)));
+            emit_pipeline(app, "pipeline:error", task_id, &column.id, PipelineState::Idle, Some(msg));
 
             let updated_task = db::get_task(conn, task_id)?;
             fire_trigger(conn, app, &updated_task, &column)
@@ -676,6 +717,85 @@ mod tests {
         let task = make_task(0, "running");
         let action = decide_completion(&task, Some("{}"), false);
         assert_eq!(action, CompletionAction::Failed);
+    }
+
+    // ─── siege (unbounded retry) tests ───────────────────────────────
+
+    fn siege_triggers_json(auto_advance: bool) -> String {
+        serde_json::json!({
+            "exit_criteria": {
+                "type": "agent_complete",
+                "auto_advance": auto_advance,
+                "max_retries": -1
+            }
+        }).to_string()
+    }
+
+    #[test]
+    fn test_decide_siege_retries_when_recent() {
+        let mut task = make_task(3, "running");
+        // Started 5 minutes ago — well within 30-min cap
+        task.pipeline_triggered_at = Some(
+            (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339()
+        );
+        let triggers = siege_triggers_json(true);
+        let action = decide_completion(&task, Some(&triggers), false);
+        assert_eq!(action, CompletionAction::Retry { attempt: 4, max: -1 });
+    }
+
+    #[test]
+    fn test_decide_siege_fails_when_timed_out() {
+        let mut task = make_task(50, "running");
+        // Started 31 minutes ago — past the 30-min cap
+        task.pipeline_triggered_at = Some(
+            (chrono::Utc::now() - chrono::Duration::minutes(31)).to_rfc3339()
+        );
+        let triggers = siege_triggers_json(true);
+        let action = decide_completion(&task, Some(&triggers), false);
+        assert_eq!(action, CompletionAction::Failed);
+    }
+
+    #[test]
+    fn test_decide_siege_retries_without_timestamp() {
+        let mut task = make_task(5, "running");
+        task.pipeline_triggered_at = None; // No timestamp — allow retry
+        let triggers = siege_triggers_json(false);
+        let action = decide_completion(&task, Some(&triggers), false);
+        assert_eq!(action, CompletionAction::Retry { attempt: 6, max: -1 });
+    }
+
+    #[test]
+    fn test_decide_siege_success_still_advances() {
+        let mut task = make_task(3, "running");
+        task.pipeline_triggered_at = Some(chrono::Utc::now().to_rfc3339());
+        let triggers = siege_triggers_json(true);
+        // Success should advance regardless of siege mode
+        let action = decide_completion(&task, Some(&triggers), true);
+        assert_eq!(action, CompletionAction::Advance);
+    }
+
+    // ─── is_siege_timed_out tests ────────────────────────────────────
+
+    #[test]
+    fn test_siege_timeout_none_timestamp() {
+        assert!(!is_siege_timed_out(None));
+    }
+
+    #[test]
+    fn test_siege_timeout_recent() {
+        let ts = (chrono::Utc::now() - chrono::Duration::minutes(10)).to_rfc3339();
+        assert!(!is_siege_timed_out(Some(&ts)));
+    }
+
+    #[test]
+    fn test_siege_timeout_expired() {
+        let ts = (chrono::Utc::now() - chrono::Duration::minutes(31)).to_rfc3339();
+        assert!(is_siege_timed_out(Some(&ts)));
+    }
+
+    #[test]
+    fn test_siege_timeout_invalid_timestamp() {
+        assert!(!is_siege_timed_out(Some("not-a-date")));
     }
 
     // ─── check_exit_met tests ─────────────────────────────────────────


### PR DESCRIPTION
Change the Verify column's retry behavior from fixed count to unbounded with a 30-minute time cap.

## Scope
- `src-tauri/src/pipeline/mod.rs` — modify retry logic in `decide_completion` and `mark_complete_with_error`

## What exists
- `decide_completion()` checks `max_retries` and returns `CompletionAction::Retry` or `CompletionAction::Failed`
- `CompletionAction::Retry { attempt, max }` tracks current attempt vs max
- `pipeline_triggered_at` timestamp exists on tasks

## Implementation
1. Add a new exit criteria option: `"type": "agent_complete_siege"` or use `max_retries: -1` to mean unbounded
2. In `decide_completion()`, when max_retries is -1 (or a very high number like 99):
   - Check `pipeline_triggered_at` timestamp
   - If elapsed time < 30 minutes (1800 seconds): return Retry
   - If elapsed time >= 30 minutes: return Failed with "Siege timeout after 30 minutes"
3. Alternative simpler approach: just set `max_retries: 10` on Verify column. 10 retries × ~30 sec each = ~5 min max. Good enough for most cases.

## Acceptance criteria
- [ ] Verify column retries until checks pass (not just 2 attempts)
- [ ] Has a time or count cap to prevent infinite loops
- [ ] Timeout error message is clear
- [ ] cargo check passes
- [ ] cargo test passes

## Recommendation
The simplest approach: just bump `max_retries` to 10 on Verify. If the agent can't fix it in 10 tries, it's not going to fix it. This avoids any Rust code changes — just a DB trigger config update. But if we want proper time-based siege, modify `decide_completion`.