### PR TITLE
Add task detail view with full context

### DIFF
--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -26,6 +26,7 @@ import { getColumnShortcutIndex, getVisibleColumnsForShortcuts } from './column-
 
 export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const expandTask = useUIStore((s) => s.expandTask)
+  const focusTask = useUIStore((s) => s.focusTask)
   const expandedTaskId = useUIStore((s) => s.expandedTaskId)
   const isExpanded = expandedTaskId === task.id
   const hasAttention = useAttentionStore((s) => s.hasAttention(task.id))
@@ -108,6 +109,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const openChat = useUIStore((s) => s.openChat)
   const closeChat = useUIStore((s) => s.closeChat)
   const collapseTask = useUIStore((s) => s.collapseTask)
+  const setPanelView = useUIStore((s) => s.setPanelView)
 
   function handleClick() {
     if (hasAttention) {
@@ -307,6 +309,13 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
             e.preventDefault()
             setSettingsTab('dependencies')
             setShowSettings(true)
+            break
+          case 'i':
+          case 'I':
+            e.preventDefault()
+            focusTask(task.id)
+            openChat(task.id)
+            setPanelView('detail')
             break
         }
       }}

--- a/src/components/layout/split-view.tsx
+++ b/src/components/layout/split-view.tsx
@@ -4,6 +4,7 @@ import { useUIStore } from '@/stores/ui-store'
 import { useResizablePanel } from '@/hooks/use-resizable-panel'
 import { ResizeHandle } from '@/components/shared/resize-handle'
 import { AgentPanel } from '@/components/panel/agent-panel'
+import { TaskDetailPanel } from '@/components/task-detail/task-detail-panel'
 
 const SPRING = { type: 'spring' as const, stiffness: 300, damping: 28 }
 
