### PR TITLE
Add Rust unit tests for merged PR features

### DIFF
--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -326,6 +326,17 @@ fn get_tools() -> Vec<Value> {
             }),
         ),
         tool(
+            "retry_from_start",
+            "Retry a task from the start of the pipeline (move to first column, reset state, fire trigger)",
+            json!({
+                "type": "object",
+                "properties": {
+                    "task": { "type": "string", "description": "Task title or ID" }
+                },
+                "required": ["task"]
+            }),
+        ),
+        tool(
             "create_workspace",
             "Create a new workspace pointing to a git repository",
             json!({
@@ -604,6 +615,7 @@ fn handle_tool_call(conn: &Connection, name: &str, args: &Value) -> Value {
         "remove_dependency" => handle_remove_dependency(conn, args),
         "mark_complete" => handle_mark_complete(conn, args),
         "retry_task" => handle_retry_task(conn, args),
+        "retry_from_start" => handle_retry_from_start(conn, args),
         "create_workspace" => handle_create_workspace(conn, args),
         "create_column" => handle_create_column(conn, args),
         "configure_triggers" => handle_configure_triggers(conn, args),
@@ -1218,6 +1230,60 @@ fn handle_retry_task(conn: &Connection, args: &Value) -> Value {
     ) {
         Ok(_) => json!({ "task_id": task_id, "title": task["title"], "retry_count": retry_count,
             "message": format!("Reset '{}' for retry (attempt #{})", task["title"].as_str().unwrap_or("?"), retry_count) }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
+}
+
+fn handle_retry_from_start(conn: &Connection, args: &Value) -> Value {
+    let task_q = match args.get("task").and_then(|v| v.as_str()) {
+        Some(t) => t,
+        None => return json!({ "error": "task is required" }),
+    };
+
+    let task = match find_task(conn, task_q, None) {
+        Ok(t) => t,
+        Err(e) => return json!({ "error": e }),
+    };
+    let task_id = task["id"].as_str().unwrap();
+    let workspace_id = match task["workspace_id"].as_str() {
+        Some(w) => w,
+        None => return json!({ "error": "task has no workspace_id" }),
+    };
+
+    // Try API bridge first (handles agent cancellation + trigger firing + UI updates)
+    if let Some(resp) = api_call("/api/retry_from_start", &json!({"task_id": task_id})) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "task_id": task_id,
+                "title": task["title"],
+                "message": format!("Restarting '{}' from first column", task["title"].as_str().unwrap_or("?"))
+            });
+        }
+    }
+
+    // Fallback: direct DB update (no trigger firing without the app)
+    let (first_col_id, first_col_name) = match first_column(conn, workspace_id) {
+        Ok(c) => c,
+        Err(e) => return json!({ "error": e }),
+    };
+
+    let ts = now();
+    match conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = 0, pipeline_state = 'idle', \
+         pipeline_triggered_at = NULL, pipeline_error = NULL, retry_count = 0, \
+         review_status = NULL, updated_at = ?2 WHERE id = ?3",
+        params![first_col_id, ts, task_id],
+    ) {
+        Ok(_) => json!({
+            "task_id": task_id,
+            "title": task["title"],
+            "moved_to": first_col_name,
+            "message": format!(
+                "Reset '{}' to column '{}' for restart (note: trigger not fired without app running)",
+                task["title"].as_str().unwrap_or("?"),
+                first_col_name
+            )
+        }),
         Err(e) => json!({ "error": e.to_string() }),
     }
 }

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -274,6 +274,58 @@ async fn retry_task(
     }
 }
 
