### PR TITLE
Wire orchestrator chat to actual LLM calls

### DIFF
--- a/src-tauri/src/chat/chef.rs
+++ b/src-tauri/src/chat/chef.rs
@@ -97,10 +97,11 @@ impl ChefSession {
         &self,
         workspace: &Workspace,
         columns: &[Column],
+        tasks: &[Task],
     ) -> String {
         match self.mode {
-            ChefMode::Api => context::build_system_prompt(workspace, columns),
-            ChefMode::Cli => context::build_cli_system_prompt(workspace, columns),
+            ChefMode::Api => context::build_system_prompt(workspace, columns, tasks),
+            ChefMode::Cli => context::build_cli_system_prompt(workspace, columns, tasks),
         }
     }
 
@@ -165,7 +166,7 @@ impl ChefSession {
             .map_err(|e| format!("Failed to list tasks: {}", e))?;
 
         // Update system prompt with current board state
-        let system_prompt = self.build_system_prompt(&workspace, &columns);
+        let system_prompt = self.build_system_prompt(&workspace, &columns, &tasks);
         self.session.set_system_prompt(system_prompt);
 
         // Augment message with board context
@@ -272,8 +273,8 @@ mod tests {
         let cli_chef = ChefSession::new_cli("ws-1".to_string(), test_config());
         let api_chef = ChefSession::new_api("ws-1".to_string(), test_config());
 
-        let cli_prompt = cli_chef.build_system_prompt(&workspace, &[]);
-        let api_prompt = api_chef.build_system_prompt(&workspace, &[]);
+        let cli_prompt = cli_chef.build_system_prompt(&workspace, &[], &[]);
+        let api_prompt = api_chef.build_system_prompt(&workspace, &[], &[]);
 
         // CLI mode has action block instructions
         assert!(cli_prompt.contains("```action"));

--- a/src-tauri/src/commands/orchestrator.rs
+++ b/src-tauri/src/commands/orchestrator.rs
@@ -19,7 +19,8 @@ use crate::llm::{
 use crate::llm::types::{LlmRequest, Message};
 use tauri::{AppHandle, Emitter, State};
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::AbortHandle;
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -107,6 +108,44 @@ pub struct ToolCallPayload {
     pub input: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<String>,
+}
+
+/// Tracks abort handles for in-flight API orchestrator streams so cancel can stop them.
+#[derive(Default)]
+pub struct ApiStreamRegistry {
+    handles: Mutex<HashMap<String, AbortHandle>>,
+}
+
+impl ApiStreamRegistry {
+    async fn insert(&self, key: String, handle: AbortHandle) {
+        let mut handles = self.handles.lock().await;
+        if let Some(previous) = handles.insert(key, handle) {
+            previous.abort();
+        }
+    }
+
+    async fn abort(&self, key: &str) -> bool {
+        let mut handles = self.handles.lock().await;
+        if let Some(handle) = handles.remove(key) {
+            handle.abort();
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn remove(&self, key: &str) {
+        self.handles.lock().await.remove(key);
+    }
+
+    #[cfg(test)]
+    async fn len(&self) -> usize {
+        self.handles.lock().await.len()
+    }
+}
+
+fn api_stream_key(workspace_id: &str, session_id: &str) -> String {
+    format!("chef-api:{}:{}", workspace_id, session_id)
 }
 
 // ─── Commands ───────────────────────────────────────────────────────────────
@@ -359,6 +398,7 @@ pub async fn stream_orchestrator_chat(
     app: AppHandle,
     state: State<'_, AppState>,
     session_registry: State<'_, SharedSessionRegistry>,
+    api_stream_registry: State<'_, ApiStreamRegistry>,
     workspace_id: String,
     session_id: String,
     message: String,
@@ -418,7 +458,7 @@ pub async fn stream_orchestrator_chat(
     });
 
     // Handle based on connection mode
-    match connection_mode.as_str() {
+    let result = match connection_mode.as_str() {
         "api" => {
             // Get API key: explicit param > env var from provider config > ANTHROPIC_API_KEY fallback
             let env_var_name = api_key_env_var.as_deref().unwrap_or("ANTHROPIC_API_KEY");
@@ -426,7 +466,17 @@ pub async fn stream_orchestrator_chat(
                 .or_else(|| std::env::var(env_var_name).ok())
                 .ok_or_else(|| AppError::InvalidInput(format!("No API key provided and {} not set", env_var_name)))?;
 
-            stream_via_api(app.clone(), state.clone(), &workspace_id, &actual_session_id, &orch_session_id, &api_key, &model, history).await
+            stream_via_api(
+                app.clone(),
+                state.clone(),
+                api_stream_registry.inner(),
+                &workspace_id,
+                &actual_session_id,
+                &orch_session_id,
+                &api_key,
+                &model,
+                history,
+            ).await
         }
         "cli" => {
             let cli = cli_path.clone().unwrap_or_else(|| "claude".to_string());
@@ -446,7 +496,28 @@ pub async fn stream_orchestrator_chat(
         _ => {
             Err(AppError::InvalidInput(format!("Unknown connection mode: {}", connection_mode)))
         }
+    };
+
+    if let Err(err) = &result {
+        let error_message = err.to_string();
+
+        if let Ok(conn) = state.db.lock() {
+            let _ = db::update_orchestrator_session(
+                &conn,
+                &orch_session_id,
+                Some("error"),
+                Some(Some(error_message.as_str())),
+            );
+        }
+
+        let _ = app.emit("orchestrator:error", &OrchestratorEvent {
+            workspace_id,
+            event_type: "error".to_string(),
+            message: Some(error_message),
+        });
     }
+
+    result
 }
 
 /// Cancel an ongoing orchestrator chat (kills the CLI process)
@@ -455,6 +526,7 @@ pub async fn cancel_orchestrator_chat(
     app: AppHandle,
     state: State<'_, AppState>,
     session_registry: State<'_, SharedSessionRegistry>,
+    api_stream_registry: State<'_, ApiStreamRegistry>,
     session_id: String,
     workspace_id: String,
 ) -> Result<(), AppError> {
@@ -466,6 +538,10 @@ pub async fn cancel_orchestrator_chat(
             let _ = session.kill();
         }
     }
+
+    let _ = api_stream_registry
+        .abort(&api_stream_key(&workspace_id, &session_id))
+        .await;
 
     // Update orchestrator session to idle
     {
@@ -487,6 +563,7 @@ pub async fn cancel_orchestrator_chat(
 async fn stream_via_api(
     app: AppHandle,
     state: State<'_, AppState>,
+    api_stream_registry: &ApiStreamRegistry,
     workspace_id: &str,
     session_id: &str,
     orch_session_id: &str,
@@ -568,6 +645,10 @@ async fn stream_via_api(
     let stream_handle = tokio::spawn(async move {
         client.stream_chat(request, tx).await
     });
+    let stream_registry_key = api_stream_key(workspace_id, session_id);
+    api_stream_registry
+        .insert(stream_registry_key.clone(), stream_handle.abort_handle())
+        .await;
 
     // Forward chunks to frontend
     while let Some(chunk) = rx.recv().await {
@@ -599,10 +680,12 @@ async fn stream_via_api(
     }
 
     // Wait for streaming to complete and get response
-    let response = stream_handle
-        .await
-        .map_err(|e| AppError::DatabaseError(format!("Stream task failed: {}", e)))?
-        .map_err(|e| AppError::DatabaseError(e))?;
+    api_stream_registry.remove(&stream_registry_key).await;
+    let response = match stream_handle.await {
+        Ok(result) => result.map_err(AppError::DatabaseError)?,
+        Err(err) if err.is_cancelled() => return Ok(()),
+        Err(err) => return Err(AppError::DatabaseError(format!("Stream task failed: {}", err))),
+    };
 
     // Execute any tool calls
     let mut tool_results_summary = String::new();
@@ -689,6 +772,51 @@ async fn stream_via_api(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{api_stream_key, ApiStreamRegistry};
+
+    #[test]
+    fn test_api_stream_key() {
+        assert_eq!(api_stream_key("ws-1", "session-1"), "chef-api:ws-1:session-1");
+    }
+
+    #[tokio::test]
+    async fn test_api_stream_registry_abort() {
+        let registry = ApiStreamRegistry::default();
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        registry.insert("stream-1".to_string(), handle.abort_handle()).await;
+        assert_eq!(registry.len().await, 1);
+
+        assert!(registry.abort("stream-1").await);
+        assert_eq!(registry.len().await, 0);
+        assert!(handle.await.unwrap_err().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_api_stream_registry_replaces_existing_handle() {
+        let registry = ApiStreamRegistry::default();
+        let first = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        let second = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        registry.insert("stream-1".to_string(), first.abort_handle()).await;
+        registry.insert("stream-1".to_string(), second.abort_handle()).await;
+
+        assert_eq!(registry.len().await, 1);
+        assert!(first.await.unwrap_err().is_cancelled());
+
+        assert!(registry.abort("stream-1").await);
+        assert!(second.await.unwrap_err().is_cancelled());
+    }
 }
 
 /// Stream orchestrator chat via unified CLI session.

--- a/src-tauri/src/commands/orchestrator.rs
+++ b/src-tauri/src/commands/orchestrator.rs
@@ -5,20 +5,19 @@
 
 use std::collections::HashMap;
 
-use crate::chat::ChefSession;
 use crate::chat::events::{ChatEvent, ToolStatus};
 use crate::chat::registry::SharedSessionRegistry;
 use crate::chat::session::{SessionConfig, TransportType, UnifiedChatSession};
-use crate::db::{self, AppState, ChatMessage, ChatSession, OrchestratorSession, Column, Task};
+use crate::chat::ChefSession;
+use crate::db::{self, AppState, ChatMessage, ChatSession, Column, OrchestratorSession, Task};
 use crate::error::AppError;
-use crate::llm::{
-    AnthropicClient, calculate_cost, resolve_model_id,
-    build_cli_system_prompt, build_board_context, format_board_context_message,
-    orchestrator_tools, tools_to_api_format, execute_tools, parse_cli_action_blocks,
-};
 use crate::llm::types::{LlmRequest, Message};
-use tauri::{AppHandle, Emitter, State};
+use crate::llm::{
+    calculate_cost, execute_tools, orchestrator_tools, parse_cli_action_blocks, resolve_model_id,
+    tools_to_api_format, AnthropicClient,
+};
 use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State};
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::AbortHandle;
 
@@ -156,13 +155,16 @@ pub fn get_orchestrator_context(
     state: State<AppState>,
     workspace_id: String,
 ) -> Result<OrchestratorContext, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
     let workspace = db::get_workspace(&conn, &workspace_id)?;
     let columns = db::list_columns(&conn, &workspace_id)?;
     let tasks = db::list_tasks(&conn, &workspace_id)?;
     let recent_messages = db::list_chat_messages(&conn, &workspace_id, Some(20))?;
-    
+
     Ok(OrchestratorContext {
         workspace_id: workspace.id,
         workspace_name: workspace.name,
@@ -178,8 +180,14 @@ pub fn get_orchestrator_session(
     state: State<AppState>,
     workspace_id: String,
 ) -> Result<OrchestratorSession, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    Ok(db::get_or_create_orchestrator_session(&conn, &workspace_id)?)
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::get_or_create_orchestrator_session(
+        &conn,
+        &workspace_id,
+    )?)
 }
 
 /// List chat sessions for a workspace
@@ -188,7 +196,10 @@ pub fn list_chat_sessions(
     state: State<AppState>,
     workspace_id: String,
 ) -> Result<Vec<ChatSession>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_chat_sessions(&conn, &workspace_id)?)
 }
 
@@ -198,7 +209,10 @@ pub fn get_active_chat_session(
     state: State<AppState>,
     workspace_id: String,
 ) -> Result<ChatSession, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::get_or_create_active_session(&conn, &workspace_id)?)
 }
 
@@ -209,7 +223,10 @@ pub fn create_chat_session(
     workspace_id: String,
     title: Option<String>,
 ) -> Result<ChatSession, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let title = title.unwrap_or_else(|| "New Chat".to_string());
     Ok(db::create_chat_session(&conn, &workspace_id, &title)?)
 }
@@ -223,7 +240,10 @@ pub async fn delete_chat_session(
 ) -> Result<(), AppError> {
     // Look up workspace_id from the session to build registry key
     let workspace_id = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         db::get_chat_session(&conn, &session_id)
             .map(|s| s.workspace_id)
             .ok()
@@ -237,7 +257,10 @@ pub async fn delete_chat_session(
     }
 
     // Delete from database
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::delete_chat_session(&conn, &session_id)?;
     Ok(())
 }
@@ -249,17 +272,20 @@ pub fn get_chat_history(
     session_id: String,
     limit: Option<i64>,
 ) -> Result<Vec<ChatMessage>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_chat_messages(&conn, &session_id, limit)?)
 }
 
 /// Clear chat history for a session
 #[tauri::command]
-pub fn clear_chat_history(
-    state: State<AppState>,
-    session_id: String,
-) -> Result<(), AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+pub fn clear_chat_history(state: State<AppState>, session_id: String) -> Result<(), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::delete_chat_messages(&conn, &session_id)?;
     Ok(())
 }
@@ -274,7 +300,10 @@ pub async fn reset_cli_session(
 ) -> Result<(), AppError> {
     // Look up workspace_id from the session to build registry key
     let workspace_id = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         db::get_chat_session(&conn, &session_id)
             .map(|s| s.workspace_id)
             .ok()
@@ -291,7 +320,10 @@ pub async fn reset_cli_session(
 
     // Clear cli_session_id from database
     {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let _ = db::update_chat_session_cli_id(&conn, &session_id, None);
     }
 
@@ -308,17 +340,26 @@ pub fn process_orchestrator_response(
     response_text: String,
     actions: Vec<OrchestratorAction>,
 ) -> Result<OrchestratorResponse, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Get active chat session
     let chat_session = db::get_or_create_active_session(&conn, &workspace_id)?;
 
     // Store assistant message
-    let _ = db::insert_chat_message(&conn, &workspace_id, &chat_session.id, "assistant", &response_text)?;
-    
+    let _ = db::insert_chat_message(
+        &conn,
+        &workspace_id,
+        &chat_session.id,
+        "assistant",
+        &response_text,
+    )?;
+
     // Process actions
     let mut tasks_created = Vec::new();
-    
+
     for action in &actions {
         match action.action_type.as_str() {
             "create_task" => {
@@ -350,18 +391,21 @@ pub fn process_orchestrator_response(
             _ => {}
         }
     }
-    
+
     // Update session status to idle
     let session = db::get_or_create_orchestrator_session(&conn, &workspace_id)?;
     let _ = db::update_orchestrator_session(&conn, &session.id, Some("idle"), None);
-    
+
     // Emit completion event
-    let _ = app.emit("orchestrator:complete", &OrchestratorEvent {
-        workspace_id: workspace_id.clone(),
-        event_type: "complete".to_string(),
-        message: Some(format!("Created {} task(s)", tasks_created.len())),
-    });
-    
+    let _ = app.emit(
+        "orchestrator:complete",
+        &OrchestratorEvent {
+            workspace_id: workspace_id.clone(),
+            event_type: "complete".to_string(),
+            message: Some(format!("Created {} task(s)", tasks_created.len())),
+        },
+    );
+
     Ok(OrchestratorResponse {
         message: response_text,
         actions: actions.clone(),
@@ -377,22 +421,34 @@ pub fn set_orchestrator_error(
     workspace_id: String,
     error_message: String,
 ) -> Result<OrchestratorSession, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
     let session = db::get_or_create_orchestrator_session(&conn, &workspace_id)?;
-    let updated = db::update_orchestrator_session(&conn, &session.id, Some("error"), Some(Some(&error_message)))?;
-    
+    let updated = db::update_orchestrator_session(
+        &conn,
+        &session.id,
+        Some("error"),
+        Some(Some(&error_message)),
+    )?;
+
     // Emit error event
-    let _ = app.emit("orchestrator:error", &OrchestratorEvent {
-        workspace_id,
-        event_type: "error".to_string(),
-        message: Some(error_message),
-    });
+    let _ = app.emit(
+        "orchestrator:error",
+        &OrchestratorEvent {
+            workspace_id,
+            event_type: "error".to_string(),
+            message: Some(error_message),
+        },
+    );
 
     Ok(updated)
 }
 
 /// Stream a chat message to the LLM and emit chunks
+#[allow(clippy::too_many_arguments)]
 #[tauri::command(rename_all = "camelCase")]
 pub async fn stream_orchestrator_chat(
     app: AppHandle,
@@ -412,7 +468,10 @@ pub async fn stream_orchestrator_chat(
 
     // Store user message and get history
     let (history, orch_session_id, actual_session_id, cli_session_id) = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
         // Verify session exists, or fall back to active session
         let chat_session = match db::get_chat_session(&conn, &session_id) {
@@ -451,11 +510,14 @@ pub async fn stream_orchestrator_chat(
     };
 
     // Emit processing event
-    let _ = app.emit("orchestrator:processing", &OrchestratorEvent {
-        workspace_id: workspace_id.clone(),
-        event_type: "processing".to_string(),
-        message: Some(message.clone()),
-    });
+    let _ = app.emit(
+        "orchestrator:processing",
+        &OrchestratorEvent {
+            workspace_id: workspace_id.clone(),
+            event_type: "processing".to_string(),
+            message: Some(message.clone()),
+        },
+    );
 
     // Handle based on connection mode
     let result = match connection_mode.as_str() {
@@ -464,7 +526,12 @@ pub async fn stream_orchestrator_chat(
             let env_var_name = api_key_env_var.as_deref().unwrap_or("ANTHROPIC_API_KEY");
             let api_key = api_key
                 .or_else(|| std::env::var(env_var_name).ok())
-                .ok_or_else(|| AppError::InvalidInput(format!("No API key provided and {} not set", env_var_name)))?;
+                .ok_or_else(|| {
+                    AppError::InvalidInput(format!(
+                        "No API key provided and {} not set",
+                        env_var_name
+                    ))
+                })?;
 
             stream_via_api(
                 app.clone(),
@@ -476,7 +543,8 @@ pub async fn stream_orchestrator_chat(
                 &api_key,
                 &model,
                 history,
-            ).await
+            )
+            .await
         }
         "cli" => {
             let cli = cli_path.clone().unwrap_or_else(|| "claude".to_string());
@@ -491,11 +559,13 @@ pub async fn stream_orchestrator_chat(
                 &model,
                 &message,
                 cli_session_id.as_deref(),
-            ).await
+            )
+            .await
         }
-        _ => {
-            Err(AppError::InvalidInput(format!("Unknown connection mode: {}", connection_mode)))
-        }
+        _ => Err(AppError::InvalidInput(format!(
+            "Unknown connection mode: {}",
+            connection_mode
+        ))),
     };
 
     if let Err(err) = &result {
@@ -510,11 +580,14 @@ pub async fn stream_orchestrator_chat(
             );
         }
 
-        let _ = app.emit("orchestrator:error", &OrchestratorEvent {
-            workspace_id,
-            event_type: "error".to_string(),
-            message: Some(error_message),
-        });
+        let _ = app.emit(
+            "orchestrator:error",
+            &OrchestratorEvent {
+                workspace_id,
+                event_type: "error".to_string(),
+                message: Some(error_message),
+            },
+        );
     }
 
     result
@@ -545,21 +618,28 @@ pub async fn cancel_orchestrator_chat(
 
     // Update orchestrator session to idle
     {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let session = db::get_or_create_orchestrator_session(&conn, &workspace_id)?;
         let _ = db::update_orchestrator_session(&conn, &session.id, Some("idle"), None);
     }
 
     // Emit cancelled event
-    let _ = app.emit("orchestrator:complete", &OrchestratorEvent {
-        workspace_id: workspace_id.clone(),
-        event_type: "cancelled".to_string(),
-        message: Some("Request cancelled".to_string()),
-    });
+    let _ = app.emit(
+        "orchestrator:complete",
+        &OrchestratorEvent {
+            workspace_id: workspace_id.clone(),
+            event_type: "cancelled".to_string(),
+            message: Some("Request cancelled".to_string()),
+        },
+    );
 
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn stream_via_api(
     app: AppHandle,
     state: State<'_, AppState>,
@@ -586,7 +666,10 @@ async fn stream_via_api(
 
     // Get workspace context for system prompt
     let (workspace, columns, tasks) = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let workspace = db::get_workspace(&conn, workspace_id)?;
         let columns = db::list_columns(&conn, workspace_id)?;
         let tasks = db::list_tasks(&conn, workspace_id)?;
@@ -642,9 +725,7 @@ async fn stream_via_api(
     let workspace_id_clone = workspace_id.to_string();
     let mut pending_tool_calls: HashMap<String, (String, serde_json::Value)> = HashMap::new();
 
-    let stream_handle = tokio::spawn(async move {
-        client.stream_chat(request, tx).await
-    });
+    let stream_handle = tokio::spawn(async move { client.stream_chat(request, tx).await });
     let stream_registry_key = api_stream_key(workspace_id, session_id);
     api_stream_registry
         .insert(stream_registry_key.clone(), stream_handle.abort_handle())
@@ -655,14 +736,17 @@ async fn stream_via_api(
         let tool_use_payload = chunk.tool_use.as_ref().map(|tu| {
             pending_tool_calls.insert(tu.id.clone(), (tu.name.clone(), tu.input.clone()));
 
-            let _ = app_clone.emit("orchestrator:tool_call", &ToolCallPayload {
-                workspace_id: workspace_id_clone.clone(),
-                tool_id: tu.id.clone(),
-                tool_name: tu.name.clone(),
-                status: "running".to_string(),
-                input: Some(tu.input.clone()),
-                result: None,
-            });
+            let _ = app_clone.emit(
+                "orchestrator:tool_call",
+                &ToolCallPayload {
+                    workspace_id: workspace_id_clone.clone(),
+                    tool_id: tu.id.clone(),
+                    tool_name: tu.name.clone(),
+                    status: "running".to_string(),
+                    input: Some(tu.input.clone()),
+                    result: None,
+                },
+            );
 
             ToolUsePayload {
                 id: tu.id.clone(),
@@ -671,12 +755,15 @@ async fn stream_via_api(
             }
         });
 
-        let _ = app_clone.emit("orchestrator:stream", &StreamChunkPayload {
-            workspace_id: workspace_id_clone.clone(),
-            delta: chunk.delta,
-            finish_reason: chunk.finish_reason.clone(),
-            tool_use: tool_use_payload,
-        });
+        let _ = app_clone.emit(
+            "orchestrator:stream",
+            &StreamChunkPayload {
+                workspace_id: workspace_id_clone.clone(),
+                delta: chunk.delta,
+                finish_reason: chunk.finish_reason.clone(),
+                tool_use: tool_use_payload,
+            },
+        );
     }
 
     // Wait for streaming to complete and get response
@@ -684,22 +771,32 @@ async fn stream_via_api(
     let response = match stream_handle.await {
         Ok(result) => result.map_err(AppError::DatabaseError)?,
         Err(err) if err.is_cancelled() => return Ok(()),
-        Err(err) => return Err(AppError::DatabaseError(format!("Stream task failed: {}", err))),
+        Err(err) => {
+            return Err(AppError::DatabaseError(format!(
+                "Stream task failed: {}",
+                err
+            )))
+        }
     };
 
     // Execute any tool calls
     let mut tool_results_summary = String::new();
     if !response.tool_uses.is_empty() {
-        let tool_uses: Vec<crate::llm::ToolUse> = response.tool_uses.iter().map(|tu| {
-            crate::llm::ToolUse {
+        let tool_uses: Vec<crate::llm::ToolUse> = response
+            .tool_uses
+            .iter()
+            .map(|tu| crate::llm::ToolUse {
                 id: tu.id.clone(),
                 name: tu.name.clone(),
                 input: tu.input.clone(),
-            }
-        }).collect();
+            })
+            .collect();
 
         let execution_result = {
-            let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let conn = state
+                .db
+                .lock()
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
             execute_tools(&conn, &app, workspace_id, &tool_uses, &columns)?
         };
 
@@ -710,21 +807,31 @@ async fn stream_via_api(
                 .cloned()
                 .unwrap_or_else(|| ("unknown".to_string(), serde_json::Value::Null));
 
-            let _ = app.emit("orchestrator:tool_result", &ToolResultPayload {
-                workspace_id: workspace_id.to_string(),
-                tool_use_id: result.tool_use_id.clone(),
-                result: result.content.clone(),
-                is_error: result.is_error,
-            });
+            let _ = app.emit(
+                "orchestrator:tool_result",
+                &ToolResultPayload {
+                    workspace_id: workspace_id.to_string(),
+                    tool_use_id: result.tool_use_id.clone(),
+                    result: result.content.clone(),
+                    is_error: result.is_error,
+                },
+            );
 
-            let _ = app.emit("orchestrator:tool_call", &ToolCallPayload {
-                workspace_id: workspace_id.to_string(),
-                tool_id: result.tool_use_id.clone(),
-                tool_name,
-                status: if result.is_error { "error" } else { "complete" }.to_string(),
-                input: if tool_input.is_null() { None } else { Some(tool_input) },
-                result: Some(result.content.clone()),
-            });
+            let _ = app.emit(
+                "orchestrator:tool_call",
+                &ToolCallPayload {
+                    workspace_id: workspace_id.to_string(),
+                    tool_id: result.tool_use_id.clone(),
+                    tool_name,
+                    status: if result.is_error { "error" } else { "complete" }.to_string(),
+                    input: if tool_input.is_null() {
+                        None
+                    } else {
+                        Some(tool_input)
+                    },
+                    result: Some(result.content.clone()),
+                },
+            );
         }
 
         tool_results_summary = execution_result.summary;
@@ -741,10 +848,19 @@ async fn stream_via_api(
 
     // Store assistant message and usage
     {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
         // Store assistant response
-        let assistant_msg = db::insert_chat_message(&conn, workspace_id, session_id, "assistant", &assistant_content)?;
+        let assistant_msg = db::insert_chat_message(
+            &conn,
+            workspace_id,
+            session_id,
+            "assistant",
+            &assistant_content,
+        )?;
 
         // Record usage (use original alias for cost lookup since model info uses aliases)
         let cost = calculate_cost(model, &response.usage);
@@ -764,59 +880,17 @@ async fn stream_via_api(
         let _ = db::update_orchestrator_session(&conn, orch_session_id, Some("idle"), None);
 
         // Emit complete event
-        let _ = app.emit("orchestrator:complete", &OrchestratorEvent {
-            workspace_id: workspace_id.to_string(),
-            event_type: "complete".to_string(),
-            message: Some(assistant_msg.id),
-        });
+        let _ = app.emit(
+            "orchestrator:complete",
+            &OrchestratorEvent {
+                workspace_id: workspace_id.to_string(),
+                event_type: "complete".to_string(),
+                message: Some(assistant_msg.id),
+            },
+        );
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{api_stream_key, ApiStreamRegistry};
-
-    #[test]
-    fn test_api_stream_key() {
-        assert_eq!(api_stream_key("ws-1", "session-1"), "chef-api:ws-1:session-1");
-    }
-
-    #[tokio::test]
-    async fn test_api_stream_registry_abort() {
-        let registry = ApiStreamRegistry::default();
-        let handle = tokio::spawn(async {
-            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-        });
-
-        registry.insert("stream-1".to_string(), handle.abort_handle()).await;
-        assert_eq!(registry.len().await, 1);
-
-        assert!(registry.abort("stream-1").await);
-        assert_eq!(registry.len().await, 0);
-        assert!(handle.await.unwrap_err().is_cancelled());
-    }
-
-    #[tokio::test]
-    async fn test_api_stream_registry_replaces_existing_handle() {
-        let registry = ApiStreamRegistry::default();
-        let first = tokio::spawn(async {
-            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-        });
-        let second = tokio::spawn(async {
-            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-        });
-
-        registry.insert("stream-1".to_string(), first.abort_handle()).await;
-        registry.insert("stream-1".to_string(), second.abort_handle()).await;
-
-        assert_eq!(registry.len().await, 1);
-        assert!(first.await.unwrap_err().is_cancelled());
-
-        assert!(registry.abort("stream-1").await);
-        assert!(second.await.unwrap_err().is_cancelled());
-    }
 }
 
 /// Stream orchestrator chat via unified CLI session.
@@ -824,6 +898,7 @@ mod tests {
 /// Replaces the old `stream_via_cli` which used `CliSessionManager`.
 /// Uses `UnifiedChatSession` from the `SessionRegistry` with board
 /// context injection and retry logic for stale resume IDs.
+#[allow(clippy::too_many_arguments)]
 async fn stream_via_unified_cli(
     app: AppHandle,
     state: State<'_, AppState>,
@@ -849,6 +924,7 @@ async fn stream_via_unified_cli(
             working_dir: None,
             effort_level: None,
         };
+        let prompt_builder = ChefSession::new_cli(workspace_id.to_string(), config.clone());
 
         // Get or create session
         if !registry.has(&registry_key) {
@@ -877,19 +953,19 @@ async fn stream_via_unified_cli(
 
         // Build system prompt + board context, then send
         let (workspace, columns, tasks) = {
-            let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let conn = state
+                .db
+                .lock()
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
             let workspace = db::get_workspace(&conn, workspace_id)?;
             let columns = db::list_columns(&conn, workspace_id)?;
             let tasks = db::list_tasks(&conn, workspace_id)?;
             (workspace, columns, tasks)
         };
 
-        let system_prompt = build_cli_system_prompt(&workspace, &columns, &tasks);
+        let system_prompt = prompt_builder.build_system_prompt(&workspace, &columns, &tasks);
         session.set_system_prompt(system_prompt);
-
-        let board_context = build_board_context(&workspace, &columns, &tasks);
-        let board_context_msg = format_board_context_message(&board_context);
-        let full_message = format!("{}\n\n{}", board_context_msg, message);
+        let full_message = prompt_builder.augment_message(message, &workspace, &columns, &tasks);
 
         // Forward events to frontend
         let ws_id = workspace_id.to_string();
@@ -905,12 +981,17 @@ async fn stream_via_unified_cli(
             Ok((response, sid)) => {
                 // Check for empty response (stale resume)
                 if response.is_empty() {
-                    log::warn!("Empty CLI response — likely stale --resume, retrying without resume");
+                    log::warn!(
+                        "Empty CLI response — likely stale --resume, retrying without resume"
+                    );
                     session.set_resume_id(None);
 
                     // Clear stale cli_session_id from DB
                     {
-                        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+                        let conn = state
+                            .db
+                            .lock()
+                            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
                         let _ = db::update_chat_session_cli_id(&conn, session_id, None);
                     }
 
@@ -922,7 +1003,7 @@ async fn stream_via_unified_cli(
                             emit_orchestrator_cli_event(&app_retry, &ws_id2, event);
                         })
                         .await
-                        .map_err(|e| AppError::InvalidInput(e))?
+                        .map_err(AppError::InvalidInput)?
                 } else {
                     (response, sid)
                 }
@@ -939,20 +1020,26 @@ async fn stream_via_unified_cli(
                         emit_orchestrator_cli_event(&app_retry, &ws_id2, event);
                     })
                     .await
-                    .map_err(|e| AppError::InvalidInput(e))?
+                    .map_err(AppError::InvalidInput)?
             }
         }
     };
 
     // Save cli_session_id to database
     if let Some(cli_sid) = &captured_cli_session_id {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let _ = db::update_chat_session_cli_id(&conn, session_id, Some(cli_sid));
     }
 
     // Parse action blocks and execute tools
     {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let tool_uses = parse_cli_action_blocks(&full_response);
 
         if !tool_uses.is_empty() {
@@ -963,21 +1050,27 @@ async fn stream_via_unified_cli(
                         if tool_result.is_error {
                             log::warn!("CLI action error: {}", tool_result.content);
                         }
-                        let _ = app.emit("orchestrator:tool_result", &ToolResultPayload {
-                            workspace_id: workspace_id.to_string(),
-                            tool_use_id: tool_result.tool_use_id.clone(),
-                            result: tool_result.content.clone(),
-                            is_error: tool_result.is_error,
-                        });
+                        let _ = app.emit(
+                            "orchestrator:tool_result",
+                            &ToolResultPayload {
+                                workspace_id: workspace_id.to_string(),
+                                tool_use_id: tool_result.tool_use_id.clone(),
+                                result: tool_result.content.clone(),
+                                is_error: tool_result.is_error,
+                            },
+                        );
                     }
                 }
                 Err(e) => {
                     log::error!("CLI action execution failed: {}", e);
-                    let _ = app.emit("orchestrator:error", &OrchestratorEvent {
-                        workspace_id: workspace_id.to_string(),
-                        event_type: "warning".to_string(),
-                        message: Some(format!("Action execution failed: {}", e)),
-                    });
+                    let _ = app.emit(
+                        "orchestrator:error",
+                        &OrchestratorEvent {
+                            workspace_id: workspace_id.to_string(),
+                            event_type: "warning".to_string(),
+                            message: Some(format!("Action execution failed: {}", e)),
+                        },
+                    );
                 }
             }
         }
@@ -985,15 +1078,22 @@ async fn stream_via_unified_cli(
 
     // Store assistant message and emit completion
     {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-        let assistant_msg = db::insert_chat_message(&conn, workspace_id, session_id, "assistant", &full_response)?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let assistant_msg =
+            db::insert_chat_message(&conn, workspace_id, session_id, "assistant", &full_response)?;
         let _ = db::update_orchestrator_session(&conn, orch_session_id, Some("idle"), None);
 
-        let _ = app.emit("orchestrator:complete", &OrchestratorEvent {
-            workspace_id: workspace_id.to_string(),
-            event_type: "complete".to_string(),
-            message: Some(assistant_msg.id.clone()),
-        });
+        let _ = app.emit(
+            "orchestrator:complete",
+            &OrchestratorEvent {
+                workspace_id: workspace_id.to_string(),
+                event_type: "complete".to_string(),
+                message: Some(assistant_msg.id.clone()),
+            },
+        );
     }
 
     // Emit finish event (empty delta with finish_reason)
@@ -1024,7 +1124,10 @@ fn emit_orchestrator_cli_event(app: &AppHandle, workspace_id: &str, event: ChatE
                 },
             );
         }
-        ChatEvent::ThinkingContent { content, is_complete } => {
+        ChatEvent::ThinkingContent {
+            content,
+            is_complete,
+        } => {
             let _ = app.emit(
                 "orchestrator:thinking",
                 &ThinkingPayload {
@@ -1034,7 +1137,9 @@ fn emit_orchestrator_cli_event(app: &AppHandle, workspace_id: &str, event: ChatE
                 },
             );
         }
-        ChatEvent::ToolUse { id, name, status, .. } => {
+        ChatEvent::ToolUse {
+            id, name, status, ..
+        } => {
             let status_str = match status {
                 ToolStatus::Running => "running",
                 ToolStatus::Complete => "complete",
@@ -1051,6 +1156,63 @@ fn emit_orchestrator_cli_event(app: &AppHandle, workspace_id: &str, event: ChatE
                 },
             );
         }
-        ChatEvent::Complete | ChatEvent::SessionId(_) | ChatEvent::RawOutput(_) | ChatEvent::Unknown => {}
+        ChatEvent::Complete
+        | ChatEvent::SessionId(_)
+        | ChatEvent::RawOutput(_)
+        | ChatEvent::Unknown => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{api_stream_key, ApiStreamRegistry};
+
+    #[test]
+    fn test_api_stream_key() {
+        assert_eq!(
+            api_stream_key("ws-1", "session-1"),
+            "chef-api:ws-1:session-1"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_api_stream_registry_abort() {
+        let registry = ApiStreamRegistry::default();
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        registry
+            .insert("stream-1".to_string(), handle.abort_handle())
+            .await;
+        assert_eq!(registry.len().await, 1);
+
+        assert!(registry.abort("stream-1").await);
+        assert_eq!(registry.len().await, 0);
+        assert!(handle.await.unwrap_err().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_api_stream_registry_replaces_existing_handle() {
+        let registry = ApiStreamRegistry::default();
+        let first = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        let second = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        registry
+            .insert("stream-1".to_string(), first.abort_handle())
+            .await;
+        registry
+            .insert("stream-1".to_string(), second.abort_handle())
+            .await;
+
+        assert_eq!(registry.len().await, 1);
+        assert!(first.await.unwrap_err().is_cancelled());
+
+        assert!(registry.abort("stream-1").await);
+        assert!(second.await.unwrap_err().is_cancelled());
     }
 }

--- a/src-tauri/src/commands/orchestrator.rs
+++ b/src-tauri/src/commands/orchestrator.rs
@@ -3,6 +3,9 @@
 //! The orchestrator is a dedicated agent that interprets natural language
 //! and creates/manages tasks on the board.
 
+use std::collections::HashMap;
+
+use crate::chat::ChefSession;
 use crate::chat::events::{ChatEvent, ToolStatus};
 use crate::chat::registry::SharedSessionRegistry;
 use crate::chat::session::{SessionConfig, TransportType, UnifiedChatSession};
@@ -10,7 +13,7 @@ use crate::db::{self, AppState, ChatMessage, ChatSession, OrchestratorSession, C
 use crate::error::AppError;
 use crate::llm::{
     AnthropicClient, calculate_cost, resolve_model_id,
-    build_system_prompt, build_cli_system_prompt, build_board_context, format_board_context_message,
+    build_cli_system_prompt, build_board_context, format_board_context_message,
     orchestrator_tools, tools_to_api_format, execute_tools, parse_cli_action_blocks,
 };
 use crate::llm::types::{LlmRequest, Message};
@@ -493,6 +496,16 @@ async fn stream_via_api(
 ) -> Result<(), AppError> {
     // Resolve model alias to full API ID (e.g., "sonnet" -> "claude-sonnet-4-6-20260217")
     let model_id = resolve_model_id(model);
+    let chef = ChefSession::new_api(
+        workspace_id.to_string(),
+        SessionConfig {
+            cli_path: String::new(),
+            model: model.to_string(),
+            system_prompt: String::new(),
+            working_dir: None,
+            effort_level: None,
+        },
+    );
 
     // Get workspace context for system prompt
     let (workspace, columns, tasks) = {
@@ -504,9 +517,7 @@ async fn stream_via_api(
     };
 
     // Build system prompt with board context
-    let system_prompt = build_system_prompt(&workspace, &columns);
-    let board_context = build_board_context(&workspace, &columns, &tasks);
-    let board_context_msg = format_board_context_message(&board_context);
+    let system_prompt = chef.build_system_prompt(&workspace, &columns, &tasks);
 
     // Build messages from history, injecting board context into the last user message
     let mut messages: Vec<Message> = Vec::new();
@@ -521,7 +532,7 @@ async fn stream_via_api(
         if m.role == "user" && i == history_len - 1 {
             messages.push(Message {
                 role: m.role.clone(),
-                content: format!("{}\n\n{}", board_context_msg, m.content),
+                content: chef.augment_message(&m.content, &workspace, &columns, &tasks),
             });
         } else {
             messages.push(Message {
@@ -552,6 +563,7 @@ async fn stream_via_api(
     let client = AnthropicClient::new(api_key.to_string());
     let app_clone = app.clone();
     let workspace_id_clone = workspace_id.to_string();
+    let mut pending_tool_calls: HashMap<String, (String, serde_json::Value)> = HashMap::new();
 
     let stream_handle = tokio::spawn(async move {
         client.stream_chat(request, tx).await
@@ -559,10 +571,23 @@ async fn stream_via_api(
 
     // Forward chunks to frontend
     while let Some(chunk) = rx.recv().await {
-        let tool_use_payload = chunk.tool_use.as_ref().map(|tu| ToolUsePayload {
-            id: tu.id.clone(),
-            name: tu.name.clone(),
-            input: tu.input.clone(),
+        let tool_use_payload = chunk.tool_use.as_ref().map(|tu| {
+            pending_tool_calls.insert(tu.id.clone(), (tu.name.clone(), tu.input.clone()));
+
+            let _ = app_clone.emit("orchestrator:tool_call", &ToolCallPayload {
+                workspace_id: workspace_id_clone.clone(),
+                tool_id: tu.id.clone(),
+                tool_name: tu.name.clone(),
+                status: "running".to_string(),
+                input: Some(tu.input.clone()),
+                result: None,
+            });
+
+            ToolUsePayload {
+                id: tu.id.clone(),
+                name: tu.name.clone(),
+                input: tu.input.clone(),
+            }
         });
 
         let _ = app_clone.emit("orchestrator:stream", &StreamChunkPayload {
@@ -597,11 +622,25 @@ async fn stream_via_api(
 
         // Emit tool results to frontend
         for result in &execution_result.results {
+            let (tool_name, tool_input) = pending_tool_calls
+                .get(&result.tool_use_id)
+                .cloned()
+                .unwrap_or_else(|| ("unknown".to_string(), serde_json::Value::Null));
+
             let _ = app.emit("orchestrator:tool_result", &ToolResultPayload {
                 workspace_id: workspace_id.to_string(),
                 tool_use_id: result.tool_use_id.clone(),
                 result: result.content.clone(),
                 is_error: result.is_error,
+            });
+
+            let _ = app.emit("orchestrator:tool_call", &ToolCallPayload {
+                workspace_id: workspace_id.to_string(),
+                tool_id: result.tool_use_id.clone(),
+                tool_name,
+                status: if result.is_error { "error" } else { "complete" }.to_string(),
+                input: if tool_input.is_null() { None } else { Some(tool_input) },
+                result: Some(result.content.clone()),
             });
         }
 
@@ -717,7 +756,7 @@ async fn stream_via_unified_cli(
             (workspace, columns, tasks)
         };
 
-        let system_prompt = build_cli_system_prompt(&workspace, &columns);
+        let system_prompt = build_cli_system_prompt(&workspace, &columns, &tasks);
         session.set_system_prompt(system_prompt);
 
         let board_context = build_board_context(&workspace, &columns, &tasks);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub mod whisper;
 use commands::voice::RecorderState;
 use db::AppState;
 use chat::registry::{new_shared_session_registry, start_idle_sweep};
+use commands::orchestrator::ApiStreamRegistry;
 use tauri::Manager;
 #[cfg(feature = "voice")]
 use whisper::AudioRecorder;
@@ -61,6 +62,7 @@ pub fn run() {
     };
 
     let session_registry = new_shared_session_registry();
+    let api_stream_registry = ApiStreamRegistry::default();
     #[cfg(feature = "voice")]
     let recorder_state = RecorderState(Mutex::new(AudioRecorder::new()));
 
@@ -73,7 +75,8 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .manage(state)
-        .manage(session_registry);
+        .manage(session_registry)
+        .manage(api_stream_registry);
 
     #[cfg(feature = "webdriver")]
     {

--- a/src-tauri/src/llm/context.rs
+++ b/src-tauri/src/llm/context.rs
@@ -6,15 +6,23 @@ use crate::db::{Column, Task, Workspace};
 use serde_json::json;
 use std::collections::HashMap;
 
+fn ordered_columns(columns: &[Column]) -> Vec<&Column> {
+    let mut ordered_columns = columns.iter().collect::<Vec<_>>();
+    ordered_columns.sort_by(|left, right| {
+        left.position
+            .cmp(&right.position)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    ordered_columns
+}
+
 /// Build the system prompt for the orchestrator (API mode with native tools)
-pub fn build_system_prompt(
-    workspace: &Workspace,
-    columns: &[Column],
-    tasks: &[Task],
-) -> String {
-    let column_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+pub fn build_system_prompt(workspace: &Workspace, columns: &[Column], tasks: &[Task]) -> String {
+    let ordered_columns = ordered_columns(columns);
+    let column_names: Vec<&str> = ordered_columns.iter().map(|c| c.name.as_str()).collect();
     let columns_str = column_names.join(", ");
-    let tasks_str = format_task_snapshot(columns, tasks);
+    let tasks_str = format_task_snapshot(&ordered_columns, tasks);
 
     format!(
         r#"You are the orchestrator for "{workspace_name}", a Kanban board.
@@ -45,9 +53,10 @@ pub fn build_cli_system_prompt(
     columns: &[Column],
     tasks: &[Task],
 ) -> String {
-    let column_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+    let ordered_columns = ordered_columns(columns);
+    let column_names: Vec<&str> = ordered_columns.iter().map(|c| c.name.as_str()).collect();
     let columns_str = column_names.join(", ");
-    let tasks_str = format_task_snapshot(columns, tasks);
+    let tasks_str = format_task_snapshot(&ordered_columns, tasks);
 
     format!(
         r#"You are the orchestrator for "{workspace_name}", a Kanban board.
@@ -142,7 +151,7 @@ pub fn format_board_context_message(context: &serde_json::Value) -> String {
     )
 }
 
-fn format_task_snapshot(columns: &[Column], tasks: &[Task]) -> String {
+fn format_task_snapshot(columns: &[&Column], tasks: &[Task]) -> String {
     if tasks.is_empty() {
         return "- No tasks on the board.".to_string();
     }
@@ -160,7 +169,15 @@ fn format_task_snapshot(columns: &[Column], tasks: &[Task]) -> String {
         lines.push(format!("- {}:", column.name));
         match tasks_by_column.get(column.id.as_str()) {
             Some(column_tasks) if !column_tasks.is_empty() => {
-                for task in column_tasks {
+                let mut ordered_tasks = column_tasks.clone();
+                ordered_tasks.sort_by(|left, right| {
+                    left.position
+                        .cmp(&right.position)
+                        .then_with(|| left.title.cmp(&right.title))
+                        .then_with(|| left.id.cmp(&right.id))
+                });
+
+                for task in ordered_tasks {
                     let description = task
                         .description
                         .as_deref()
@@ -168,7 +185,7 @@ fn format_task_snapshot(columns: &[Column], tasks: &[Task]) -> String {
                         .filter(|d| !d.is_empty());
                     let detail = description
                         .map(|d| truncate_for_prompt(d, 120))
-                        .map(|d| format!(" — {}", d))
+                        .map(|d| format!(" - {}", d))
                         .unwrap_or_default();
                     lines.push(format!("  - [{}] {}{}", task.id, task.title, detail));
                 }
@@ -253,55 +270,53 @@ mod tests {
     }
 
     fn mock_tasks() -> Vec<Task> {
-        vec![
-            Task {
-                id: "task-1".to_string(),
-                workspace_id: "ws-1".to_string(),
-                column_id: "col-1".to_string(),
-                title: "Fix login bug".to_string(),
-                description: Some("Users can't log in".to_string()),
-                position: 0,
-                priority: "medium".to_string(),
-                agent_mode: None,
-                branch_name: None,
-                files_touched: "[]".to_string(),
-                checklist: None,
-                pipeline_state: "idle".to_string(),
-                pipeline_triggered_at: None,
-                pipeline_error: None,
-                retry_count: 0,
-                model: None,
-                agent_session_id: None,
-                last_script_exit_code: None,
-                review_status: None,
-                pr_number: None,
-                pr_url: None,
-                siege_iteration: 0,
-                siege_active: false,
-                siege_max_iterations: 5,
-                siege_last_checked: None,
-                pr_mergeable: None,
-                pr_ci_status: None,
-                pr_review_decision: None,
-                pr_comment_count: 0,
-                pr_is_draft: false,
-                pr_labels: "[]".to_string(),
-                pr_last_fetched: None,
-                pr_head_sha: None,
-                notify_stakeholders: None,
-                notification_sent_at: None,
-                trigger_overrides: None,
-                trigger_prompt: None,
-                last_output: None,
-                dependencies: None,
-                blocked: false,
-                worktree_path: None,
-                agent_status: None,
-                queued_at: None,
-                created_at: "2024-01-01".to_string(),
-                updated_at: "2024-01-01".to_string(),
-            },
-        ]
+        vec![Task {
+            id: "task-1".to_string(),
+            workspace_id: "ws-1".to_string(),
+            column_id: "col-1".to_string(),
+            title: "Fix login bug".to_string(),
+            description: Some("Users can't log in".to_string()),
+            position: 0,
+            priority: "medium".to_string(),
+            agent_mode: None,
+            branch_name: None,
+            files_touched: "[]".to_string(),
+            checklist: None,
+            pipeline_state: "idle".to_string(),
+            pipeline_triggered_at: None,
+            pipeline_error: None,
+            retry_count: 0,
+            model: None,
+            agent_session_id: None,
+            last_script_exit_code: None,
+            review_status: None,
+            pr_number: None,
+            pr_url: None,
+            siege_iteration: 0,
+            siege_active: false,
+            siege_max_iterations: 5,
+            siege_last_checked: None,
+            pr_mergeable: None,
+            pr_ci_status: None,
+            pr_review_decision: None,
+            pr_comment_count: 0,
+            pr_is_draft: false,
+            pr_labels: "[]".to_string(),
+            pr_last_fetched: None,
+            pr_head_sha: None,
+            notify_stakeholders: None,
+            notification_sent_at: None,
+            trigger_overrides: None,
+            trigger_prompt: None,
+            last_output: None,
+            dependencies: None,
+            blocked: false,
+            worktree_path: None,
+            agent_status: None,
+            queued_at: None,
+            created_at: "2024-01-01".to_string(),
+            updated_at: "2024-01-01".to_string(),
+        }]
     }
 
     #[test]
@@ -342,8 +357,14 @@ mod tests {
 
         let col_with_triggers = &context["columns"][1];
         assert_eq!(col_with_triggers["name"], "In Progress");
-        assert_eq!(col_with_triggers["triggers"]["on_entry"]["type"], "spawn_cli");
-        assert_eq!(col_with_triggers["triggers"]["exit_criteria"]["auto_advance"], true);
+        assert_eq!(
+            col_with_triggers["triggers"]["on_entry"]["type"],
+            "spawn_cli"
+        );
+        assert_eq!(
+            col_with_triggers["triggers"]["exit_criteria"]["auto_advance"],
+            true
+        );
 
         // Column without triggers should not have triggers field
         assert!(context["columns"][0]["triggers"].is_null());
@@ -360,5 +381,37 @@ mod tests {
 
         let cli_prompt = build_cli_system_prompt(&workspace, &columns, &tasks);
         assert!(cli_prompt.contains("configure_triggers"));
+    }
+
+    #[test]
+    fn test_task_snapshot_is_ordered_by_column_and_position() {
+        let workspace = mock_workspace();
+        let mut columns = mock_columns();
+        columns.swap(0, 1);
+
+        let mut tasks = vec![
+            Task {
+                id: "task-2".to_string(),
+                title: "Second task".to_string(),
+                position: 2,
+                ..mock_tasks()[0].clone()
+            },
+            Task {
+                id: "task-0".to_string(),
+                title: "First task".to_string(),
+                position: 0,
+                ..mock_tasks()[0].clone()
+            },
+        ];
+        tasks[1].description = Some("Needs sorting".to_string());
+
+        let prompt = build_system_prompt(&workspace, &columns, &tasks);
+        let backlog_index = prompt.find("- Backlog:").unwrap();
+        let in_progress_index = prompt.find("- In Progress:").unwrap();
+        let first_task_index = prompt.find("[task-0] First task - Needs sorting").unwrap();
+        let second_task_index = prompt.find("[task-2] Second task").unwrap();
+
+        assert!(backlog_index < in_progress_index);
+        assert!(first_task_index < second_task_index);
     }
 }

--- a/src-tauri/src/llm/context.rs
+++ b/src-tauri/src/llm/context.rs
@@ -4,16 +4,25 @@
 
 use crate::db::{Column, Task, Workspace};
 use serde_json::json;
+use std::collections::HashMap;
 
 /// Build the system prompt for the orchestrator (API mode with native tools)
-pub fn build_system_prompt(workspace: &Workspace, columns: &[Column]) -> String {
+pub fn build_system_prompt(
+    workspace: &Workspace,
+    columns: &[Column],
+    tasks: &[Task],
+) -> String {
     let column_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
     let columns_str = column_names.join(", ");
+    let tasks_str = format_task_snapshot(columns, tasks);
 
     format!(
         r#"You are the orchestrator for "{workspace_name}", a Kanban board.
 
 Columns: {columns}
+
+Current tasks:
+{tasks}
 
 ## Style
 - Be concise. Short answers.
@@ -25,19 +34,28 @@ Use the provided tools to modify the board. Briefly confirm actions taken.
 
 You can also configure column automation triggers using the configure_triggers tool."#,
         workspace_name = workspace.name,
-        columns = columns_str
+        columns = columns_str,
+        tasks = tasks_str
     )
 }
 
 /// Build the system prompt for CLI mode (with embedded action blocks)
-pub fn build_cli_system_prompt(workspace: &Workspace, columns: &[Column]) -> String {
+pub fn build_cli_system_prompt(
+    workspace: &Workspace,
+    columns: &[Column],
+    tasks: &[Task],
+) -> String {
     let column_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
     let columns_str = column_names.join(", ");
+    let tasks_str = format_task_snapshot(columns, tasks);
 
     format!(
         r#"You are the orchestrator for "{workspace_name}", a Kanban board.
 
 Columns: {columns}
+
+Current tasks:
+{tasks}
 
 ## Style
 - Be concise. Short answers.
@@ -69,7 +87,8 @@ Use `"__LAST__"` as task_id to reference the last created task (e.g. create_task
 Put all actions in a SINGLE action block — do not output multiple blocks.
 Briefly confirm actions taken."#,
         workspace_name = workspace.name,
-        columns = columns_str
+        columns = columns_str,
+        tasks = tasks_str
     )
 }
 
@@ -121,6 +140,52 @@ pub fn format_board_context_message(context: &serde_json::Value) -> String {
         "Current board state:\n```json\n{}\n```",
         serde_json::to_string_pretty(context).unwrap_or_else(|_| "{}".to_string())
     )
+}
+
+fn format_task_snapshot(columns: &[Column], tasks: &[Task]) -> String {
+    if tasks.is_empty() {
+        return "- No tasks on the board.".to_string();
+    }
+
+    let mut tasks_by_column: HashMap<&str, Vec<&Task>> = HashMap::new();
+    for task in tasks {
+        tasks_by_column
+            .entry(task.column_id.as_str())
+            .or_default()
+            .push(task);
+    }
+
+    let mut lines = Vec::new();
+    for column in columns {
+        lines.push(format!("- {}:", column.name));
+        match tasks_by_column.get(column.id.as_str()) {
+            Some(column_tasks) if !column_tasks.is_empty() => {
+                for task in column_tasks {
+                    let description = task
+                        .description
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|d| !d.is_empty());
+                    let detail = description
+                        .map(|d| truncate_for_prompt(d, 120))
+                        .map(|d| format!(" — {}", d))
+                        .unwrap_or_default();
+                    lines.push(format!("  - [{}] {}{}", task.id, task.title, detail));
+                }
+            }
+            _ => lines.push("  - (empty)".to_string()),
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn truncate_for_prompt(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+
+    value.chars().take(max_chars).collect::<String>() + "..."
 }
 
 #[cfg(test)]
@@ -243,11 +308,13 @@ mod tests {
     fn test_build_system_prompt() {
         let workspace = mock_workspace();
         let columns = mock_columns();
-        let prompt = build_system_prompt(&workspace, &columns);
+        let tasks = mock_tasks();
+        let prompt = build_system_prompt(&workspace, &columns, &tasks);
 
         assert!(prompt.contains("Test Project"));
         assert!(prompt.contains("Backlog, In Progress, Done"));
         assert!(prompt.contains("orchestrator"));
+        assert!(prompt.contains("[task-1] Fix login bug"));
     }
 
     #[test]
@@ -286,11 +353,12 @@ mod tests {
     fn test_system_prompt_mentions_configure_triggers() {
         let workspace = mock_workspace();
         let columns = mock_columns();
+        let tasks = mock_tasks();
 
-        let api_prompt = build_system_prompt(&workspace, &columns);
+        let api_prompt = build_system_prompt(&workspace, &columns, &tasks);
         assert!(api_prompt.contains("configure_triggers"));
 
-        let cli_prompt = build_cli_system_prompt(&workspace, &columns);
+        let cli_prompt = build_cli_system_prompt(&workspace, &columns, &tasks);
         assert!(cli_prompt.contains("configure_triggers"));
     }
 }

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useEffect } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { IconButton } from '@/components/shared/icon-button'
 import { shouldEnableColumnShortcuts } from './column-shortcuts'
@@ -30,7 +30,6 @@ type ColumnHeaderProps = {
   onCancelQueue?: () => void
 }
 
-// Icon components
 function getIcon(icon: string) {
   switch (icon) {
     case 'inbox':
@@ -78,7 +77,7 @@ function getIcon(icon: string) {
           <path fillRule="evenodd" d="M13 6H3v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V6ZM5.72 7.47a.75.75 0 0 1 1.06 0L8 8.69l1.22-1.22a.75.75 0 1 1 1.06 1.06l-1.75 1.75a.75.75 0 0 1-1.06 0L5.72 8.53a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
         </svg>
       )
-    default: // list
+    default:
       return (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
           <path fillRule="evenodd" d="M2.5 3.5c0-.56.44-1 1-1h9a1 1 0 1 1 0 2h-9a1 1 0 0 1-1-1ZM2.5 8c0-.56.44-1 1-1h9a1 1 0 1 1 0 2h-9a1 1 0 0 1-1-1ZM3.5 11.5a1 1 0 1 0 0 2h9a1 1 0 1 0 0-2h-9Z" clipRule="evenodd" />
@@ -108,21 +107,20 @@ export const ColumnHeader = memo(function ColumnHeader({
   const menuRef = useRef<HTMLDivElement>(null)
   const showShortcutHint = shouldEnableColumnShortcuts(columnCount)
 
-  // Close menu when clicking outside
   useEffect(() => {
     if (!showMenu) return
+
     const handleClick = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setShowMenu(false)
       }
     }
-    document.addEventListener('mousedown', handleClick)
-    return () => { document.removeEventListener('mousedown', handleClick); }
-  }, [showMenu])
 
-  const handleRunAllClick = () => {
-    setShowConfirm(true)
-  }
+    document.addEventListener('mousedown', handleClick)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+    }
+  }, [showMenu])
 
   const handleConfirmRunAll = () => {
     setShowConfirm(false)
@@ -139,9 +137,7 @@ export const ColumnHeader = memo(function ColumnHeader({
           {getIcon(icon)}
         </span>
         <h3 className="flex min-w-0 items-center text-xs font-semibold uppercase tracking-wider text-text-secondary">
-          <span className="truncate">
-            {name}
-          </span>
+          <span className="truncate">{name}</span>
           {showShortcutHint && (
             <kbd className="ml-1 rounded bg-muted/30 px-1 font-mono text-xs text-muted-foreground opacity-50">
               {columnIndex + 1}
@@ -161,7 +157,6 @@ export const ColumnHeader = memo(function ColumnHeader({
           </span>
         )}
 
-        {/* Batch queue progress badge */}
         {batchQueue && (
           <span className="rounded bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium text-accent">
             Queued: {batchQueue.completed}/{batchQueue.total}
@@ -169,7 +164,6 @@ export const ColumnHeader = memo(function ColumnHeader({
         )}
 
         <div className="ml-auto flex items-center gap-0.5">
-          {/* Run All button (backlog only, when tasks exist and not already queuing) */}
           {isBacklog && taskCount > 0 && !batchQueue && (
             <IconButton
               icon={
@@ -177,54 +171,54 @@ export const ColumnHeader = memo(function ColumnHeader({
                   <path d="M2 4.5A2.5 2.5 0 0 1 4.5 2h2.879a2.5 2.5 0 0 1 1.767.732l4.122 4.122a2.5 2.5 0 0 1 0 3.536l-2.879 2.878a2.5 2.5 0 0 1-3.536 0L2.731 9.146A2.5 2.5 0 0 1 2 7.38V4.5ZM5.5 5a.5.5 0 1 0 0 1 .5.5 0 0 0 0-1Z" />
                 </svg>
               }
-              onClick={handleRunAllClick}
+              onClick={() => { setShowConfirm(true) }}
               tooltip="Run All"
               tooltipSide="bottom"
             />
           )}
 
-        {/* Cancel queue button */}
-        {batchQueue && (
+          {/* Cancel queue button */}
+          {batchQueue && (
+            <IconButton
+              icon={
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+                  <path fillRule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14Zm2.78-4.22a.75.75 0 0 1-1.06 0L8 9.06l-1.72 1.72a.75.75 0 1 1-1.06-1.06L6.94 8 5.22 6.28a.75.75 0 0 1 1.06-1.06L8 6.94l1.72-1.72a.75.75 0 1 1 1.06 1.06L9.06 8l1.72 1.72a.75.75 0 0 1 0 1.06Z" clipRule="evenodd" />
+                </svg>
+              }
+              onClick={onCancelQueue}
+              tooltip="Cancel queue"
+              tooltipSide="bottom"
+            />
+          )}
+
+          {/* Add task button */}
           <IconButton
             icon={
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
-                <path fillRule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14Zm2.78-4.22a.75.75 0 0 1-1.06 0L8 9.06l-1.72 1.72a.75.75 0 1 1-1.06-1.06L6.94 8 5.22 6.28a.75.75 0 0 1 1.06-1.06L8 6.94l1.72-1.72a.75.75 0 1 1 1.06 1.06L9.06 8l1.72 1.72a.75.75 0 0 1 0 1.06Z" clipRule="evenodd" />
+                <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
               </svg>
             }
-            onClick={onCancelQueue}
-            tooltip="Cancel queue"
-            tooltipSide="bottom"
-          />
-        )}
-
-        {/* Add task button */}
-        <IconButton
-          icon={
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
-              <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
-            </svg>
-          }
-          onClick={onAddTask}
-          tooltip="Add task"
-          tooltipSide="bottom"
-        />
-
-        {/* Menu button */}
-        <div className="relative" ref={menuRef}>
-          <IconButton
-            icon={
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-4 w-4">
-                <path d="M8 2a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM8 6.5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM9.5 12.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0Z" />
-              </svg>
-            }
-            onClick={() => { setShowMenu(!showMenu); }}
-            tooltip="Column options"
+            onClick={onAddTask}
+            tooltip="Add task"
             tooltipSide="bottom"
           />
 
-          <AnimatePresence>
-            {showMenu && (
-              <motion.div
+          {/* Menu button */}
+          <div className="relative" ref={menuRef}>
+            <IconButton
+              icon={
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-4 w-4">
+                  <path d="M8 2a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM8 6.5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM9.5 12.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0Z" />
+                </svg>
+              }
+              onClick={() => { setShowMenu(!showMenu) }}
+              tooltip="Column options"
+              tooltipSide="bottom"
+            />
+
+            <AnimatePresence>
+              {showMenu && (
+                <motion.div
                   initial={{ opacity: 0, scale: 0.95, y: -5 }}
                   animate={{ opacity: 1, scale: 1, y: 0 }}
                   exit={{ opacity: 0, scale: 0.95, y: -5 }}
@@ -255,23 +249,22 @@ export const ColumnHeader = memo(function ColumnHeader({
                     </svg>
                     Delete
                   </button>
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
         </div>
       </div>
 
-      {/* Run All confirmation dialog */}
       {showConfirm && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => { setShowConfirm(false); }}
+          onClick={() => { setShowConfirm(false) }}
         >
           <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
-            onClick={(e) => { e.stopPropagation(); }}
+            onClick={(e) => { e.stopPropagation() }}
             className="w-full max-w-sm rounded border border-border-default bg-surface p-6 shadow-xl"
           >
             <h3 className="mb-2 text-lg font-semibold text-text-primary">
@@ -282,7 +275,7 @@ export const ColumnHeader = memo(function ColumnHeader({
             </p>
             <div className="flex justify-end gap-2">
               <button
-                onClick={() => { setShowConfirm(false); }}
+                onClick={() => { setShowConfirm(false) }}
                 className="rounded px-4 py-2 text-sm text-text-secondary hover:bg-surface-hover"
               >
                 Cancel

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -18,6 +18,8 @@ type ColumnProps = {
   column: ColumnType
   columnIndex: number
   columnCount: number
+  autoOpenConfig?: boolean
+  onConfigOpened?: () => void
 }
 
 type BatchQueueLocalState = {
@@ -31,13 +33,15 @@ export const Column = memo(function Column({
   column,
   columnIndex,
   columnCount,
+  autoOpenConfig = false,
+  onConfigOpened,
 }: ColumnProps) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
   const allTasks = useTaskStore((s) => s.tasks)
   const addTask = useTaskStore((s) => s.add)
   const remove = useColumnStore((s) => s.remove)
   const getScriptName = useScriptStore((s) => s.getScriptName)
-  const isBacklog = columnIndex === 0
+  const isBacklog = columnIndex === 0 || column.name.toLowerCase() === 'backlog'
 
   // Memoize filtered tasks to prevent infinite loops
   const tasks = useMemo(

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -8,7 +8,11 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
-import { SortableContext, horizontalListSortingStrategy, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
 import { useColumnStore } from '@/stores/column-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -36,11 +40,22 @@ export function Board() {
   const tasks = useTaskStore((s) => s.tasks)
   const loadScripts = useScriptStore((s) => s.load)
 
-  const handleAddColumn = useCallback(() => {
+  const [newColumnId, setNewColumnId] = useState<string | null>(null)
+
+  const handleAddColumn = useCallback(async () => {
     if (!activeWorkspaceId) return
+
     const name = `Column ${String(columns.length + 1)}`
-    void addColumn(activeWorkspaceId, name)
+    try {
+      const col = await addColumn(activeWorkspaceId, name)
+      setNewColumnId(col.id)
+    } catch (error) {
+      console.error('[Board] Failed to add column:', error)
+    }
   }, [activeWorkspaceId, columns.length, addColumn])
+  const handleConfigOpened = useCallback(() => {
+    setNewColumnId(null)
+  }, [])
 
   const { registerCard, positions } = useCardPositionProvider()
   const { dragState, handlePointerDown: onDepDragStart } = useDepDrag(tasks, positions)
@@ -55,9 +70,7 @@ export function Board() {
     collapseTask()
   }, [closeChat, collapseTask])
 
-  const sortedColumns = columns
-    .filter((c) => c.visible)
-    .sort((a, b) => a.position - b.position)
+  const sortedColumns = columns.filter((c) => c.visible).sort((a, b) => a.position - b.position)
   const columnIds = sortedColumns.map((c) => c.id)
 
   const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd()
@@ -94,69 +107,90 @@ export function Board() {
 
   return (
     <CardPositionContext.Provider value={{ registerCard, positions }}>
-    <DepDragContext.Provider value={{ onDepDragStart, isDraggingDep: !!dragState, hoveredTaskId, setHoveredTaskId }}>
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCorners}
-        onDragStart={(e) => { setHoveredTaskId(null); collapseTask(); onDragStart(e) }}
-        onDragOver={onDragOver}
-        onDragEnd={onDragEnd}
+      <DepDragContext.Provider
+        value={{ onDepDragStart, isDraggingDep: !!dragState, hoveredTaskId, setHoveredTaskId }}
       >
-        <div className="flex h-full" data-board-container>
-          {/* Board + orchestrator panel (left side, shrinks when task panel open) */}
-          <div className="flex flex-1 flex-col overflow-hidden">
-            <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
-              <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
-                {sortedColumns.map((col, index) => (
-                  <Column
-                    key={col.id}
-                    column={col}
-                    columnIndex={index}
-                    columnCount={sortedColumns.length}
-                    autoOpenConfig={col.id === newColumnId}
-                    onConfigOpened={() => { setNewColumnId(null) }}
-                  />
-                ))}
-              </SortableContext>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCorners}
+          onDragStart={(e) => {
+            setHoveredTaskId(null)
+            collapseTask()
+            onDragStart(e)
+          }}
+          onDragOver={onDragOver}
+          onDragEnd={onDragEnd}
+        >
+          <div className="flex h-full" data-board-container>
+            {/* Board + orchestrator panel (left side, shrinks when task panel open) */}
+            <div className="flex flex-1 flex-col overflow-hidden">
+              <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
+                <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
+                  {sortedColumns.map((col, index) => (
+                    <Column
+                      key={col.id}
+                      column={col}
+                      columnIndex={index}
+                      columnCount={sortedColumns.length}
+                      autoOpenConfig={col.id === newColumnId}
+                      onConfigOpened={handleConfigOpened}
+                    />
+                  ))}
+                </SortableContext>
 
-              {/* Add column button */}
-              {!isChatOpen && (
-                <button
-                  onClick={handleAddColumn}
-                  className="group flex h-full w-[280px] min-w-[200px] shrink-0 flex-col items-center justify-center gap-2 border-r border-dashed border-border-default bg-surface/10 text-text-secondary/40 transition-all hover:border-accent/50 hover:bg-accent/10 hover:text-accent"
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-8 w-8">
-                    <path d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4M9 3v18M9 3h6m-6 18h6m0-18h4a2 2 0 0 1 2 2v6m-6-8v10" strokeLinecap="round"/>
-                    <path d="M19 15v3m0 3v-3m0 0h-3m3 0h3" strokeLinecap="round"/>
-                  </svg>
-                  <span className="text-xs font-medium">Add Column</span>
-                </button>
+                {/* Add column button */}
+                {!isChatOpen && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void handleAddColumn()
+                    }}
+                    className="group flex h-full w-[280px] min-w-[200px] shrink-0 flex-col items-center justify-center gap-2 border-r border-dashed border-border-default bg-surface/10 text-text-secondary/40 transition-all hover:border-accent/50 hover:bg-accent/10 hover:text-accent"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      className="h-8 w-8"
+                    >
+                      <path
+                        d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4M9 3v18M9 3h6m-6 18h6m0-18h4a2 2 0 0 1 2 2v6m-6-8v10"
+                        strokeLinecap="round"
+                      />
+                      <path d="M19 15v3m0 3v-3m0 0h-3m3 0h3" strokeLinecap="round" />
+                    </svg>
+                    <span className="text-xs font-medium">Add Column</span>
+                  </button>
+                )}
+
+                {/* Dependency lines overlay */}
+                <DependencyLines
+                  tasks={tasks}
+                  positions={positions}
+                  hoveredTaskId={hoveredTaskId}
+                />
+                {dragState && <DepDragPreview dragState={dragState} positions={positions} />}
+              </div>
+
+              {/* Orchestrator panel - bottom dock */}
+              {activeWorkspaceId && panelDock === 'bottom' && (
+                <OrchestratorPanel workspaceId={activeWorkspaceId} />
               )}
-
-              {/* Dependency lines overlay */}
-              <DependencyLines tasks={tasks} positions={positions} hoveredTaskId={hoveredTaskId} />
-              {dragState && <DepDragPreview dragState={dragState} positions={positions} />}
             </div>
 
-            {/* Orchestrator panel - bottom dock */}
-            {activeWorkspaceId && panelDock === 'bottom' && (
+            {/* Orchestrator panel - right dock */}
+            {activeWorkspaceId && panelDock === 'right' && (
               <OrchestratorPanel workspaceId={activeWorkspaceId} />
             )}
+
+            {/* Task side panel (slides in from right, board stays visible) */}
+            <TaskSidePanel taskId={activeTaskId} onClose={handleCloseAll} />
           </div>
-
-          {/* Orchestrator panel - right dock */}
-          {activeWorkspaceId && panelDock === 'right' && (
-            <OrchestratorPanel workspaceId={activeWorkspaceId} />
-          )}
-
-          {/* Task side panel (slides in from right, board stays visible) */}
-          <TaskSidePanel taskId={activeTaskId} onClose={handleCloseAll} />
-        </div>
-        <DragOverlay dropAnimation={null}>
-          {overlayContent}
-        </DragOverlay>
-      </DndContext>
-    </DepDragContext.Provider>
+          <DragOverlay dropAnimation={null}>{overlayContent}</DragOverlay>
+        </DndContext>
+      </DepDragContext.Provider>
     </CardPositionContext.Provider>
   )
 }

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -113,6 +113,8 @@ export function Board() {
                     column={col}
                     columnIndex={index}
                     columnCount={sortedColumns.length}
+                    autoOpenConfig={col.id === newColumnId}
+                    onConfigOpened={() => { setNewColumnId(null) }}
                   />
                 ))}
               </SortableContext>

--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import {
   DndContext,
@@ -22,9 +22,8 @@ import { useAttentionStore } from '@/stores/attention-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useChecklistStore } from '@/stores/checklist-store'
 import { Tooltip } from '@/components/shared/tooltip'
+import { useSwipeNavigation } from '@/hooks/use-swipe'
 import type { Workspace } from '@/types'
-import { AddWorkspaceDialog } from './add-workspace-dialog'
-import { useTabBarNavigation } from './use-tab-bar-navigation'
 
 type TabProps = {
   workspace: Workspace

--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import {
   DndContext,
@@ -24,6 +24,7 @@ import { useChecklistStore } from '@/stores/checklist-store'
 import { Tooltip } from '@/components/shared/tooltip'
 import { useSwipeNavigation } from '@/hooks/use-swipe'
 import type { Workspace } from '@/types'
+import { AddWorkspaceDialog } from './add-workspace-dialog'
 
 type TabProps = {
   workspace: Workspace

--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -1,27 +1,27 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { buildPromptWithAttachments } from '@/types'
 import { thinkingToEffort } from '@/components/shared/thinking-utils'
 import { useTaskStore } from '@/stores/task-store'
 import { useSettingsStore } from '@/stores/settings-store'
-import { useOrchestratorSessions } from '@/hooks/use-orchestrator-sessions'
-import { useChatSession } from '@/hooks/chat-session'
 import { useCliPath } from '@/hooks/use-cli-path'
+import { useChatSession } from '@/hooks/chat-session'
+import { useOrchestratorSessions } from '@/hooks/use-orchestrator-sessions'
+import { ResizeHandle } from '@/components/shared/resize-handle'
 import { useOrchestratorPanelLayout } from './use-orchestrator-panel-layout'
 import { useOrchestratorTaskRefresh } from './use-orchestrator-task-refresh'
-import { ResizeHandle } from '@/components/shared/resize-handle'
+import { ChatErrorBoundary } from './chat-error-boundary'
 import { ChatHistory } from './chat-history'
 import { PanelSidebar } from './panel-sidebar'
 import { PipelineDashboard } from './pipeline-dashboard'
-import { ChatErrorBoundary } from './chat-error-boundary'
 import {
+  ChatInput,
+  CliDetectingBanner,
   ErrorBanner,
   FailedMessageBanner,
-  CliDetectingBanner,
-  ChatInput,
-  type ChatInputMessage,
   mapMessages,
   mapToolCalls,
+  type ChatInputMessage,
 } from './shared'
 
 type OrchestratorPanelProps = {
@@ -34,6 +34,15 @@ const COLLAPSED_HEIGHT = 40
 
 export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
   const loadTasks = useTaskStore((s) => s.load)
+  const settings = useSettingsStore((s) => s.global)
+  const anthropicProvider = settings.model.providers.find((p) => p.id === 'anthropic')
+  const connectionMode = anthropicProvider?.connectionMode ?? 'cli'
+  const apiKeyEnvVar = anthropicProvider?.apiKeyEnvVar || 'ANTHROPIC_API_KEY'
+  const apiKey = settings.agent.envVars[apiKeyEnvVar] || undefined
+  const { cliPath, isDetecting: cliDetecting, detectionError: cliDetectionError } = useCliPath()
+  const [sidebarMode, setSidebarMode] = useState<SidebarMode>(null)
+  const [localError, setLocalError] = useState<string | null>(null)
+
   const {
     panelRef,
     isPanelCollapsed,
@@ -47,17 +56,6 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
     handleHeaderClick,
   } = useOrchestratorPanelLayout()
 
-  const settings = useSettingsStore((s) => s.global)
-  const anthropicProvider = settings.model.providers.find((provider) => provider.id === 'anthropic')
-  const connectionMode = anthropicProvider?.connectionMode ?? 'cli'
-  const apiKeyEnvVar = anthropicProvider?.apiKeyEnvVar ?? 'ANTHROPIC_API_KEY'
-  const apiKey = settings.agent.envVars[apiKeyEnvVar]
-  const {
-    cliPath,
-    isDetecting: cliDetecting,
-    detectionError: cliDetectionError,
-  } = useCliPath()
-
   const {
     sessions,
     activeSession,
@@ -69,9 +67,6 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
     resetSession,
   } = useOrchestratorSessions(workspaceId)
 
-  const [sidebarMode, setSidebarMode] = useState<SidebarMode>(null)
-  const [localError, setLocalError] = useState<string | null>(null)
-
   const chat = useChatSession({
     mode: 'orchestrator',
     workspaceId,
@@ -81,7 +76,6 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
     apiKey: apiKey || undefined,
     apiKeyEnvVar,
     onError: (err) => {
-      console.error('[OrchestratorPanel] Chat error:', err)
       setLocalError(err)
     },
     onToolResult: () => {
@@ -388,11 +382,15 @@ function ProcessingIndicator({ startTime }: { startTime: number | null }) {
       return
     }
 
-    const interval = setInterval(() => {
+    const tick = () => {
       setElapsed(Math.floor((Date.now() - startTime) / 1000))
-    }, 1000)
+    }
 
-    return () => { clearInterval(interval) }
+    tick()
+    const interval = window.setInterval(tick, 1000)
+    return () => {
+      window.clearInterval(interval)
+    }
   }, [startTime])
 
   return (

--- a/src/hooks/use-chat-session.test.ts
+++ b/src/hooks/use-chat-session.test.ts
@@ -620,6 +620,7 @@ describe('useChatSession', () => {
 
       expect(mockIpc.getAgentMessages).not.toHaveBeenCalled()
       expect(result.current.isLoading).toBe(false)
+      expect(result.current.messages).toEqual([])
     })
   })
 })

--- a/src/stores/column-store.test.ts
+++ b/src/stores/column-store.test.ts
@@ -255,5 +255,29 @@ describe('column-store', () => {
       expect(state.columns[0]!.icon).toBe('check')
       expect(state.columns[0]!.name).toBe('Name')
     })
+
+    it('should not throw when optimistic trigger parsing fails', async () => {
+      useColumnStore.setState({
+        columns: [createMockColumn({ id: 'col-1' })],
+        loaded: true,
+      })
+      const originalTriggers = useColumnStore.getState().columns[0]!.triggers
+      const updated = createMockColumn({
+        id: 'col-1',
+        triggers: {
+          on_entry: { type: 'move_column', target: 'next' },
+          on_exit: { type: 'none' },
+          exit_criteria: { type: 'manual', auto_advance: false },
+        },
+      })
+      mockIpc.updateColumn.mockResolvedValueOnce(updated)
+
+      await expect(
+        useColumnStore.getState().updateColumnAsync('col-1', { triggers: 'not valid json' }),
+      ).resolves.toBeUndefined()
+
+      expect(mockIpc.updateColumn).toHaveBeenCalledWith('col-1', { triggers: 'not valid json' })
+      expect(useColumnStore.getState().columns[0]!.triggers).not.toEqual(originalTriggers)
+    })
   })
 })

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
-import type { Column, ColumnTriggers } from '@/types'
+import type { Column } from '@/types'
 import * as ipc from '@/lib/ipc'
 import { useWorkspaceStore } from './workspace-store'
 
@@ -28,14 +28,6 @@ type ColumnState = {
   reorder: (workspaceId: string, ids: string[]) => Promise<void>
   updateColumn: (id: string, updates: Partial<Column>) => void
   updateColumnAsync: (id: string, updates: ColumnUpdates) => Promise<void>
-}
-
-function parseTriggersSafely(triggers: string): ColumnTriggers | undefined {
-  try {
-    return JSON.parse(triggers) as ColumnTriggers
-  } catch {
-    return undefined
-  }
 }
 
 export const useColumnStore = create<ColumnState>()(
@@ -97,8 +89,6 @@ export const useColumnStore = create<ColumnState>()(
 
       updateColumnAsync: async (id, updates) => {
         const prev = get().columns
-        const parsedTriggers =
-          updates.triggers !== undefined ? parseTriggersSafely(updates.triggers) : undefined
         // Optimistically update
         set((s) => ({
           columns: s.columns.map((c) =>
@@ -109,7 +99,6 @@ export const useColumnStore = create<ColumnState>()(
                   ...(updates.icon !== undefined && { icon: updates.icon }),
                   ...(updates.color !== undefined && { color: updates.color ?? '' }),
                   ...(updates.visible !== undefined && { visible: updates.visible }),
-                  ...(parsedTriggers !== undefined && { triggers: parsedTriggers }),
                 }
               : c,
           ),

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import type { Column } from '@/types'
+import { parseColumnTriggers } from '@/types/column'
 import * as ipc from '@/lib/ipc'
 import { useWorkspaceStore } from './workspace-store'
 
@@ -89,6 +90,11 @@ export const useColumnStore = create<ColumnState>()(
 
       updateColumnAsync: async (id, updates) => {
         const prev = get().columns
+        const optimisticTriggers =
+          updates.triggers !== undefined
+            ? parseColumnTriggers(updates.triggers as Column['triggers'])
+            : undefined
+
         // Optimistically update
         set((s) => ({
           columns: s.columns.map((c) =>
@@ -99,6 +105,7 @@ export const useColumnStore = create<ColumnState>()(
                   ...(updates.icon !== undefined && { icon: updates.icon }),
                   ...(updates.color !== undefined && { color: updates.color ?? '' }),
                   ...(updates.visible !== undefined && { visible: updates.visible }),
+                  ...(optimisticTriggers && { triggers: optimisticTriggers }),
                 }
               : c,
           ),

--- a/src/types/node-shims.d.ts
+++ b/src/types/node-shims.d.ts
@@ -1,0 +1,11 @@
+declare module 'node:fs' {
+  export function readFileSync(path: string, encoding: string): string
+}
+
+declare module 'node:path' {
+  export function join(...parts: string[]): string
+}
+
+declare const process: {
+  cwd(): string
+}


### PR DESCRIPTION
## Description

The orchestrator panel and ChefSession backend have full UI and context-building infrastructure but ROADMAP.md notes "Orchestrator chat is UI-only (no LLM calls)." The ChefSession in chat/chef.rs can build system prompts and augment messages with board context but needs final wiring to invoke the Anthropic API and stream responses back. This is the critical path — without it the app is just a kanban board.

## Acceptance criteria
- [ ] Orchestrator chat sends messages to Anthropic API
- [ ] Responses stream back to the UI in real-time
- [ ] Board context (columns, tasks) included in system prompt
- [ ] cargo check && npx tsc --noEmit passes

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/wire-orchestrator-chat-to-actual-llm-calls` → `feat/readme-v2-features`

## Commits

```
e2e6c34 Fix recent code quality regressions
b3a202b Fix orchestrator API stream cancellation
7d7b1dd Wire orchestrator chat to Anthropic streaming
3a65c83 Fix audit findings and split panels (#47)
ae7aa12 Add task count badge to workspace tab (#46)
3530bbb Add keyboard shortcut hint to column headers (#45)
```

## Changes

```
.tickets/_docs/HANDOFF_2026-04-06.md               |    24 +-
 .tickets/_docs/HANDOFF_2026-04-07.md               |    79 +
 .tickets/_docs/HANDOFF_2026-04-09.md               |    97 +
 .tickets/_docs/HANDOFF_2026-04-10.md               |   100 +
 .tickets/_docs/HANDOFF_TERMINAL_REWRITE.md         |   164 +
 .tickets/_docs/INTERACTIVE_AGENT_TERMINAL.md       |   337 +
 .tickets/_docs/TERMINAL_VIEW_V2.md                 |   241 +
 .tickets/_docs/UI_RESTRUCTURE.md                   |     2 +-
 .tickets/_docs/UNIFIED_CHAT.md                     |    19 +-
 CLAUDE.md                                          |    58 +-
 Cargo.lock                                         |    86 +
 README.md                                          |    10 +-
 docs/PIPELINE-ROADMAP.md                           |   103 +
 docs/dynamic-model-discovery-plan.md               |   349 +
 mcp-server/src/main.rs                             |   219 +-
 package-lock.json                                  | 13353 +++++++++++++------
 src-tauri/src/api.rs                               |    32 +
 src-tauri/src/chat/bridge.rs                       |   552 +-
 src-tauri/src/chat/chef.rs                         |    12 +-
 src-tauri/src/chat/events.rs                       |     2 +-
 src-tauri/src/chat/gc.rs                           |   156 +
 src-tauri/src/chat/mod.rs                          |     3 +
 src-tauri/src/chat/pty_transport.rs                |    84 +-
 src-tauri/src/chat/registry.rs                     |   219 +-
 src-tauri/src/chat/session.rs                      |    38 +-
 src-tauri/src/chat/tmux_transport.rs               |   565 +
 src-tauri/src/chat/transport.rs                    |    18 +-
 src-tauri/src/commands/agent.rs                    |   409 +-
 src-tauri/src/commands/cli_detect.rs               |   309 +-
 src-tauri/src/commands/column.rs                   |    16 +
 src-tauri/src/commands/history.rs                  |    21 +-
 src-tauri/src/commands/mod.rs                      |     3 +
 src-tauri/src/commands/orchestrator.rs             |   635 +-
 src-tauri/src/commands/pipeline.rs                 |    22 +-
 src-tauri/src/commands/siege.rs                    |   116 +-
 src-tauri/src/commands/task.rs                     |    14 +
 src-tauri/src/commands/terminal.rs                 |    50 +-
 src-tauri/src/commands/workspace.rs                |   300 +-
 src-tauri/src/config/mod.rs                        |   245 +-
 src-tauri/src/db/column.rs                         |    15 +-
 .../src/db/migrations/030_pipeline_timing.sql      |    16 +
 src-tauri/src/db/mod.rs                            |    15 +-
 src-tauri/src/db/models.rs                         |    31 +-
 src-tauri/src/db/pipeline_timing.rs                |   132 +
 src-tauri/src/db/script.rs                         |    30 +-
 src-tauri/src/db/workspace.rs                      |    28 +-
 src-tauri/src/lib.rs                               |   119 +-
 src-tauri/src/llm/anthropic.rs                     |    33 +-
 src-tauri/src/llm/context.rs                       |   247 +-
 src-tauri/src/llm/executor.rs                      |   123 +-
 src-tauri/src/llm/mod.rs                           |     2 +-
 src-tauri/src/llm/types.rs                         |    63 +-
 src-tauri/src/models/cache.rs                      |    55 +
 src-tauri/src/models/cli_scan.rs                   |   263 +
 src-tauri/src/models/fetcher.rs                    |   153 +
 src-tauri/src/models/metadata.rs                   |   237 +
 src-tauri/src/models/mod.rs                        |   224 +
 src-tauri/src/models/types.rs                      |    88 +
 src-tauri/src/pipeline/mod.rs                      |   205 +-
 src-tauri/src/pipeline/template.rs                 |     1 +
 src-tauri/src/pipeline/triggers.rs                 |   252 +-
 src-tauri/src/process/agent_runner.rs              |   193 -
 src-tauri/src/process/mod.rs                       |     7 -
 src-tauri/src/process/pty_manager.rs               |   325 -
 src/components/about/index.ts                      |     1 -
 src/components/command-palette/command-palette.tsx |    12 +-
 src/components/history/index.ts                    |     1 -
 src/components/kanban/column-config-constants.ts   |    25 +-
 src/components/kanban/column-config-dialog.tsx     |    68 +-
 src/components/kanban/column-header.tsx            |   257 +-
 src/components/kanban/column-shortcuts.test.ts     |    54 +
 src/components/kanban/column-shortcuts.ts          |    21 +
 .../kanban/column-trigger-action-editors.tsx       |    88 +
 src/components/kanban/column-trigger-editor.tsx    |   415 +-
 src/components/kanban/column.tsx                   |    94 +-
 src/components/kanban/create-pr-action-editor.tsx  |    29 +
 src/components/kanban/dep-drag-preview.tsx         |     2 +-
 src/components/kanban/dependency-lines.tsx         |    43 +-
 src/components/kanban/dependency-path.ts           |    13 +
 .../kanban/move-column-action-editor.tsx           |    27 +
 src/components/kanban/run-script-action-editor.tsx |    91 +
 src/components/kanban/spawn-cli-action-editor.tsx  |    82 +
 src/components/kanban/task-card-expanded.tsx       |    89 +
 src/components/kanban/task-card-status.tsx         |     2 +-
 src/components/kanban/task-card.tsx                |   153 +-
 src/components/kanban/task-dependencies-tab.tsx    |    18 -
 src/components/kanban/task-dependency-utils.ts     |    19 +
 src/components/kanban/task-quick-actions.tsx       |    72 +-
 src/components/kanban/task-settings-modal.tsx      |     3 +-
 .../kanban/use-column-trigger-generation.ts        |    95 +
 src/components/layout/add-workspace-dialog.tsx     |    93 +
 src/components/layout/board.tsx                    |   162 +-
 src/components/layout/split-view.tsx               |    76 +-
 src/components/layout/tab-bar.tsx                  |   168 +-
 src/components/layout/use-tab-bar-navigation.ts    |    91 +
 src/components/onboarding/onboarding-wizard.tsx    |   116 +-
 src/components/panel/agent-output.tsx              |   364 +
 src/components/panel/agent-panel.tsx               |   171 +-
 src/components/panel/orchestrator-panel.tsx        |   665 +-
 src/components/panel/pipeline-dashboard-utils.ts   |    52 +
 src/components/panel/pipeline-dashboard.test.ts    |   208 +
 src/components/panel/pipeline-dashboard.tsx        |   229 +
 src/components/panel/shared/chat-helpers.ts        |     3 +-
 .../panel/shared/chat-input-settings-row.tsx       |    82 +
 src/components/panel/shared/chat-input-types.ts    |    53 +
 src/components/panel/shared/chat-input.tsx         |   442 +-
 .../panel/shared/collapsible-details.tsx           |     4 +-
 src/components/panel/shared/tool-call-item.tsx     |     4 +-
 .../panel/shared/use-chat-input-state.ts           |   237 +
 src/components/panel/terminal-view.tsx             |   189 +
 src/components/panel/use-agent-panel-session.ts    |    83 +
 .../panel/use-orchestrator-panel-layout.ts         |   112 +
 .../panel/use-orchestrator-task-refresh.ts         |    46 +
 src/components/settings/tabs/agent-tab.tsx         |   255 +-
 src/components/settings/tabs/scripts-tab.tsx       |    12 +-
 src/components/settings/tabs/workspace-tab.tsx     |    98 +-
 src/components/shared/cli-chat/index.ts            |    10 -
 src/components/shared/model-selector.tsx           |    19 +-
 src/components/shared/path-picker.tsx              |     7 +-
 src/components/shared/permission-selector.tsx      |     9 +-
 src/components/shared/permission-utils.ts          |     6 +
 src/components/shared/resize-handle.tsx            |    38 +
 src/components/shared/thinking-selector.tsx        |     8 +-
 src/components/shared/thinking-utils.ts            |    12 +
 src/components/task-detail/task-detail-panel.tsx   |   245 -
 src/components/templates/index.ts                  |     1 -
 src/components/usage/cost-badge.tsx                |    63 +-
 src/components/usage/metrics-dashboard.tsx         |    74 +-
 src/hooks/chat-session/use-chat-session.ts         |    70 +-
 src/hooks/use-agent-streaming-sync.ts              |    13 +-
 src/hooks/use-card-positions.ts                    |    11 +-
 src/hooks/use-chat-panel.ts                        |    54 +
 src/hooks/use-chat-session.test.ts                 |     3 +-
 src/hooks/use-chat-session.ts                      |     5 -
 src/hooks/use-cli-path.ts                          |    65 +-
 src/hooks/use-model-capabilities.ts                |   123 +-
 src/hooks/use-models.ts                            |   134 +
 src/hooks/use-native-input.ts                      |    35 +
 src/hooks/use-resizable-panel.ts                   |    76 +
 src/hooks/use-split-view.ts                        |    45 -
 src/hooks/use-task-detail.ts                       |    32 +
 src/hooks/use-task-sync.ts                         |     2 +-
 src/hooks/use-workspace-usage.ts                   |    74 +
 src/lib/browser-mock.ts                            |   389 +-
 src/lib/ipc/cli.ts                                 |    14 +
 src/lib/ipc/index.ts                               |     2 +
 src/lib/ipc/models.ts                              |    49 +
 src/lib/ipc/orchestrator.ts                        |     7 -
 src/lib/ipc/pipeline.ts                            |    14 +
 src/lib/ipc/script.ts                              |     4 +-
 src/lib/ipc/terminal.ts                            |    46 +
 src/lib/panel-coordination.ts                      |    20 +
 src/lib/usage.ts                                   |    17 +
 src/stores/agent-streaming-store.test.ts           |    46 +-
 src/stores/agent-streaming-store.ts                |    59 +-
 src/stores/checklist-store.ts                      |     9 +-
 src/stores/column-store.test.ts                    |    59 +-
 src/stores/column-store.ts                         |    19 +-
 src/stores/settings-store.ts                       |     9 +-
 src/stores/task-store.test.ts                      |    49 +-
 src/stores/task-store.ts                           |    16 +
 src/stores/ui-store.ts                             |    77 +-
 src/stores/workspace-store.test.ts                 |    23 +
 src/stores/workspace-store.ts                      |     8 +
 src/test/mocks/tauri.ts                            |     1 +
 src/testing/fixtures/column-triggers-v2.json       |    19 +
 src/types/column.test.ts                           |    33 +-
 src/types/column.ts                                |    31 +-
 src/types/events.ts                                |     2 +-
 src/types/index.ts                                 |     4 +-
 src/types/node-shims.d.ts                          |    11 +
 src/types/settings.ts                              |     3 +
 src/types/workspace.ts                             |    17 +
 tests/webdriver/core-flow.spec.mjs                 |   160 +-
 174 files changed, 22333 insertions(+), 7826 deletions(-)
```