@@ -20,6 +21,8 @@ export function TaskSidePanel({
 
   const agentPanelWidth = useUIStore((s) => s.agentPanelWidth)
   const setAgentPanelWidth = useUIStore((s) => s.setAgentPanelWidth)
+  const panelView = useUIStore((s) => s.panelView)
+  const setPanelView = useUIStore((s) => s.setPanelView)
 
   const { handleMouseDown: handleResize, isDragging } = useResizablePanel({
     direction: 'horizontal',
@@ -44,7 +47,19 @@ export function TaskSidePanel({
             position="left"
             onMouseDown={handleResize}
           />
-          <AgentPanel task={task} onClose={onClose} />
+          {panelView === 'detail' ? (
+            <TaskDetailPanel
+              task={task}
+              onClose={onClose}
+              onSwitchToTerminal={() => { setPanelView('chat') }}
+            />
+          ) : (
+            <AgentPanel
+              task={task}
+              onClose={onClose}
+              onSwitchToDetail={() => { setPanelView('detail') }}
+            />
+          )}
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -11,9 +11,10 @@ import { TerminalView } from './terminal-view'
 type AgentPanelProps = {
   task: Task
   onClose?: () => void
+  onSwitchToDetail?: () => void
 }
 
-export function AgentPanel({ task, onClose }: AgentPanelProps) {
+export function AgentPanel({ task, onClose, onSwitchToDetail }: AgentPanelProps) {
   const workspace = useWorkspaceStore((s) =>
     s.workspaces.find((w) => w.id === task.workspaceId)
   )
@@ -43,6 +44,16 @@ export function AgentPanel({ task, onClose }: AgentPanelProps) {
             {task.title}
           </span>
         </div>
+        {onSwitchToDetail && (
+          <button
+            type="button"
+            onClick={onSwitchToDetail}
+            className="rounded border border-border-default px-2 py-1 text-[10px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+            title="Switch to task detail (⌘I)"
+          >
+            Detail
+          </button>
+        )}
       </div>
 
       {/* Terminal */}

--- a/src/components/task-detail/task-detail-panel.tsx
+++ b/src/components/task-detail/task-detail-panel.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { Task, TaskChecklistItem } from '@/types'
+import * as ipc from '@/lib/ipc'
+import { useTaskDetail } from '@/hooks/use-task-detail'
+import { ChangesSection } from './changes-section'
+import { CommitsSection } from './commits-section'
+import { UsageSection } from './usage-section'
+import { NotificationSection } from './notification-section'
+import { TaskChecklist } from './task-checklist'
+import { SiegeStatus } from './siege-status'
+
+type Tab = 'overview' | 'changes' | 'commits' | 'usage'
+
+const TABS: readonly Tab[] = ['overview', 'changes', 'commits', 'usage'] as const
+
+const TAB_LABELS: Record<Tab, string> = {
+  overview: 'Overview',
+  changes: 'Changes',
+  commits: 'Commits',
+  usage: 'Usage',
+}
+
+type TaskDetailPanelProps = {
+  task: Task
+  onClose: () => void
+  onSwitchToTerminal: () => void
+}
+
+export function TaskDetailPanel({
+  task,
+  onClose,
+  onSwitchToTerminal,
+}: TaskDetailPanelProps) {
+  const [tab, setTab] = useState<Tab>('overview')
+  const { changes, commits, loading, updateTask, repoPath } = useTaskDetail(task)
+
+  // Refresh the local task in the store from the backend (used by
+  // NotificationSection after it mutates stakeholders/notification state).
+  const refreshTask = useCallback(async () => {
+    const fresh = await ipc.getTask(task.id)
+    updateTask(task.id, fresh)
+  }, [task.id, updateTask])
+
+  // Persist checklist edits to backend + store.
+  const handleChecklistUpdate = useCallback(
+    (items: TaskChecklistItem[]) => {
+      const json = JSON.stringify(items)
+      updateTask(task.id, { checklist: json })
+      void ipc.updateTask(task.id, { checklist: json })
+    },
+    [task.id, updateTask],
+  )
+
+  // Keyboard: 1–4 switches tabs, but only when focus isn't in an input.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.defaultPrevented) return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      const target = e.target as HTMLElement | null
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return
+      }
+      const idx = ['1', '2', '3', '4'].indexOf(e.key)
+      if (idx >= 0) {
+        const next = TABS[idx]
+        if (next) {
+          e.preventDefault()
+          setTab(next)
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => { window.removeEventListener('keydown', handleKeyDown) }
+  }, [])
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border-default px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+            title="Close (Esc)"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M5 3l5 4-5 4" />
+            </svg>
+          </button>
+          <span className="text-xs font-medium text-text-primary">Detail</span>
+          <span className="truncate text-[10px] text-text-secondary max-w-[160px]">
+            {task.title}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onSwitchToTerminal}
+          className="rounded border border-border-default px-2 py-1 text-[10px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+          title="Switch to terminal (⌘I)"
+        >
+          Terminal
+        </button>
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex border-b border-border-default px-3">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => { setTab(t) }}
+            className={`px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
+              tab === t
+                ? 'border-accent text-accent'
+                : 'border-transparent text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {TAB_LABELS[t]}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'overview' && (
+          <OverviewTab
+            task={task}
+            repoPath={repoPath}
+            onRefresh={() => { void refreshTask() }}
+            onChecklistUpdate={handleChecklistUpdate}
+            onTaskUpdate={updateTask}
+          />
+        )}
+        {tab === 'changes' && (
+          <div className="p-3">
+            <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+              Changes
+            </h4>
+            <ChangesSection changes={changes} loading={loading} />
+          </div>
+        )}
+        {tab === 'commits' && (
+          <div className="p-3">
+            <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+              Commits
+            </h4>
+            <CommitsSection commits={commits} />
+          </div>
+        )}
+        {tab === 'usage' && (
+          <div className="p-3">
+            <UsageSection
+              agentType={task.agentType}
+              agentStatus={task.agentStatus}
+              startedAt={task.pipelineTriggeredAt}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Overview tab ───────────────────────────────────────────────────────────
+
+type OverviewTabProps = {
+  task: Task
+  repoPath: string | null
+  onRefresh: () => void
+  onChecklistUpdate: (items: TaskChecklistItem[]) => void
+  onTaskUpdate: (id: string, updates: Partial<Task>) => void
+}
+
+function OverviewTab({
+  task,
+  repoPath,
+  onRefresh,
+  onChecklistUpdate,
+  onTaskUpdate,
+}: OverviewTabProps) {
+  const labels = (() => {
+    try {
+      return JSON.parse(task.prLabels || '[]') as string[]
+    } catch {
+      return []
+    }
+  })()
+
+  const showSiege = task.siegeActive || task.siegeIteration > 0
+
+  return (
+    <div className="p-3 space-y-4">
+      {/* Description */}
+      {task.description && (
+        <section>
+          <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+            Description
+          </h4>
+          <p className="whitespace-pre-wrap text-xs leading-relaxed text-text-primary">
+            {task.description}
+          </p>
+        </section>
+      )}
+
+      {/* Metadata row */}
+      <section className="flex flex-wrap items-center gap-2">
+        {task.branch && (
+          <div className="flex items-center gap-1.5">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              className="text-text-secondary shrink-0"
+            >
+              <circle cx="4" cy="3" r="1.5" />
+              <circle cx="8" cy="9" r="1.5" />
+              <path d="M4 4.5V7.5C4 8.5 5 9 8 9M8 7.5V3" />
+            </svg>
+            <span
+              className="truncate font-mono text-[11px] text-accent max-w-[220px]"
+              title={task.branch}
+            >
+              {task.branch}
+            </span>
+            {task.worktreePath && (
+              <span
+                className="rounded bg-purple-500/10 px-1 py-0.5 text-[10px] font-medium text-purple-400"
+                title={task.worktreePath}
+              >
+                worktree
+              </span>
+            )}
+          </div>
+        )}
+        {task.model && (
+          <span className="rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+            {task.model}
+          </span>
+        )}
+        {task.agentType && (
+          <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] text-text-secondary">
+            {task.agentType}
+          </span>
+        )}
+        {task.prNumber && (
+          <a
+            href={task.prUrl ?? '#'}
+            target="_blank"
+            rel="noreferrer"
+            onClick={(e) => { if (!task.prUrl) e.preventDefault() }}
+            className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-primary hover:text-accent"
+          >
+            PR #{task.prNumber}
+            {task.prIsDraft ? ' · draft' : ''}
+          </a>
+        )}
+      </section>
+
+      {/* Labels */}
+      {labels.length > 0 && (
+        <section>
+          <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+            Labels
+          </h4>
+          <div className="flex flex-wrap items-center gap-1">
+            {labels.map((label) => (
+              <span
+                key={label}
+                className="rounded-full bg-surface-hover px-2 py-0.5 text-[10px] text-text-secondary"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Siege Loop (only when active/iterating) */}
+      {showSiege && (
+        <section>
+          <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+            Siege Loop
+          </h4>
+          <SiegeStatus task={task} onUpdate={onTaskUpdate} />
+        </section>
+      )}
+
+      {/* Checklist */}
+      <section>
+        <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-2">
+          Checklist
+        </h4>
+        <TaskChecklist
+          task={task}
+          onUpdate={onChecklistUpdate}
+          repoPath={repoPath}
+        />
+      </section>
+
+      {/* Notifications */}
+      <section>
+        <NotificationSection
+          taskId={task.id}
+          stakeholders={task.notifyStakeholders}
+          notificationSentAt={task.notificationSentAt}
+          onUpdate={onRefresh}
+        />
+      </section>
+
+      {/* Timestamps */}
+      <section className="grid grid-cols-2 gap-2 text-[11px] text-text-secondary">
+        <div>
+          <div className="font-medium uppercase tracking-wider">Created</div>
+          <div className="text-text-primary">
+            {new Date(task.createdAt).toLocaleString()}
+          </div>
+        </div>
+        <div>
+          <div className="font-medium uppercase tracking-wider">Updated</div>
+          <div className="text-text-primary">
+            {new Date(task.updatedAt).toLocaleString()}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/hooks/use-chat-panel.ts
+++ b/src/hooks/use-chat-panel.ts
@@ -1,17 +1,37 @@
 /** Hook for managing the agent chat slide-in panel. */
 
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { useUIStore } from '@/stores/ui-store'
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return true
+  if (target.isContentEditable) return true
+  return false
+}
 
 export function useChatPanel() {
   const viewMode = useUIStore((s) => s.viewMode)
   const activeTaskId = useUIStore((s) => s.activeTaskId)
   const expandedTaskId = useUIStore((s) => s.expandedTaskId)
   const closeChatAction = useUIStore((s) => s.closeChat)
+  const openChatAction = useUIStore((s) => s.openChat)
   const collapseTask = useUIStore((s) => s.collapseTask)
+  const panelView = useUIStore((s) => s.panelView)
+  const setPanelView = useUIStore((s) => s.setPanelView)
+  const togglePanelView = useUIStore((s) => s.togglePanelView)
 
   const isChatOpen = viewMode === 'chat'
+
+  // Open the detail view on a specific task (used by cards, command palette).
+  const openDetail = useCallback(
+    (taskId: string) => {
+      setPanelView('detail')
+      openChatAction(taskId)
+    },
+    [openChatAction, setPanelView],
+  )
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -26,6 +46,22 @@ export function useChatPanel() {
           collapseTask()
         }
         // Opening requires a task — handled by card click, not shortcut
+        return
+      }
+
+      // Cmd+I: toggle detail view on the active/focused task.
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'i' || e.key === 'I')) {
+        if (isEditableTarget(e.target)) return
+        if (isChatOpen && activeTaskId) {
+          e.preventDefault()
+          togglePanelView()
+          return
+        }
+        if (expandedTaskId) {
+          e.preventDefault()
+          setPanelView('detail')
+          openChatAction(expandedTaskId)
+        }
         return
       }
 
@@ -44,11 +80,22 @@ export function useChatPanel() {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => { window.removeEventListener('keydown', handleKeyDown) }
-  }, [isChatOpen, expandedTaskId, closeChatAction, collapseTask])
+  }, [
+    isChatOpen,
+    expandedTaskId,
+    activeTaskId,
+    closeChatAction,
+    openChatAction,
+    collapseTask,
+    togglePanelView,
+    setPanelView,
+  ])
 
   return {
     isChatOpen,
     activeTaskId,
+    panelView,
     closeChat: closeChatAction,
+    openDetail,
   }
 }

--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUIStore } from './ui-store'
+
+describe('ui-store', () => {
+  beforeEach(() => {
+    useUIStore.setState({ panelView: 'chat' })
+  })
+
+  describe('panelView', () => {
+    it('defaults to chat', () => {
+      expect(useUIStore.getState().panelView).toBe('chat')
+    })
+
+    it('setPanelView switches to detail', () => {
+      useUIStore.getState().setPanelView('detail')
+      expect(useUIStore.getState().panelView).toBe('detail')
+    })
+
+    it('togglePanelView flips chat <-> detail', () => {
+      useUIStore.getState().togglePanelView()
+      expect(useUIStore.getState().panelView).toBe('detail')
+      useUIStore.getState().togglePanelView()
+      expect(useUIStore.getState().panelView).toBe('chat')
+    })
+  })
+})

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -4,6 +4,7 @@ import { devtools, persist } from 'zustand/middleware'
 type ViewMode = 'board' | 'chat'
 type PanelDock = 'bottom' | 'right'
 type AgentPanelDock = 'right' | 'left'
+type PanelView = 'chat' | 'detail'
 
 type ModalState = {
   type: string
@@ -62,6 +63,9 @@ type UIState = {
   // Agent chat panel state
   agentPanelWidth: number
   agentPanelDock: AgentPanelDock
+
+  // Panel view (terminal vs detail) — routed inside the agent side panel
+  panelView: PanelView
   setViewMode: (mode: ViewMode) => void
   expandTask: (taskId: string) => void
   focusTask: (taskId: string) => void
@@ -86,6 +90,10 @@ type UIState = {
   // Agent panel actions
   setAgentPanelWidth: (width: number) => void
   setAgentPanelDock: (dock: AgentPanelDock) => void
+
+  // Panel view actions
+  setPanelView: (view: PanelView) => void
+  togglePanelView: () => void
 }
 
 export const useUIStore = create<UIState>()(
@@ -102,6 +110,7 @@ export const useUIStore = create<UIState>()(
         isPanelCollapsed: false,
         agentPanelWidth: DEFAULT_AGENT_PANEL_WIDTH,
         agentPanelDock: 'right' as AgentPanelDock,
+        panelView: 'chat' as PanelView,
 
         setViewMode: (mode) => {
           set({ viewMode: mode })
@@ -180,6 +189,14 @@ export const useUIStore = create<UIState>()(
         setAgentPanelDock: (dock) => {
           set({ agentPanelDock: dock })
         },
+
+        setPanelView: (view) => {
+          set({ panelView: view })
+        },
+
+        togglePanelView: () => {
+          set((state) => ({ panelView: state.panelView === 'chat' ? 'detail' : 'chat' }))
+        },
       }),
       {
         name: 'bento-ya-ui',
@@ -190,6 +207,7 @@ export const useUIStore = create<UIState>()(
           isPanelCollapsed: state.isPanelCollapsed,
           agentPanelWidth: state.agentPanelWidth,
           agentPanelDock: state.agentPanelDock,
+          panelView: state.panelView,
         }),
       },
     ),
@@ -200,4 +218,4 @@ export const useUIStore = create<UIState>()(
 export { MIN_PANEL_HEIGHT, MAX_PANEL_HEIGHT, DEFAULT_PANEL_HEIGHT, MIN_BOARD_HEIGHT }
 export { MIN_PANEL_WIDTH, MAX_PANEL_WIDTH, DEFAULT_PANEL_WIDTH, MIN_BOARD_WIDTH }
 export { MIN_AGENT_PANEL_WIDTH, MAX_AGENT_PANEL_WIDTH, DEFAULT_AGENT_PANEL_WIDTH }
-export type { PanelDock, AgentPanelDock }
+export type { PanelDock, AgentPanelDock, PanelView }


### PR DESCRIPTION
Clicking a task card opens the agent chat panel but there's no unified task detail view. Sub-sections exist individually in components/task-detail/ (changes, commits, usage, notifications) but aren't composed into a cohesive panel. Create a tabbed task detail view that aggregates all sub-sections.

## Acceptance criteria
- [ ] Tabbed detail view with description, changes, commits, usage
- [ ] Accessible via card click or keyboard shortcut
- [ ] Existing sub-components reused
- [ ] npx tsc --noEmit passes