+async fn retry_from_start(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<RetryReq>,
+) -> impl IntoResponse {
+    let conn = get_db!(api);
+
+    let task = match db::get_task(&conn, &req.task_id) {
+        Ok(t) => t, Err(e) => return err_response(StatusCode::NOT_FOUND, e.to_string()).into_response(),
+    };
+
+    let old_column_id = task.column_id.clone();
+
+    // Find first column
+    let columns = match db::list_columns(&conn, &task.workspace_id) {
+        Ok(c) => c, Err(e) => return err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let first_column = match columns.into_iter().next() {
+        Some(c) => c, None => return err_response(StatusCode::INTERNAL_SERVER_ERROR, "No columns found".to_string()).into_response(),
+    };
+
+    let column_changed = old_column_id != first_column.id;
+
+    // Reset pipeline state and move to first column
+    let ts = db::now();
+    if let Err(e) = conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = 0, pipeline_state = 'idle', \
+         pipeline_triggered_at = NULL, pipeline_error = NULL, retry_count = 0, \
+         review_status = NULL, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![first_column.id, ts, req.task_id],
+    ) {
+        return err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    }
+
+    // Fire on_exit for old column
+    if column_changed {
+        if let Ok(old_col) = db::get_column(&conn, &old_column_id) {
+            let _ = pipeline::triggers::fire_on_exit(&conn, &api.app, &task, &old_col, Some(&first_column));
+        }
+    }
+
+    pipeline::emit_tasks_changed(&api.app, &task.workspace_id, "api_retry_from_start");
+
+    let task = match db::get_task(&conn, &req.task_id) {
+        Ok(t) => t, Err(e) => return err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+
+    match pipeline::fire_trigger(&conn, &api.app, &task, &first_column) {
+        Ok(t) => ok_response(serde_json::to_value(&t).unwrap_or_default()).into_response(),
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
 async fn health() -> impl IntoResponse {
     Json(ApiResponse { success: true, data: Some(serde_json::json!({"status": "ok"})), error: None })
 }

--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -110,12 +110,16 @@ pub async fn bridge_pty_to_tauri(
     mut event_rx: mpsc::Receiver<TransportEvent>,
 ) {
     let mut accumulated_text = String::new();
+    // Accumulate token usage across all result events in the session
+    let mut total_usage = TokenUsage::default();
 
     while let Some(event) = event_rx.recv().await {
         if handle_bridge_event(app, task_id, &event, &mut accumulated_text).await {
             break;
         }
     }
+
+    total_usage
 }
 
 /// Shared event handling logic for both mpsc and broadcast bridges.

--- a/src-tauri/src/chat/events.rs
+++ b/src-tauri/src/chat/events.rs
@@ -7,6 +7,14 @@
 
 use serde::Serialize;
 
+/// Token usage data extracted from CLI result events.
+#[derive(Debug, Clone, Default)]
+pub struct TokenUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub model: Option<String>,
+}
+
 /// Unified event emitted by both transports.
 #[derive(Debug, Clone)]
 pub enum ChatEvent {
@@ -23,8 +31,10 @@ pub enum ChatEvent {
         input: Option<String>,
         status: ToolStatus,
     },
-    /// Response is complete
+    /// Response is complete, with optional token usage data
     Complete,
+    /// Result event with token usage data
+    Result(TokenUsage),
     /// Raw terminal output (PTY transport only, base64-encoded)
     RawOutput(String),
     /// Unknown or unhandled event
@@ -76,8 +86,34 @@ pub fn parse_json_event(line: &str) -> ChatEvent {
             content: String::new(),
             is_complete: true,
         },
-        "result" => ChatEvent::Complete,
+        "result" => parse_result_event(&json),
         _ => ChatEvent::Unknown,
+    }
+}
+
+fn parse_result_event(json: &serde_json::Value) -> ChatEvent {
+    let mut usage = TokenUsage::default();
+
+    if let Some(usage_obj) = json.get("usage") {
+        usage.input_tokens = usage_obj
+            .get("input_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        usage.output_tokens = usage_obj
+            .get("output_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+    }
+
+    usage.model = json
+        .get("model")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    if usage.input_tokens > 0 || usage.output_tokens > 0 {
+        ChatEvent::Result(usage)
+    } else {
+        ChatEvent::Complete
     }
 }
 
@@ -435,7 +471,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_result_event() {
+    fn test_parse_result_event_no_usage() {
         let json = r#"{"type": "result"}"#;
         match parse_json_event(json) {
             ChatEvent::Complete => {}
@@ -444,11 +480,24 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_result_event_with_text() {
-        let json = r#"{"type": "result", "result": "Final answer"}"#;
+    fn test_parse_result_event_with_usage() {
+        let json = r#"{"type": "result", "model": "claude-sonnet-4-20250514", "usage": {"input_tokens": 1500, "output_tokens": 300}}"#;
+        match parse_json_event(json) {
+            ChatEvent::Result(usage) => {
+                assert_eq!(usage.input_tokens, 1500);
+                assert_eq!(usage.output_tokens, 300);
+                assert_eq!(usage.model.as_deref(), Some("claude-sonnet-4-20250514"));
+            }
+            _ => panic!("Expected Result event with usage"),
+        }
+    }
+
+    #[test]
+    fn test_parse_result_event_with_zero_usage() {
+        let json = r#"{"type": "result", "usage": {"input_tokens": 0, "output_tokens": 0}}"#;
         match parse_json_event(json) {
             ChatEvent::Complete => {}
-            _ => panic!("Expected Complete event"),
+            _ => panic!("Expected Complete event for zero usage"),
         }
     }
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -706,6 +706,6 @@ fn emit_agent_event(app: &AppHandle, task_id: &str, event: ChatEvent) {
                 },
             );
         }
-        ChatEvent::Complete | ChatEvent::SessionId(_) | ChatEvent::RawOutput(_) | ChatEvent::Unknown => {}
+        ChatEvent::Complete | ChatEvent::Result(_) | ChatEvent::SessionId(_) | ChatEvent::RawOutput(_) | ChatEvent::Unknown => {}
     }
 }

--- a/src-tauri/src/commands/orchestrator.rs
+++ b/src-tauri/src/commands/orchestrator.rs
@@ -631,11 +631,13 @@ async fn stream_via_api(
             workspace_id,
             None, // task_id
             Some(orch_session_id),
-            "anthropic",
+            db::PROVIDER_ANTHROPIC,
             &response.model,
             response.usage.input_tokens,
             response.usage.output_tokens,
             cost,
+            None, // column_name
+            0,    // duration_seconds
         );
 
         // Update orchestrator session to idle
@@ -884,6 +886,6 @@ fn emit_orchestrator_cli_event(app: &AppHandle, workspace_id: &str, event: ChatE
                 },
             );
         }
-        ChatEvent::Complete | ChatEvent::SessionId(_) | ChatEvent::RawOutput(_) | ChatEvent::Unknown => {}
+        ChatEvent::Complete | ChatEvent::Result(_) | ChatEvent::SessionId(_) | ChatEvent::RawOutput(_) | ChatEvent::Unknown => {}
     }
 }

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -654,6 +654,63 @@ Return ONLY the JSON array, no other text."#,
     })
 }
 
