### PR TITLE
Add task card quick actions — run, retry, move, delete

### DIFF
--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -128,6 +128,34 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
     return names.length > 0 ? names.join(', ') : null
   }, [task.blocked, task.dependencies])
 
+  // Find next column for "move right" action
+  const nextColumnId = useMemo(() => {
+    const currentCol = columns.find(c => c.id === task.columnId)
+    if (!currentCol) return null
+    const sorted = [...columns].sort((a, b) => a.position - b.position)
+    const idx = sorted.findIndex(c => c.id === task.columnId)
+    const next = sorted[idx + 1]
+    return idx < sorted.length - 1 && next ? next.id : null
+  }, [columns, task.columnId])
+
+  const handleMoveNext = useCallback(() => {
+    if (nextColumnId) {
+      actions.handleMoveToColumn(nextColumnId)
+    }
+  }, [nextColumnId, actions])
+
+  const [deleteConfirmPending, setDeleteConfirmPending] = useState(false)
+
+  const handleDeleteWithConfirm = useCallback(() => {
+    if (deleteConfirmPending) {
+      actions.handleDeleteTask()
+      setDeleteConfirmPending(false)
+    } else {
+      setDeleteConfirmPending(true)
+      setTimeout(() => { setDeleteConfirmPending(false) }, 2000)
+    }
+  }, [deleteConfirmPending, actions])
+
   const needsAttention = hasAttention || task.agentStatus === 'needs_attention'
   const isPipelineActive = task.pipelineState !== 'idle'
   const hasPipelineError = !!task.pipelineError
