### PR TITLE
Add pipeline timing stats per column

### DIFF
--- a/src-tauri/src/commands/pipeline.rs
+++ b/src-tauri/src/commands/pipeline.rs
@@ -1,6 +1,6 @@
 //! Pipeline commands for Tauri IPC
 
-use crate::db::{self, AppState, Task};
+use crate::db::{self, AppState, ColumnTimingAverage, PipelineTiming, Task};
 use crate::error::AppError;
 use crate::pipeline;
 use tauri::{AppHandle, State};
@@ -71,4 +71,24 @@ pub fn update_script_exit_code(
     // Mark pipeline as complete with success based on exit code
     let success = exit_code == 0;
     pipeline::mark_complete(&conn, &app, &task_id, success)
+}
+
+/// Get pipeline timing breakdown for a task
+#[tauri::command(rename_all = "camelCase")]
+pub fn get_pipeline_timing(
+    state: State<AppState>,
+    task_id: String,
+) -> Result<Vec<PipelineTiming>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    db::get_pipeline_timing(&conn, &task_id).map_err(|e| AppError::DatabaseError(e.to_string()))
+}
+
+/// Get average pipeline timing per column for a workspace
+#[tauri::command(rename_all = "camelCase")]
+pub fn get_average_pipeline_timing(
+    state: State<AppState>,
+    workspace_id: String,
+) -> Result<Vec<ColumnTimingAverage>, AppError> {
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    db::get_average_timing(&conn, &workspace_id).map_err(|e| AppError::DatabaseError(e.to_string()))
 }

--- a/src-tauri/src/commands/pipeline.rs
+++ b/src-tauri/src/commands/pipeline.rs
@@ -80,7 +80,7 @@ pub fn get_pipeline_timing(
     task_id: String,
 ) -> Result<Vec<PipelineTiming>, AppError> {
     let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    db::get_pipeline_timing(&conn, &task_id).map_err(|e| AppError::DatabaseError(e.to_string()))
+    Ok(db::get_pipeline_timing(&conn, &task_id)?)
 }
 
 /// Get average pipeline timing per column for a workspace
@@ -90,5 +90,5 @@ pub fn get_average_pipeline_timing(
     workspace_id: String,
 ) -> Result<Vec<ColumnTimingAverage>, AppError> {
     let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    db::get_average_timing(&conn, &workspace_id).map_err(|e| AppError::DatabaseError(e.to_string()))
+    Ok(db::get_average_pipeline_timing(&conn, &workspace_id)?)
 }

--- a/src-tauri/src/db/migrations/030_pipeline_timing.sql
+++ b/src-tauri/src/db/migrations/030_pipeline_timing.sql
@@ -1,0 +1,16 @@
+-- Track how long each task spends in each column for bottleneck analysis
+CREATE TABLE IF NOT EXISTS pipeline_timing (
+    id TEXT PRIMARY KEY NOT NULL,
+    task_id TEXT NOT NULL,
+    column_id TEXT NOT NULL,
+    column_name TEXT NOT NULL,
+    entered_at TEXT NOT NULL,
+    exited_at TEXT,
+    duration_seconds INTEGER,
+    success INTEGER,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_timing_task ON pipeline_timing(task_id);
+CREATE INDEX IF NOT EXISTS idx_pipeline_timing_column ON pipeline_timing(column_id);

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -16,6 +16,7 @@ pub mod checklist;
 pub mod column;
 pub mod history;
 pub mod orchestrator_session;
+pub mod pipeline_timing;
 pub mod script;
 pub mod task;
 pub mod usage;
@@ -33,6 +34,7 @@ pub use checklist::*;
 pub use column::*;
 pub use history::*;
 pub use orchestrator_session::*;
+pub use pipeline_timing::*;
 pub use script::*;
 pub use task::*;
 pub use usage::*;
@@ -134,6 +136,7 @@ fn run_migrations(conn: &Connection) -> SqlResult<()> {
         ("027_task_model", include_str!("migrations/027_task_model.sql")),
         ("028_scripts", include_str!("migrations/028_scripts.sql")),
         ("029_task_worktree", include_str!("migrations/029_task_worktree.sql")),
+        ("030_pipeline_timing", include_str!("migrations/030_pipeline_timing.sql")),
     ];
 
     for (name, sql) in migrations {
@@ -196,8 +199,8 @@ mod tests {
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
             .unwrap();
-        // We have 29 migrations: 001-029
-        assert_eq!(count, 29);
+        // We have 30 migrations: 001-030
+        assert_eq!(count, 30);
     }
 
     #[test]

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -242,6 +242,35 @@ pub struct Script {
     pub updated_at: String,
 }
 
+// ─── Pipeline Timing Entities ───────────────────────────────────────────────
+
+/// Tracks how long a task spends in each column for bottleneck analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineTiming {
+    pub id: String,
+    pub task_id: String,
+    pub column_id: String,
+    pub column_name: String,
+    pub entered_at: String,
+    pub exited_at: Option<String>,
+    pub duration_seconds: Option<i64>,
+    pub success: Option<bool>,
+    pub retry_count: i64,
+}
+
+/// Average timing per column for workspace-level analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnTimingAverage {
+    pub column_id: String,
+    pub column_name: String,
+    pub avg_duration_seconds: f64,
+    pub task_count: i64,
+    pub success_count: i64,
+    pub failure_count: i64,
+}
+
 // ─── Usage Tracking Entities ────────────────────────────────────────────────
 
 /// A record of LLM token usage (per-request).

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -14,7 +14,7 @@ fn map_timing_row(row: &rusqlite::Row) -> rusqlite::Result<PipelineTiming> {
         exited_at: row.get(5)?,
         duration_seconds: row.get(6)?,
         success: row.get::<_, Option<i64>>(7)?.map(|v| v != 0),
-        retry_count: row.get::<_, Option<i64>>(8)?.unwrap_or(0),
+        retry_count: row.get(8)?,
     })
 }
 