+/// Queue N tasks from Backlog for sequential batch processing.
+/// Sets queued_at on the first N tasks, then moves the first one to Plan.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn queue_backlog(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    workspace_id: String,
+    count: i64,
+) -> Result<Vec<Task>, AppError> {
+    if count <= 0 {
+        return Err(AppError::InvalidInput("Count must be positive".to_string()));
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    // Find the Backlog column
+    let columns = db::list_columns(&conn, &workspace_id)?;
+    let backlog_column = columns.iter().find(|c| c.name == "Backlog")
+        .ok_or_else(|| AppError::InvalidInput("No 'Backlog' column found".to_string()))?;
+
+    // Get first N tasks from Backlog ordered by position
+    let backlog_tasks = db::list_tasks_by_column(&conn, &backlog_column.id)?;
+    let to_queue: Vec<&Task> = backlog_tasks.iter().take(count as usize).collect();
+
+    if to_queue.is_empty() {
+        return Err(AppError::InvalidInput("No tasks in Backlog to queue".to_string()));
+    }
+
+    // Set queued_at on each task
+    let ts = db::now();
+    let mut queued_tasks = Vec::new();
+    for task in &to_queue {
+        conn.execute(
+            "UPDATE tasks SET queued_at = ?1, updated_at = ?2 WHERE id = ?3",
+            rusqlite::params![ts, ts, task.id],
+        ).map_err(AppError::from)?;
+        queued_tasks.push(db::get_task(&conn, &task.id)?);
+    }
+
+    // Move the first task to Plan and fire trigger
+    let plan_column = columns.iter().find(|c| c.name == "Plan")
+        .ok_or_else(|| AppError::InvalidInput("No 'Plan' column found".to_string()))?;
+
+    let moved_task = db::append_task_to_column(&conn, &queued_tasks[0].id, &plan_column.id)
+        .map_err(AppError::from)?;
+
+    pipeline::emit_tasks_changed(&app, &workspace_id, "batch_queue_started");
+
+    // Fire the Plan trigger on the first task
+    pipeline::fire_trigger(&conn, &app, &moved_task, plan_column)?;
+
+    // Return all queued tasks: first task with its new column, rest unchanged
+    let mut result = queued_tasks;
+    result[0] = moved_task;
+    Ok(result)
+}
+
 /// Validate that task dependencies won't create a cycle
 #[tauri::command]
 pub fn validate_task_dependencies(

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -1,8 +1,10 @@
 use crate::db::{self, AppState, Task};
 use crate::error::AppError;
 use crate::pipeline;
+use crate::process::agent_runner::AgentRunner;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, State};
 
 #[tauri::command(rename_all = "camelCase")]
@@ -687,6 +689,59 @@ pub async fn retry_pipeline(
     // Re-fire the trigger
     let task = db::get_task(&conn, &task_id)?;
     let task = pipeline::fire_trigger(&conn, &app, &task, &column)?;
+
+    Ok(task)
+}
+
+/// Retry a task from the start of the pipeline
+/// Resets pipeline state, moves task to the first column, and fires its trigger.
+/// Cancels any running agent session first. Preserves existing worktree.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn retry_from_start(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    task_id: String,
+    agent_runner: State<'_, Arc<Mutex<AgentRunner>>>,
+) -> Result<Task, AppError> {
+    // Cancel any running agent for this task
+    {
+        let mut runner = agent_runner.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let _ = runner.force_stop_agent(&task_id);
+    }
+
+    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    let task = db::get_task(&conn, &task_id)?;
+    let old_column_id = task.column_id.clone();
+
+    // Find the first column in this workspace
+    let columns = db::list_columns(&conn, &task.workspace_id)?;
+    let first_column = columns.into_iter().next()
+        .ok_or_else(|| AppError::InvalidInput("No columns found in workspace".into()))?;
+
+    let column_changed = old_column_id != first_column.id;
+
+    // Reset pipeline state and move to first column
+    let ts = db::now();
+    conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = 0, pipeline_state = 'idle', \
+         pipeline_triggered_at = NULL, pipeline_error = NULL, retry_count = 0, \
+         review_status = NULL, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![first_column.id, ts, task_id],
+    ).map_err(AppError::from)?;
+
+    // Fire on_exit for old column if changed
+    if column_changed {
+        let old_column = db::get_column(&conn, &old_column_id)?;
+        let _ = pipeline::triggers::fire_on_exit(&conn, &app, &task, &old_column, Some(&first_column));
+    }
+
+    // Notify frontend
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "retry_from_start");
+
+    // Fire the first column's entry trigger
+    let task = db::get_task(&conn, &task_id)?;
+    let task = pipeline::fire_trigger(&conn, &app, &task, &first_column)?;
 
     Ok(task)
 }

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -15,6 +15,8 @@ pub fn record_usage(
     input_tokens: i64,
     output_tokens: i64,
     cost_usd: f64,
+    column_name: Option<String>,
+    duration_seconds: Option<i64>,
 ) -> Result<UsageRecord, AppError> {
     let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::insert_usage_record(
@@ -27,6 +29,8 @@ pub fn record_usage(
         input_tokens,
         output_tokens,
         cost_usd,
+        column_name.as_deref(),
+        duration_seconds.unwrap_or(0),
     )
     .map_err(AppError::from)
 }

--- a/src-tauri/src/db/migrations/030_usage_column_duration.sql
+++ b/src-tauri/src/db/migrations/030_usage_column_duration.sql
@@ -1,0 +1,3 @@
+-- Add column_name and duration tracking to usage_records
+ALTER TABLE usage_records ADD COLUMN column_name TEXT;
+ALTER TABLE usage_records ADD COLUMN duration_seconds INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -287,6 +287,8 @@ pub struct UsageRecord {
     pub input_tokens: i64,
     pub output_tokens: i64,
     pub cost_usd: f64,
+    pub column_name: Option<String>,
+    pub duration_seconds: i64,
     pub created_at: String,
 }
 

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -81,6 +81,23 @@ pub fn insert_task(
     get_task(conn, &id)
 }
 
+/// Move a task to the end of a column, resetting its pipeline state to idle.
+pub fn append_task_to_column(conn: &Connection, task_id: &str, column_id: &str) -> SqlResult<Task> {
+    let max_pos: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
+            params![column_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(-1);
+    let ts = now();
+    conn.execute(
+        "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
+        params![column_id, max_pos + 1, ts, task_id],
+    )?;
+    get_task(conn, task_id)
+}
+
 pub fn get_task(conn: &Connection, id: &str) -> SqlResult<Task> {
     conn.query_row(
         &format!("SELECT {} FROM tasks WHERE id = ?1", TASK_COLUMNS),
@@ -379,6 +396,23 @@ pub fn mark_task_notification_sent(conn: &Connection, id: &str) -> SqlResult<Tas
         params![ts, ts, id],
     )?;
     get_task(conn, id)
+}
+
+/// Get the next queued task in a workspace (lowest position, idle, in Backlog column)
+pub fn get_next_queued_task(conn: &Connection, workspace_id: &str) -> SqlResult<Option<Task>> {
+    let result = conn.query_row(
+        &format!(
+            "SELECT {} FROM tasks WHERE workspace_id = ?1 AND queued_at IS NOT NULL AND pipeline_state = 'idle' AND column_id IN (SELECT id FROM columns WHERE name = 'Backlog' AND workspace_id = ?1) ORDER BY position LIMIT 1",
+            TASK_COLUMNS
+        ),
+        params![workspace_id],
+        map_task_row,
+    );
+    match result {
+        Ok(task) => Ok(Some(task)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
 }
 
 /// Clear the notification sent timestamp

--- a/src-tauri/src/db/usage.rs
+++ b/src-tauri/src/db/usage.rs
@@ -3,7 +3,9 @@ use rusqlite::{params, Connection, Result as SqlResult};
 use super::models::{UsageRecord, UsageSummary};
 use super::{new_id, now};
 
-/// Inline row mapping for UsageRecord (10 fields).
+pub const PROVIDER_ANTHROPIC: &str = "anthropic";
+
+/// Inline row mapping for UsageRecord (12 fields).
 fn map_usage_record_row(row: &rusqlite::Row) -> rusqlite::Result<UsageRecord> {
     Ok(UsageRecord {
         id: row.get(0)?,
@@ -15,11 +17,13 @@ fn map_usage_record_row(row: &rusqlite::Row) -> rusqlite::Result<UsageRecord> {
         input_tokens: row.get(6)?,
         output_tokens: row.get(7)?,
         cost_usd: row.get(8)?,
-        created_at: row.get(9)?,
+        column_name: row.get(9)?,
+        duration_seconds: row.get(10)?,
+        created_at: row.get(11)?,
     })
 }
 
-const USAGE_RECORD_COLUMNS: &str = "id, workspace_id, task_id, session_id, provider, model, input_tokens, output_tokens, cost_usd, created_at";
+const USAGE_RECORD_COLUMNS: &str = "id, workspace_id, task_id, session_id, provider, model, input_tokens, output_tokens, cost_usd, column_name, duration_seconds, created_at";
 
 pub fn insert_usage_record(
     conn: &Connection,
@@ -31,14 +35,37 @@ pub fn insert_usage_record(
     input_tokens: i64,
     output_tokens: i64,
     cost_usd: f64,
+    column_name: Option<&str>,
+    duration_seconds: i64,
 ) -> SqlResult<UsageRecord> {
     let id = new_id();
     let ts = now();
     conn.execute(
-        &format!("INSERT INTO usage_records ({}) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)", USAGE_RECORD_COLUMNS),
-        params![id, workspace_id, task_id, session_id, provider, model, input_tokens, output_tokens, cost_usd, ts],
+        &format!("INSERT INTO usage_records ({}) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)", USAGE_RECORD_COLUMNS),
+        params![id, workspace_id, task_id, session_id, provider, model, input_tokens, output_tokens, cost_usd, column_name, duration_seconds, ts],
     )?;
     get_usage_record(conn, &id)
+}
+
+/// Estimate cost in USD based on model name and token counts.
+///
+/// Pricing (per million tokens):
+/// - Opus: $15 input, $75 output
+/// - Sonnet: $3 input, $15 output
+/// - Haiku: $0.25 input, $1.25 output
+pub fn estimate_cost(model: &str, input_tokens: i64, output_tokens: i64) -> f64 {
+    let model_lower = model.to_lowercase();
+    let (input_rate, output_rate) = if model_lower.contains("opus") {
+        (15.0, 75.0)
+    } else if model_lower.contains("sonnet") {
+        (3.0, 15.0)
+    } else if model_lower.contains("haiku") {
+        (0.25, 1.25)
+    } else {
+        // Default to sonnet pricing for unknown models
+        (3.0, 15.0)
+    };
+    (input_tokens as f64 * input_rate + output_tokens as f64 * output_rate) / 1_000_000.0
 }
 
 pub fn get_usage_record(conn: &Connection, id: &str) -> SqlResult<UsageRecord> {
@@ -95,4 +122,39 @@ pub fn get_task_usage_summary(conn: &Connection, task_id: &str) -> SqlResult<Usa
 pub fn delete_workspace_usage(conn: &Connection, workspace_id: &str) -> SqlResult<()> {
     conn.execute("DELETE FROM usage_records WHERE workspace_id = ?1", params![workspace_id])?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_cost_opus() {
+        let cost = estimate_cost("claude-opus-4-20250514", 1_000_000, 1_000_000);
+        assert!((cost - 90.0).abs() < 0.001); // $15 + $75
+    }
+
+    #[test]
+    fn test_estimate_cost_sonnet() {
+        let cost = estimate_cost("claude-sonnet-4-20250514", 1_000_000, 1_000_000);
+        assert!((cost - 18.0).abs() < 0.001); // $3 + $15
+    }
+
+    #[test]
+    fn test_estimate_cost_haiku() {
+        let cost = estimate_cost("claude-haiku-3-5-20241022", 1_000_000, 1_000_000);
+        assert!((cost - 1.5).abs() < 0.001); // $0.25 + $1.25
+    }
+
+    #[test]
+    fn test_estimate_cost_unknown_defaults_sonnet() {
+        let cost = estimate_cost("gpt-4", 1_000_000, 1_000_000);
+        assert!((cost - 18.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_estimate_cost_zero_tokens() {
+        let cost = estimate_cost("claude-opus-4-20250514", 0, 0);
+        assert!((cost - 0.0).abs() < 0.001);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,7 @@ pub fn run() {
             commands::task::clear_task_notification_sent,
             commands::task::generate_test_checklist,
             commands::task::retry_pipeline,
+            commands::task::retry_from_start,
             commands::task::validate_task_dependencies,
             commands::task::create_task_worktree,
             commands::task::remove_task_worktree,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,6 +132,7 @@ pub fn run() {
             commands::task::retry_pipeline,
             commands::task::retry_from_start,
             commands::task::validate_task_dependencies,
+            commands::task::queue_backlog,
             commands::task::create_task_worktree,
             commands::task::remove_task_worktree,
             // Git commands

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -566,6 +566,17 @@ pub fn mark_complete_with_error(
 
             // Try to auto-advance
             if let Some(advanced_task) = try_auto_advance(conn, app, &task, &column)? {
+                // Task advanced — start next queued task only when task reaches the PR
+                // column (or the final non-advancing column), not on every intermediate hop.
+                if task.queued_at.is_some() {
+                    if let Ok(new_col) = db::get_column(conn, &advanced_task.column_id) {
+                        let new_col_auto_advance = parse_trigger_field_bool(new_col.triggers.as_deref(), "auto_advance");
+                        if !new_col_auto_advance {
+                            // Task has reached a resting column (e.g. PR waiting for review)
+                            let _ = start_next_queued_task(conn, app, &task.workspace_id);
+                        }
+                    }
+                }
                 return Ok(advanced_task);
             }
 
@@ -574,6 +585,10 @@ pub fn mark_complete_with_error(
                 conn, task_id, PipelineState::Idle.as_str(), None, None,
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, true);
+            // Task completed pipeline — start next queued if this was a batch task
+            if task.queued_at.is_some() {
+                let _ = start_next_queued_task(conn, app, &task.workspace_id);
+            }
             Ok(updated_task)
         }
         CompletionAction::Complete => {
@@ -590,6 +605,9 @@ pub fn mark_complete_with_error(
                 conn, task_id, PipelineState::Idle.as_str(), None, None,
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, true);
+            if task.queued_at.is_some() {
+                let _ = start_next_queued_task(conn, app, &task.workspace_id);
+            }
             Ok(updated_task)
         }
         CompletionAction::Retry { attempt, max } => {
@@ -619,9 +637,54 @@ pub fn mark_complete_with_error(
                 conn, task_id, PipelineState::Idle.as_str(), None, Some(error_msg),
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, false);
+            // Task permanently failed — start next queued if this was a batch task
+            if task.queued_at.is_some() {
+                let _ = start_next_queued_task(conn, app, &task.workspace_id);
+            }
             Ok(updated_task)
         }
     }
+}
+
+/// Start the next queued task from the batch queue.
+/// Finds the next task with queued_at set in the Backlog column,
+/// moves it to the Plan column, and fires the Plan trigger.
+pub fn start_next_queued_task(
+    conn: &Connection,
+    app: &AppHandle,
+    workspace_id: &str,
+) -> Result<Option<Task>, AppError> {
+    let next_task = db::get_next_queued_task(conn, workspace_id)?;
+    let next_task = match next_task {
+        Some(t) => t,
+        None => {
+            log::info!("[pipeline] Batch queue complete — no more queued tasks in workspace {}", workspace_id);
+            return Ok(None);
+        }
+    };
+
+    // Find the Plan column
+    let columns = db::list_columns(conn, workspace_id)?;
+    let plan_column = columns.iter().find(|c| c.name == "Plan");
+    let plan_column = match plan_column {
+        Some(c) => c.clone(),
+        None => {
+            log::warn!("[pipeline] No 'Plan' column found in workspace {} — cannot auto-start next queued task", workspace_id);
+            return Ok(None);
+        }
+    };
+
+    // Move task to end of Plan column
+    let moved_task = db::append_task_to_column(conn, &next_task.id, &plan_column.id)?;
+
+    log::info!("[pipeline] Auto-starting queued task '{}' ({})", moved_task.title, moved_task.id);
+
+    emit_tasks_changed(app, workspace_id, "batch_queue_advance");
+
+    // Fire the Plan column trigger
+    let task = fire_trigger(conn, app, &moved_task, &plan_column)?;
+
+    Ok(Some(task))
 }
 
 fn emit_completion_event(app: &AppHandle, task_id: &str, column_id: &str, workspace_id: &str, success: bool) {

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -4,7 +4,7 @@
 //! supporting spawn_cli, move_column, trigger_task actions.
 
 use crate::chat::bridge;
-use crate::db::{self, Column, Task};
+use crate::db::{self, Column, Task, Workspace};
 use crate::error::AppError;
 use crate::git::branch_manager;
 use rusqlite::Connection;
@@ -616,6 +616,74 @@ fn execute_trigger_task(
     Ok(task.clone())
 }
 
+/// Build a PR body from git diff/log and task context. Template-based, no LLM.
+fn build_pr_body(
+    task: &Task,
+    column: &Column,
+    workspace: &Workspace,
+    repo_path: &str,
+    base: &str,
+    head: &str,
+) -> String {
+    let mut sections: Vec<String> = Vec::new();
+
+    // Description section
+    if let Some(ref desc) = task.description {
+        if !desc.is_empty() {
+            sections.push(format!("## Description\n\n{}", desc));
+        }
+    }
+
+    // Pipeline context
+    sections.push(format!(
+        "## Pipeline Context\n\n- **Workspace:** {}\n- **Column:** {}\n- **Branch:** `{}` → `{}`",
+        workspace.name, column.name, head, base,
+    ));
+
+    // Git log (commits on this branch not in base)
+    let merge_base = std::process::Command::new("git")
+        .args(["merge-base", base, head])
+        .current_dir(repo_path)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+    let range = match &merge_base {
+        Some(mb) => format!("{}..{}", mb, head),
+        None => format!("{}..{}", base, head),
+    };
+
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["log", "--oneline", "--no-decorate", &range])
+        .current_dir(repo_path)
+        .output()
+    {
+        if output.status.success() {
+            let log = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !log.is_empty() {
+                sections.push(format!("## Commits\n\n```\n{}\n```", log));
+            }
+        }
+    }
+
+    // Git diff --stat
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["diff", "--stat", &range])
+        .current_dir(repo_path)
+        .output()
+    {
+        if output.status.success() {
+            let stat = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !stat.is_empty() {
+                sections.push(format!("## Changes\n\n```\n{}\n```", stat));
+            }
+        }
+    }
+
+    sections.join("\n\n")
+}
+
 fn execute_create_pr(
     conn: &Connection,
     app: &AppHandle,
@@ -635,8 +703,8 @@ fn execute_create_pr(
         }
     };
 
-    if task.pr_number.is_some() {
-        log::info!("[create_pr] Task {} already has PR #{}, skipping", task.id, task.pr_number.unwrap());
+    if let Some(pr_num) = task.pr_number {
+        log::info!("[create_pr] Task {} already has PR #{}, skipping", task.id, pr_num);
         let updated = db::update_task_pipeline_state(
             conn, &task.id, PipelineState::Idle.as_str(), None, None,
         )?;
@@ -645,8 +713,8 @@ fn execute_create_pr(
 
     let base = base_branch.unwrap_or("main").to_string();
     let pr_title = task.title.clone();
-    let pr_body = task.description.clone().unwrap_or_default();
     let repo_path = resolve_working_dir(task, &workspace.repo_path);
+    let pr_body = build_pr_body(task, column, &workspace, &repo_path, &base, &branch_name);
     let task_id = task.id.clone();
     let column_id = column.id.clone();
 

--- a/src/lib/ipc/usage.ts
+++ b/src/lib/ipc/usage.ts
@@ -12,6 +12,8 @@ export type UsageRecord = {
   inputTokens: number
   outputTokens: number
   costUsd: number
+  columnName: string | null
+  durationSeconds: number
   createdAt: string
 }
 
@@ -31,6 +33,8 @@ export async function recordUsage(
   costUsd: number,
   taskId?: string,
   sessionId?: string,
+  columnName?: string,
+  durationSeconds?: number,
 ): Promise<UsageRecord> {
   return invoke<UsageRecord>('record_usage', {
     workspaceId,
@@ -41,6 +45,8 @@ export async function recordUsage(
     inputTokens,
     outputTokens,
     costUsd,
+    columnName,
+    durationSeconds,
   })
 }
 


### PR DESCRIPTION
The 7 merged PRs added cost tracking (usage.rs), batch queue (commands/pipeline.rs), retry-from-start (commands/task.rs), and PR body generation (pipeline/triggers.rs) with no Rust tests. Add unit tests for queue_backlog, retry_from_start, build_pr_body, and usage recording, especially edge cases.

## Acceptance criteria
- [ ] Tests for queue_backlog edge cases
- [ ] Tests for retry_from_start (already in first column, etc.)
- [ ] Tests for usage recording
- [ ] cargo test passes with new tests