### PR TITLE
Create Discord webhook notification scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "ureq",
  "uuid",
 ]
 
@@ -276,8 +277,10 @@ name = "bento-ya"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "axum",
  "chrono",
  "cpal",
+ "dirs 5.0.1",
  "futures",
  "git2",
  "glob",
@@ -659,8 +662,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.13.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1029,6 +1051,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2438,6 +2469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3735,7 +3772,9 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5441,6 +5480,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5470,6 +5541,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5761,6 +5838,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -407,13 +407,13 @@ mod tests {
         // Seed
         seed_built_in_scripts(&conn).unwrap();
         let scripts = list_scripts(&conn).unwrap();
-        assert_eq!(scripts.len(), 5);
+        assert_eq!(scripts.len(), 7);
         assert!(scripts.iter().all(|s| s.is_built_in));
 
         // Idempotent — running again doesn't duplicate
         seed_built_in_scripts(&conn).unwrap();
         let scripts = list_scripts(&conn).unwrap();
-        assert_eq!(scripts.len(), 5);
+        assert_eq!(scripts.len(), 7);
     }
 
     #[test]
@@ -456,7 +456,7 @@ mod tests {
 
         let scripts = list_scripts(&conn).unwrap();
         // Built-in scripts come first (is_built_in DESC), then by name
-        assert_eq!(scripts.len(), 7);
+        assert_eq!(scripts.len(), 9);
         assert!(scripts[0].is_built_in, "Built-ins should come first");
         // Custom scripts should be last, sorted by name
         let custom: Vec<&str> = scripts.iter().filter(|s| !s.is_built_in).map(|s| s.name.as_str()).collect();

--- a/src-tauri/src/db/script.rs
+++ b/src-tauri/src/db/script.rs
@@ -126,19 +126,11 @@ pub fn seed_built_in_scripts(conn: &Connection) -> SqlResult<()> {
     ];
 
     for (id, name, description, steps) in built_ins {
-        // Only insert if not already present (idempotent)
-        let exists: bool = conn
-            .prepare("SELECT COUNT(*) FROM scripts WHERE id = ?1")?
-            .query_row(params![id], |row| row.get::<_, i64>(0))
-            .map(|count| count > 0)?;
-
-        if !exists {
-            let ts = now();
-            conn.execute(
-                "INSERT INTO scripts (id, name, description, steps, is_built_in, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, 1, ?5, ?6)",
-                params![id, name, description, steps, ts, ts],
-            )?;
-        }
+        let ts = now();
+        conn.execute(
+            "INSERT OR IGNORE INTO scripts (id, name, description, steps, is_built_in, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, 1, ?5, ?6)",
+            params![id, name, description, steps, ts, ts],
+        )?;
     }
 
     Ok(())

--- a/src-tauri/src/db/script.rs
+++ b/src-tauri/src/db/script.rs
@@ -111,6 +111,18 @@ pub fn seed_built_in_scripts(conn: &Connection) -> SqlResult<()> {
             "Type-check, test, lint, then create PR",
             r#"[{"type":"bash","name":"Type check","command":"npm run type-check"},{"type":"bash","name":"Tests","command":"npm test"},{"type":"check","name":"Lint clean","command":"npm run lint","failMessage":"Lint errors found"},{"type":"bash","name":"Create PR","command":"gh pr create --title '{task.title}' --fill"}]"#,
         ),
+        (
+            "discord-notify-success",
+            "Discord Notify (Success)",
+            "Send a success notification to Discord via webhook",
+            r#"[{"type":"bash","name":"Notify Discord","command":"if [ -n \"$BENTOYA_DISCORD_WEBHOOK\" ]; then curl -s -X POST \"$BENTOYA_DISCORD_WEBHOOK\" -H 'Content-Type: application/json' -d '{\"content\": \"✅ **{task.title}** completed in {column.name}\"}'; fi"}]"#,
+        ),
+        (
+            "discord-notify-failure",
+            "Discord Notify (Failure)",
+            "Send a failure notification to Discord via webhook",
+            r#"[{"type":"bash","name":"Notify Discord","command":"if [ -n \"$BENTOYA_DISCORD_WEBHOOK\" ]; then curl -s -X POST \"$BENTOYA_DISCORD_WEBHOOK\" -H 'Content-Type: application/json' -d '{\"content\": \"❌ **{task.title}** failed in {column.name}\"}'; fi"}]"#,
+        ),
     ];
 
     for (id, name, description, steps) in built_ins {


### PR DESCRIPTION
Create Script entities for Discord webhook notifications that can be referenced by column triggers.

## Scope
- `src-tauri/src/db/script.rs` — add new built-in scripts in `seed_built_in_scripts()`

## What exists
- `seed_built_in_scripts()` creates 5 built-in scripts (code-check, run-tests, create-pr, ai-code-review, full-pipeline)
- Scripts have: id, name, description, steps (JSON array), is_built_in
- Steps support: `{"type": "bash", "name": "...", "command": "..."}`
- Template variables available: `{task.title}`, `{task.id}`, `{column.name}`, `{workspace.path}`

## Implementation
1. Add two new built-in scripts in `seed_built_in_scripts()`:

   **Script: "discord-notify-success"**
   ```json
   [{"type": "bash", "name": "Notify Discord", "command": "if [ -n "$BENTOYA_DISCORD_WEBHOOK" ]; then curl -s -X POST "$BENTOYA_DISCORD_WEBHOOK" -H 'Content-Type: application/json' -d '{"content": "✅ **{task.title}** completed in {column.name}"}'; fi"}]
   ```

   **Script: "discord-notify-failure"**
   ```json
   [{"type": "bash", "name": "Notify Discord", "command": "if [ -n "$BENTOYA_DISCORD_WEBHOOK" ]; then curl -s -X POST "$BENTOYA_DISCORD_WEBHOOK" -H 'Content-Type: application/json' -d '{"content": "❌ **{task.title}** failed in {column.name}"}'; fi"}]
   ```

2. The webhook URL comes from env var `BENTOYA_DISCORD_WEBHOOK` — no hardcoded URLs
3. Scripts are no-ops if the env var isn't set (safe default)

## Acceptance criteria
- [ ] Two new scripts appear in script list
- [ ] Scripts use env var for webhook URL (not hardcoded)
- [ ] Template variables ({task.title}, {column.name}) are interpolated
- [ ] No-op when BENTOYA_DISCORD_WEBHOOK not set
- [ ] cargo check passes
- [ ] cargo test passes