@@ -102,7 +102,7 @@ pub fn get_pipeline_timing(
 }
 
 /// Get average timing per column for a workspace.
-pub fn get_average_timing(
+pub fn get_average_pipeline_timing(
     conn: &Connection,
     workspace_id: &str,
 ) -> SqlResult<Vec<ColumnTimingAverage>> {

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -1,0 +1,132 @@
+use rusqlite::{params, Connection, Result as SqlResult};
+
+use super::models::{ColumnTimingAverage, PipelineTiming};
+use super::{new_id, now};
+
+/// Map a database row to a PipelineTiming struct.
+fn map_timing_row(row: &rusqlite::Row) -> rusqlite::Result<PipelineTiming> {
+    Ok(PipelineTiming {
+        id: row.get(0)?,
+        task_id: row.get(1)?,
+        column_id: row.get(2)?,
+        column_name: row.get(3)?,
+        entered_at: row.get(4)?,
+        exited_at: row.get(5)?,
+        duration_seconds: row.get(6)?,
+        success: row.get::<_, Option<i64>>(7)?.map(|v| v != 0),
+        retry_count: row.get::<_, Option<i64>>(8)?.unwrap_or(0),
+    })
+}
+
+/// Insert a new timing record when a task enters a column.
+pub fn insert_pipeline_timing(
+    conn: &Connection,
+    task_id: &str,
+    column_id: &str,
+    column_name: &str,
+) -> SqlResult<PipelineTiming> {
+    let id = new_id();
+    let entered_at = now();
+
+    conn.execute(
+        "INSERT INTO pipeline_timing (id, task_id, column_id, column_name, entered_at, retry_count)
+         VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+        params![id, task_id, column_id, column_name, entered_at],
+    )?;
+
+    conn.query_row(
+        "SELECT id, task_id, column_id, column_name, entered_at, exited_at, duration_seconds, success, retry_count
+         FROM pipeline_timing WHERE id = ?1",
+        params![id],
+        map_timing_row,
+    )
+}
+
+/// Complete a timing record when a task exits a column.
+/// Finds the open (exited_at IS NULL) timing record for the task+column.
+pub fn complete_pipeline_timing(
+    conn: &Connection,
+    task_id: &str,
+    column_id: &str,
+    success: bool,
+    retry_count: i64,
+) -> SqlResult<Option<PipelineTiming>> {
+    let exited_at = now();
+
+    // Find the open timing record
+    let timing_id: Option<String> = conn
+        .query_row(
+            "SELECT id FROM pipeline_timing
+             WHERE task_id = ?1 AND column_id = ?2 AND exited_at IS NULL
+             ORDER BY entered_at DESC LIMIT 1",
+            params![task_id, column_id],
+            |row| row.get(0),
+        )
+        .ok();
+
+    let Some(id) = timing_id else {
+        return Ok(None);
+    };
+
+    // Calculate duration from entered_at
+    conn.execute(
+        "UPDATE pipeline_timing
+         SET exited_at = ?1,
+             duration_seconds = CAST((julianday(?1) - julianday(entered_at)) * 86400 AS INTEGER),
+             success = ?2,
+             retry_count = ?3
+         WHERE id = ?4",
+        params![exited_at, success as i64, retry_count, id],
+    )?;
+
+    conn.query_row(
+        "SELECT id, task_id, column_id, column_name, entered_at, exited_at, duration_seconds, success, retry_count
+         FROM pipeline_timing WHERE id = ?1",
+        params![id],
+        map_timing_row,
+    )
+    .map(Some)
+}
+
+/// Get all timing records for a specific task.
+pub fn get_pipeline_timing(
+    conn: &Connection,
+    task_id: &str,
+) -> SqlResult<Vec<PipelineTiming>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, task_id, column_id, column_name, entered_at, exited_at, duration_seconds, success, retry_count
+         FROM pipeline_timing WHERE task_id = ?1 ORDER BY entered_at ASC",
+    )?;
+    let rows = stmt.query_map(params![task_id], map_timing_row)?;
+    rows.collect()
+}
+
+/// Get average timing per column for a workspace.
+pub fn get_average_timing(
+    conn: &Connection,
+    workspace_id: &str,
+) -> SqlResult<Vec<ColumnTimingAverage>> {
+    let mut stmt = conn.prepare(
+        "SELECT pt.column_id, pt.column_name,
+                COALESCE(AVG(pt.duration_seconds), 0) as avg_duration,
+                COUNT(*) as task_count,
+                SUM(CASE WHEN pt.success = 1 THEN 1 ELSE 0 END) as success_count,
+                SUM(CASE WHEN pt.success = 0 THEN 1 ELSE 0 END) as failure_count
+         FROM pipeline_timing pt
+         JOIN tasks t ON pt.task_id = t.id
+         WHERE t.workspace_id = ?1 AND pt.duration_seconds IS NOT NULL
+         GROUP BY pt.column_id, pt.column_name
+         ORDER BY pt.column_name ASC",
+    )?;
+    let rows = stmt.query_map(params![workspace_id], |row| {
+        Ok(ColumnTimingAverage {
+            column_id: row.get(0)?,
+            column_name: row.get(1)?,
+            avg_duration_seconds: row.get(2)?,
+            task_count: row.get(3)?,
+            success_count: row.get(4)?,
+            failure_count: row.get(5)?,
+        })
+    })?;
+    rows.collect()
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,8 @@ pub fn run() {
             commands::pipeline::try_advance_task,
             commands::pipeline::set_pipeline_error,
             commands::pipeline::update_script_exit_code,
+            commands::pipeline::get_pipeline_timing,
+            commands::pipeline::get_average_pipeline_timing,
             // Siege loop commands
             commands::siege::start_siege,
             commands::siege::stop_siege,

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -246,6 +246,11 @@ pub fn fire_trigger(
         return Ok(task.clone());
     }
 
+    // Record timing: task entering this column
+    if let Err(e) = db::insert_pipeline_timing(conn, &task.id, &column.id, &column.name) {
+        log::warn!("Failed to insert pipeline timing for task {}: {}", task.id, e);
+    }
+
     // Check for V2 triggers
     if let Some(ref triggers_json) = column.triggers {
         if triggers_json != "{}" && !triggers_json.is_empty() {
@@ -479,6 +484,11 @@ pub fn mark_complete(
 ) -> Result<Task, AppError> {
     let task = db::get_task(conn, task_id)?;
     let column = db::get_column(conn, &task.column_id)?;
+
+    // Record timing: task exiting this column
+    if let Err(e) = db::complete_pipeline_timing(conn, task_id, &column.id, success, task.retry_count) {
+        log::warn!("Failed to complete pipeline timing for task {}: {}", task_id, e);
+    }
 
     let action = decide_completion(&task, column.triggers.as_deref(), success);
 


### PR DESCRIPTION
Track how long each task spends in each column for bottleneck analysis.

## Scope
- `src-tauri/src/pipeline/mod.rs` — record timestamps on column entry/exit
- `src-tauri/src/db/` — new timing table or extend existing

## What exists
- `pipeline_triggered_at` timestamp on tasks (when trigger fired)
- `mark_complete` called when task finishes in a column
- `try_auto_advance` moves task to next column

## Implementation
1. Create `pipeline_timing` table:
   ```sql
   CREATE TABLE IF NOT EXISTS pipeline_timing (
     id TEXT PRIMARY KEY,
     task_id TEXT NOT NULL,
     column_id TEXT NOT NULL,
     column_name TEXT NOT NULL,
     entered_at TEXT NOT NULL,
     exited_at TEXT,
     duration_seconds INTEGER,
     success BOOLEAN,
     retry_count INTEGER DEFAULT 0,
     FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
   );
   ```
2. In `fire_trigger()`: insert timing row with entered_at = now()
3. In `mark_complete_with_error()` / `try_auto_advance()`: update timing row with exited_at, calculate duration
4. Add query: `get_pipeline_timing(task_id)` returns array of column timings
5. Add query: `get_average_timing(workspace_id)` returns avg duration per column

## Acceptance criteria
- [ ] Timing recorded for each column a task passes through
- [ ] Duration calculated in seconds
- [ ] Success/failure tracked per column
- [ ] Query returns timing breakdown per task
- [ ] Average timing query works for workspace-level analysis
- [ ] cargo check passes
- [ ] cargo test passes