@@ -177,22 +205,34 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
         if (e.metaKey || e.ctrlKey || e.altKey) return
         switch (e.key) {
           case 'Enter':
-          case ' ':
             e.preventDefault()
             handleClick()
+            break
+          case ' ':
+            e.preventDefault()
+            actions.handleToggleAgent()
+            break
+          case 'r':
+          case 'R':
+            e.preventDefault()
+            if (task.pipelineError) {
+              void actions.handleRetryPipeline()
+            }
+            break
+          case 'ArrowRight':
+            e.preventDefault()
+            handleMoveNext()
+            break
+          case 'Delete':
+          case 'Backspace':
+            e.preventDefault()
+            handleDeleteWithConfirm()
             break
           case 'd':
           case 'D':
             e.preventDefault()
             actions.handleDuplicateTask()
             break
-          case 'Delete':
-          case 'Backspace': {
-            e.preventDefault()
-            const rect = e.currentTarget.getBoundingClientRect()
-            setContextMenu({ x: rect.right - 180, y: rect.top })
-            break
-          }
           case 'm':
           case 'M': {
             e.preventDefault()
@@ -228,8 +268,12 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
       {!isDragging && (
         <TaskQuickActions
           task={task}
+          hasNextColumn={!!nextColumnId}
           onOpen={handleClick}
           onToggleAgent={actions.handleToggleAgent}
+          onRetry={() => { void actions.handleRetryPipeline() }}
+          onMoveNext={handleMoveNext}
+          onDelete={actions.handleDeleteTask}
           onShowMenu={handleShowMenu}
         />
       )}

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -130,12 +130,10 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
 
   // Find next column for "move right" action
   const nextColumnId = useMemo(() => {
-    const currentCol = columns.find(c => c.id === task.columnId)
-    if (!currentCol) return null
     const sorted = [...columns].sort((a, b) => a.position - b.position)
     const idx = sorted.findIndex(c => c.id === task.columnId)
-    const next = sorted[idx + 1]
-    return idx < sorted.length - 1 && next ? next.id : null
+    if (idx === -1) return null
+    return idx < sorted.length - 1 ? (sorted[idx + 1]?.id ?? null) : null
   }, [columns, task.columnId])
 
   const handleMoveNext = useCallback(() => {
@@ -143,6 +141,8 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
       actions.handleMoveToColumn(nextColumnId)
     }
   }, [nextColumnId, actions])
+
+  const handleRetry = useCallback(() => { void actions.handleRetryPipeline() }, [actions])
 
   const [deleteConfirmPending, setDeleteConfirmPending] = useState(false)
 
@@ -271,7 +271,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
           hasNextColumn={!!nextColumnId}
           onOpen={handleClick}
           onToggleAgent={actions.handleToggleAgent}
-          onRetry={() => { void actions.handleRetryPipeline() }}
+          onRetry={handleRetry}
           onMoveNext={handleMoveNext}
           onDelete={actions.handleDeleteTask}
           onShowMenu={handleShowMenu}

--- a/src/components/kanban/task-quick-actions.tsx
+++ b/src/components/kanban/task-quick-actions.tsx
@@ -1,24 +1,47 @@
-import { memo } from 'react'
+import { memo, useState, useCallback } from 'react'
 import type { Task } from '@/types'
 
 type TaskQuickActionsProps = {
   task: Task
+  hasNextColumn: boolean
   onOpen: () => void
   onToggleAgent: () => void
+  onRetry: () => void
+  onMoveNext: () => void
+  onDelete: () => void
   onShowMenu: (e: React.MouseEvent) => void
 }
 
 export const TaskQuickActions = memo(function TaskQuickActions({
   task,
+  hasNextColumn,
   onOpen,
   onToggleAgent,
+  onRetry,
+  onMoveNext,
+  onDelete,
   onShowMenu,
 }: TaskQuickActionsProps) {
   const isRunning = task.agentStatus === 'running'
+  const hasError = !!task.pipelineError
+
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const handleDelete = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (confirmDelete) {
+      onDelete()
+      setConfirmDelete(false)
+    } else {
+      setConfirmDelete(true)
+      // Auto-dismiss after 2s
+      setTimeout(() => { setConfirmDelete(false) }, 2000)
+    }
+  }, [confirmDelete, onDelete])
 
   return (
     <div
-      className="absolute right-1 top-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+      className="absolute right-1 top-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10"
       onClick={(e) => { e.stopPropagation(); }}
     >
       {/* Open in panel */}
@@ -41,7 +64,7 @@ export const TaskQuickActions = memo(function TaskQuickActions({
             ? 'text-running hover:bg-running/20'
             : 'text-text-secondary hover:bg-surface-hover hover:text-success'
         }`}
-        title={isRunning ? 'Stop agent' : 'Run agent'}
+        title={isRunning ? 'Stop agent (Space)' : 'Run agent (Space)'}
       >
         {isRunning ? (
           <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
@@ -52,6 +75,47 @@ export const TaskQuickActions = memo(function TaskQuickActions({
             <path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.841Z" />
           </svg>
         )}
+      </button>
+
+      {/* Retry - visible when task has pipeline error */}
+      {hasError && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onRetry(); }}
+          className="flex h-6 w-6 items-center justify-center rounded text-text-secondary hover:bg-warning/20 hover:text-warning transition-colors"
+          title="Retry pipeline (R)"
+        >
+          <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H4.598a.75.75 0 0 0-.75.75v3.634a.75.75 0 0 0 1.5 0v-2.033l.312.311a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39l-.611.21ZM4.688 8.576a5.5 5.5 0 0 1 9.201-2.466l.312.311h-2.433a.75.75 0 0 0 0 1.5h3.634a.75.75 0 0 0 .75-.75V3.537a.75.75 0 0 0-1.5 0v2.033l-.312-.311A7 7 0 0 0 3.628 8.397a.75.75 0 0 0 1.449.39l-.389-.211Z" clipRule="evenodd" />
+          </svg>
+        </button>
+      )}
+
+      {/* Move to next column */}
+      {hasNextColumn && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onMoveNext(); }}
+          className="flex h-6 w-6 items-center justify-center rounded text-text-secondary hover:bg-surface-hover hover:text-accent transition-colors"
+          title="Move to next column (&rarr;)"
+        >
+          <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638l-3.96-4.158a.75.75 0 1 1 1.085-1.034l5.25 5.5a.75.75 0 0 1 0 1.034l-5.25 5.5a.75.75 0 1 1-1.085-1.034l3.96-4.158H3.75A.75.75 0 0 1 3 10Z" clipRule="evenodd" />
+          </svg>
+        </button>
+      )}
+
+      {/* Delete */}
+      <button
+        onClick={handleDelete}
+        className={`flex h-6 w-6 items-center justify-center rounded transition-colors ${
+          confirmDelete
+            ? 'text-error bg-error/20'
+            : 'text-text-secondary hover:bg-error/20 hover:text-error'
+        }`}
+        title={confirmDelete ? 'Click again to confirm' : 'Delete task (Del)'}
+      >
+        <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM7.5 3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25V4.1a40.3 40.3 0 0 0-5 0v-.35ZM9 7.75a.75.75 0 0 0-1.5 0v6.5a.75.75 0 0 0 1.5 0v-6.5Zm3.25-.75a.75.75 0 0 1 .75.75v6.5a.75.75 0 0 1-1.5 0v-6.5a.75.75 0 0 1 .75-.75Z" clipRule="evenodd" />
+        </svg>
       </button>
 
       {/* More options */}

--- a/src/components/kanban/task-quick-actions.tsx
+++ b/src/components/kanban/task-quick-actions.tsx
@@ -1,6 +1,8 @@
 import { memo, useState, useCallback } from 'react'
 import type { Task } from '@/types'
 
+const CONFIRM_TIMEOUT_MS = 2000
+
 type TaskQuickActionsProps = {
   task: Task
   hasNextColumn: boolean
@@ -35,7 +37,7 @@ export const TaskQuickActions = memo(function TaskQuickActions({
     } else {
       setConfirmDelete(true)
       // Auto-dismiss after 2s
-      setTimeout(() => { setConfirmDelete(false) }, 2000)
+      setTimeout(() => { setConfirmDelete(false) }, CONFIRM_TIMEOUT_MS)
     }
   }, [confirmDelete, onDelete])
 
@@ -95,7 +97,7 @@ export const TaskQuickActions = memo(function TaskQuickActions({
         <button
           onClick={(e) => { e.stopPropagation(); onMoveNext(); }}
           className="flex h-6 w-6 items-center justify-center rounded text-text-secondary hover:bg-surface-hover hover:text-accent transition-colors"
-          title="Move to next column (&rarr;)"
+          title="Move to next column (→)"
         >
           <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
             <path fillRule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638l-3.96-4.158a.75.75 0 1 1 1.085-1.034l5.25 5.5a.75.75 0 0 1 0 1.034l-5.25 5.5a.75.75 0 1 1-1.085-1.034l3.96-4.158H3.75A.75.75 0 0 1 3 10Z" clipRule="evenodd" />


### PR DESCRIPTION
Add hover quick-action buttons on task cards for common operations.

## Scope
- `src/components/kanban/task-card.tsx` — add quick action bar

## Implementation
1. Hover overlay: row of icon buttons at top-right of card
2. Actions: Play (run agent), Retry (restart from current column), → (move to next column), 🗑 (delete)
3. Play: visible when task is idle in a trigger column
4. Retry: visible when task has error
5. Move right: visible always, moves to next column
6. Delete: visible always, with confirmation
7. Keyboard shortcut: Space=run, R=retry, →=move, Delete=delete (when card focused)

## Acceptance criteria
- [ ] Quick actions visible on hover
- [ ] Play triggers agent
- [ ] Retry resets and reruns
- [ ] Move advances to next column
- [ ] Delete with confirmation
- [ ] Keyboard shortcuts work
- [ ] npm run type-check && npx vitest run passes