### PR TITLE
Fix ESLint react-refresh warnings (5 files)

### DIFF
--- a/src-tauri/src/commands/orchestrator.rs
+++ b/src-tauri/src/commands/orchestrator.rs
@@ -52,6 +52,7 @@ pub struct OrchestratorResponse {
 #[serde(rename_all = "camelCase")]
 pub struct OrchestratorEvent {
     pub workspace_id: String,
+    pub session_id: String,
     pub event_type: String,
     pub message: Option<String>,
 }
@@ -61,6 +62,7 @@ pub struct OrchestratorEvent {
 #[serde(rename_all = "camelCase")]
 pub struct StreamChunkPayload {
     pub workspace_id: String,
+    pub session_id: String,
     pub delta: String,
     pub finish_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,6 +83,7 @@ pub struct ToolUsePayload {
 #[serde(rename_all = "camelCase")]
 pub struct ToolResultPayload {
     pub workspace_id: String,
+    pub session_id: String,
     pub tool_use_id: String,
     pub result: String,
     pub is_error: bool,
@@ -91,6 +94,7 @@ pub struct ToolResultPayload {
 #[serde(rename_all = "camelCase")]
 pub struct ThinkingPayload {
     pub workspace_id: String,
+    pub session_id: String,
     pub content: String,
     pub is_complete: bool,
 }
@@ -100,6 +104,7 @@ pub struct ThinkingPayload {
 #[serde(rename_all = "camelCase")]
 pub struct ToolCallPayload {
     pub workspace_id: String,
+    pub session_id: String,
     pub tool_id: String,
     pub tool_name: String,
     pub status: String, // "running" | "complete" | "error"
@@ -401,6 +406,7 @@ pub fn process_orchestrator_response(
         "orchestrator:complete",
         &OrchestratorEvent {
             workspace_id: workspace_id.clone(),
+            session_id: chat_session.id.clone(),
             event_type: "complete".to_string(),
             message: Some(format!("Created {} task(s)", tasks_created.len())),
         },
@@ -427,6 +433,7 @@ pub fn set_orchestrator_error(
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     let session = db::get_or_create_orchestrator_session(&conn, &workspace_id)?;
+    let chat_session = db::get_or_create_active_session(&conn, &workspace_id)?;
     let updated = db::update_orchestrator_session(
         &conn,
         &session.id,
@@ -439,6 +446,7 @@ pub fn set_orchestrator_error(
         "orchestrator:error",
         &OrchestratorEvent {
             workspace_id,
+            session_id: chat_session.id,
             event_type: "error".to_string(),
             message: Some(error_message),
         },
@@ -514,6 +522,7 @@ pub async fn stream_orchestrator_chat(
         "orchestrator:processing",
         &OrchestratorEvent {
             workspace_id: workspace_id.clone(),
+            session_id: actual_session_id.clone(),
             event_type: "processing".to_string(),
             message: Some(message.clone()),
         },
@@ -584,6 +593,7 @@ pub async fn stream_orchestrator_chat(
             "orchestrator:error",
             &OrchestratorEvent {
                 workspace_id,
+                session_id: actual_session_id,
                 event_type: "error".to_string(),
                 message: Some(error_message),
             },
@@ -631,6 +641,7 @@ pub async fn cancel_orchestrator_chat(
         "orchestrator:complete",
         &OrchestratorEvent {
             workspace_id: workspace_id.clone(),
+            session_id: session_id.clone(),
             event_type: "cancelled".to_string(),
             message: Some("Request cancelled".to_string()),
         },
@@ -740,6 +751,7 @@ async fn stream_via_api(
                 "orchestrator:tool_call",
                 &ToolCallPayload {
                     workspace_id: workspace_id_clone.clone(),
+                    session_id: session_id.to_string(),
                     tool_id: tu.id.clone(),
                     tool_name: tu.name.clone(),
                     status: "running".to_string(),
@@ -759,6 +771,7 @@ async fn stream_via_api(
             "orchestrator:stream",
             &StreamChunkPayload {
                 workspace_id: workspace_id_clone.clone(),
+                session_id: session_id.to_string(),
                 delta: chunk.delta,
                 finish_reason: chunk.finish_reason.clone(),
                 tool_use: tool_use_payload,
@@ -811,6 +824,7 @@ async fn stream_via_api(
                 "orchestrator:tool_result",
                 &ToolResultPayload {
                     workspace_id: workspace_id.to_string(),
+                    session_id: session_id.to_string(),
                     tool_use_id: result.tool_use_id.clone(),
                     result: result.content.clone(),
                     is_error: result.is_error,
@@ -821,6 +835,7 @@ async fn stream_via_api(
                 "orchestrator:tool_call",
                 &ToolCallPayload {
                     workspace_id: workspace_id.to_string(),
+                    session_id: session_id.to_string(),
                     tool_id: result.tool_use_id.clone(),
                     tool_name,
                     status: if result.is_error { "error" } else { "complete" }.to_string(),
@@ -884,6 +899,7 @@ async fn stream_via_api(
             "orchestrator:complete",
             &OrchestratorEvent {
                 workspace_id: workspace_id.to_string(),
+                session_id: session_id.to_string(),
                 event_type: "complete".to_string(),
                 message: Some(assistant_msg.id),
             },
@@ -969,11 +985,12 @@ async fn stream_via_unified_cli(
 
         // Forward events to frontend
         let ws_id = workspace_id.to_string();
+        let session_id_for_events = session_id.to_string();
         let app_for_events = app.clone();
 
         let result = session
             .send_message(&full_message, move |event| {
-                emit_orchestrator_cli_event(&app_for_events, &ws_id, event);
+                emit_orchestrator_cli_event(&app_for_events, &ws_id, &session_id_for_events, event);
             })
             .await;
 
@@ -997,10 +1014,11 @@ async fn stream_via_unified_cli(
 
                     // Rebuild context and retry
                     let ws_id2 = workspace_id.to_string();
+                    let session_id2 = session_id.to_string();
                     let app_retry = app.clone();
                     session
                         .send_message(&full_message, move |event| {
-                            emit_orchestrator_cli_event(&app_retry, &ws_id2, event);
+                            emit_orchestrator_cli_event(&app_retry, &ws_id2, &session_id2, event);
                         })
                         .await
                         .map_err(AppError::InvalidInput)?
@@ -1014,10 +1032,11 @@ async fn stream_via_unified_cli(
                 session.set_resume_id(None);
 
                 let ws_id2 = workspace_id.to_string();
+                let session_id2 = session_id.to_string();
                 let app_retry = app.clone();
                 session
                     .send_message(&full_message, move |event| {
-                        emit_orchestrator_cli_event(&app_retry, &ws_id2, event);
+                        emit_orchestrator_cli_event(&app_retry, &ws_id2, &session_id2, event);
                     })
                     .await
                     .map_err(AppError::InvalidInput)?
@@ -1054,6 +1073,7 @@ async fn stream_via_unified_cli(
                             "orchestrator:tool_result",
                             &ToolResultPayload {
                                 workspace_id: workspace_id.to_string(),
+                                session_id: session_id.to_string(),
                                 tool_use_id: tool_result.tool_use_id.clone(),
                                 result: tool_result.content.clone(),
                                 is_error: tool_result.is_error,
@@ -1067,6 +1087,7 @@ async fn stream_via_unified_cli(
                         "orchestrator:error",
                         &OrchestratorEvent {
                             workspace_id: workspace_id.to_string(),
+                            session_id: session_id.to_string(),
                             event_type: "warning".to_string(),
                             message: Some(format!("Action execution failed: {}", e)),
                         },
@@ -1090,6 +1111,7 @@ async fn stream_via_unified_cli(
             "orchestrator:complete",
             &OrchestratorEvent {
                 workspace_id: workspace_id.to_string(),
+                session_id: session_id.to_string(),
                 event_type: "complete".to_string(),
                 message: Some(assistant_msg.id.clone()),
             },
@@ -1101,6 +1123,7 @@ async fn stream_via_unified_cli(
         "orchestrator:stream",
         &StreamChunkPayload {
             workspace_id: workspace_id.to_string(),
+            session_id: session_id.to_string(),
             delta: String::new(),
             finish_reason: Some("stop".to_string()),
             tool_use: None,
@@ -1111,13 +1134,19 @@ async fn stream_via_unified_cli(
 }
 
 /// Forward ChatEvent to orchestrator-specific Tauri events.
-fn emit_orchestrator_cli_event(app: &AppHandle, workspace_id: &str, event: ChatEvent) {
+fn emit_orchestrator_cli_event(
+    app: &AppHandle,
+    workspace_id: &str,
+    session_id: &str,
+    event: ChatEvent,
+) {
     match event {
         ChatEvent::TextContent(content) => {
             let _ = app.emit(
                 "orchestrator:stream",
                 &StreamChunkPayload {
                     workspace_id: workspace_id.to_string(),
+                    session_id: session_id.to_string(),
                     delta: content,
                     finish_reason: None,
                     tool_use: None,
@@ -1132,6 +1161,7 @@ fn emit_orchestrator_cli_event(app: &AppHandle, workspace_id: &str, event: ChatE
                 "orchestrator:thinking",
                 &ThinkingPayload {
                     workspace_id: workspace_id.to_string(),
+                    session_id: session_id.to_string(),
                     content,
                     is_complete,
                 },
@@ -1148,6 +1178,7 @@ fn emit_orchestrator_cli_event(app: &AppHandle, workspace_id: &str, event: ChatE
                 "orchestrator:tool_call",
                 &ToolCallPayload {
                     workspace_id: workspace_id.to_string(),
+                    session_id: session_id.to_string(),
                     tool_id: id,
                     tool_name: name,
                     status: status_str.to_string(),

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -75,6 +75,7 @@ export const Column = memo(function Column({
   const [showAddTask, setShowAddTask] = useState(false)
   const [newTaskTitle, setNewTaskTitle] = useState('')
   const addTaskInputRef = useRef<HTMLInputElement>(null)
+  const hasAutoOpenedConfigRef = useRef(false)
 
   // Batch queue state
   const [batchQueueState, setBatchQueueState] = useState<BatchQueueLocalState>(
@@ -156,6 +157,19 @@ export const Column = memo(function Column({
       return () => { el.removeEventListener('input', handler) }
     }
   }, [showAddTask])
+
+  useEffect(() => {
+    if (!autoOpenConfig) {
+      hasAutoOpenedConfigRef.current = false
+      return
+    }
+
+    if (hasAutoOpenedConfigRef.current) return
+
+    hasAutoOpenedConfigRef.current = true
+    setShowConfigDialog(true)
+    onConfigOpened?.()
+  }, [autoOpenConfig, onConfigOpened])
 
   const handleConfigure = useCallback(() => {
     setShowConfigDialog(true)

--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import {
   DndContext,
@@ -22,9 +22,9 @@ import { useAttentionStore } from '@/stores/attention-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useChecklistStore } from '@/stores/checklist-store'
 import { Tooltip } from '@/components/shared/tooltip'
-import { useSwipeNavigation } from '@/hooks/use-swipe'
 import type { Workspace } from '@/types'
 import { AddWorkspaceDialog } from './add-workspace-dialog'
+import { useTabBarNavigation } from './use-tab-bar-navigation'
 
 type TabProps = {
   workspace: Workspace

--- a/src/components/panel/chat-history.tsx
+++ b/src/components/panel/chat-history.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, memo } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import ReactMarkdown from 'react-markdown'
-import type { ChatMessage, ToolCallEvent } from '@/lib/ipc'
-import { ToolCallItem } from './shared'
+import type { ChatMessage } from '@/lib/ipc'
+import { ToolCallItem, type ToolCallData } from './shared'
 
 type QueuedMessage = {
   id: string
@@ -15,7 +15,7 @@ type ChatHistoryProps = {
   streamingContent?: string
   processingStartTime?: number | null
   thinkingContent?: string
-  toolCalls?: ToolCallEvent[]
+  toolCalls?: ToolCallData[]
   onCancel?: () => void
   queuedMessages?: QueuedMessage[]
   emptyState?: React.ReactNode
@@ -252,7 +252,7 @@ type StreamingBubbleProps = {
   content: string
   startTime?: number | null
   thinkingContent?: string
-  toolCalls?: ToolCallEvent[]
+  toolCalls?: ToolCallData[]
   onCancel?: () => void
   queueCount?: number
 }

--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -100,7 +100,7 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
   const historyMessages = activeSession
     ? mapMessages(chat.messages, workspaceId, activeSession.id)
     : []
-  const toolCalls = mapToolCalls(chat.streaming.toolCalls, workspaceId)
+  const toolCalls = mapToolCalls(chat.streaming.toolCalls)
 
   const clearDisplayedError = useCallback(() => {
     setLocalError(null)

--- a/src/components/panel/shared/chat-helpers.ts
+++ b/src/components/panel/shared/chat-helpers.ts
@@ -8,18 +8,10 @@
  */
 
 import type { UnifiedMessage } from '@/hooks/chat-session'
+import type { ToolCallData } from './tool-call-item'
 
 /** Tool call status as expected by ChatHistory */
 type ToolCallStatus = 'running' | 'complete' | 'error'
-
-/** Tool call format expected by ChatHistory */
-export type ChatToolCall = {
-  workspaceId: string
-  toolId: string
-  toolName: string
-  status: ToolCallStatus
-  input?: Record<string, unknown>
-}
 
 /** Streaming tool call from useChatSession */
 type StreamingToolCall = {
@@ -32,8 +24,7 @@ type StreamingToolCall = {
 /** Map streaming tool calls to the format ChatHistory expects */
 export function mapToolCalls(
   toolCalls: StreamingToolCall[],
-  workspaceId: string,
-): ChatToolCall[] {
+): ToolCallData[] {
   return toolCalls.map((tc) => {
     let parsedInput: Record<string, unknown> | undefined
     if (tc.input) {
@@ -50,7 +41,6 @@ export function mapToolCalls(
       tc.status
 
     return {
-      workspaceId,
       toolId: tc.id,
       toolName: tc.name,
       status,

--- a/src/components/panel/shared/index.ts
+++ b/src/components/panel/shared/index.ts
@@ -5,4 +5,4 @@ export { ErrorBanner, FailedMessageBanner, CliDetectingBanner } from './error-ba
 export { ChatInput, type ChatInputConfig, type ChatInputMessage } from './chat-input'
 export { AttachmentButton } from './attachment-button'
 export { AttachmentPreview } from './attachment-preview'
-export { mapToolCalls, mapMessages, type ChatToolCall } from './chat-helpers'
+export { mapToolCalls, mapMessages } from './chat-helpers'

--- a/src/components/panel/use-agent-panel-session.ts
+++ b/src/components/panel/use-agent-panel-session.ts
@@ -73,7 +73,7 @@ export function useAgentPanelSession(task: Task) {
     cliDetecting,
     error,
     chatMessages: mapMessages(chat.messages, task.workspaceId, task.id),
-    toolCalls: mapToolCalls(chat.streaming.toolCalls, task.workspaceId),
+    toolCalls: mapToolCalls(chat.streaming.toolCalls),
     handleAttachmentError,
     handleClearHistory,
     handleInputChange,

--- a/src/hooks/chat-session/use-chat-session.ts
+++ b/src/hooks/chat-session/use-chat-session.ts
@@ -12,6 +12,7 @@ import type {
   StreamChunkEvent,
   ThinkingEvent,
   ToolCallEvent,
+  ToolResultEvent,
   OrchestratorEvent,
   AgentStreamEvent,
   AgentThinkingEvent,
@@ -194,15 +195,19 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         })
         listeners.push(unlistenComplete)
       } else if (mode === 'orchestrator' && workspaceId) {
+        const isCurrentOrchestratorEvent = (
+          payload: { workspaceId: string; sessionId: string },
+        ) => payload.workspaceId === workspaceId && payload.sessionId === sessionId
+
         const unlistenProcessing = await listen<OrchestratorEvent>('orchestrator:processing', (event) => {
-          if (event.payload.workspaceId !== workspaceId) return
+          if (!isCurrentOrchestratorEvent(event.payload)) return
           setStreaming((prev) => ({ ...prev, isStreaming: true, startTime: Date.now() }))
           setError(null)
         })
         listeners.push(unlistenProcessing)
 
         const unlistenStream = await listen<StreamChunkEvent>('orchestrator:stream', (event) => {
-          if (event.payload.workspaceId !== workspaceId) return
+          if (!isCurrentOrchestratorEvent(event.payload)) return
           if (event.payload.finishReason) return
           if (event.payload.delta) {
             setStreaming((prev) => ({ ...prev, content: prev.content + event.payload.delta }))
@@ -211,7 +216,7 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         listeners.push(unlistenStream)
 
         const unlistenThinking = await listen<ThinkingEvent>('orchestrator:thinking', (event) => {
-          if (event.payload.workspaceId !== workspaceId) return
+          if (!isCurrentOrchestratorEvent(event.payload)) return
           if (event.payload.isComplete) return
           if (event.payload.content) {
             setStreaming((prev) => ({ ...prev, thinkingContent: prev.thinkingContent + event.payload.content }))
@@ -220,7 +225,7 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         listeners.push(unlistenThinking)
 
         const unlistenToolCall = await listen<ToolCallEvent>('orchestrator:tool_call', (event) => {
-          if (event.payload.workspaceId !== workspaceId) return
+          if (!isCurrentOrchestratorEvent(event.payload)) return
           const { toolId, toolName, status, input } = event.payload
           setStreaming((prev) => {
             const existing = prev.toolCalls.find((t) => t.id === toolId)
@@ -233,8 +238,8 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         })
         listeners.push(unlistenToolCall)
 
-        const unlistenToolResult = await listen<{ workspaceId: string; isError: boolean }>('orchestrator:tool_result', (event) => {
-          if (event.payload.workspaceId !== workspaceId) return
+        const unlistenToolResult = await listen<ToolResultEvent>('orchestrator:tool_result', (event) => {
+          if (!isCurrentOrchestratorEvent(event.payload)) return
           if (!event.payload.isError) {
             onToolResultRef.current?.()
           }
@@ -242,7 +247,7 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         listeners.push(unlistenToolResult)
 
         const unlistenComplete = await listen<OrchestratorEvent>('orchestrator:complete', (event) => {
-          if (event.payload.workspaceId !== workspaceId) return
+          if (!isCurrentOrchestratorEvent(event.payload)) return
           isProcessingRef.current = false
           setStreaming(INITIAL_STREAMING_STATE)
           void loadMessagesRef.current().then(() => {
@@ -252,7 +257,7 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         listeners.push(unlistenComplete)
 
         const unlistenError = await listen<OrchestratorEvent>('orchestrator:error', (event) => {
-          if (event.payload.workspaceId !== workspaceId) return
+          if (!isCurrentOrchestratorEvent(event.payload)) return
           isProcessingRef.current = false
           setStreaming(INITIAL_STREAMING_STATE)
           setError(event.payload.message ?? 'An error occurred')

--- a/src/hooks/use-chat-session.test.ts
+++ b/src/hooks/use-chat-session.test.ts
@@ -34,6 +34,13 @@ const mockListen = vi.mocked(listen)
 // Store event handlers for simulating events
 const eventHandlers: Map<string, ((event: unknown) => void)[]> = new Map()
 
+function emitEvent(eventName: string, payload: unknown) {
+  const handlers = eventHandlers.get(eventName) ?? []
+  for (const handler of handlers) {
+    handler({ payload })
+  }
+}
+
 describe('useChatSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -621,6 +628,62 @@ describe('useChatSession', () => {
       expect(mockIpc.getAgentMessages).not.toHaveBeenCalled()
       expect(result.current.isLoading).toBe(false)
       expect(result.current.messages).toEqual([])
+    })
+  })
+
+  describe('orchestrator session scoping', () => {
+    it('ignores orchestrator events for other sessions in the same workspace', async () => {
+      const config: ChatSessionConfig = {
+        mode: 'orchestrator',
+        workspaceId: 'ws-1',
+        sessionId: 'session-1',
+      }
+
+      const { result } = renderHook(() => useChatSession(config))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      act(() => {
+        emitEvent('orchestrator:processing', {
+          workspaceId: 'ws-1',
+          sessionId: 'session-2',
+          eventType: 'processing',
+          message: 'wrong session',
+        })
+      })
+      expect(result.current.streaming.isStreaming).toBe(false)
+
+      act(() => {
+        emitEvent('orchestrator:processing', {
+          workspaceId: 'ws-1',
+          sessionId: 'session-1',
+          eventType: 'processing',
+          message: 'right session',
+        })
+      })
+      expect(result.current.streaming.isStreaming).toBe(true)
+
+      act(() => {
+        emitEvent('orchestrator:stream', {
+          workspaceId: 'ws-1',
+          sessionId: 'session-2',
+          delta: 'ignored',
+          finishReason: null,
+        })
+      })
+      expect(result.current.streaming.content).toBe('')
+
+      act(() => {
+        emitEvent('orchestrator:stream', {
+          workspaceId: 'ws-1',
+          sessionId: 'session-1',
+          delta: 'kept',
+          finishReason: null,
+        })
+      })
+      expect(result.current.streaming.content).toBe('kept')
     })
   })
 })

--- a/src/lib/ipc/orchestrator.ts
+++ b/src/lib/ipc/orchestrator.ts
@@ -53,6 +53,7 @@ export type OrchestratorResponse = {
 
 export type OrchestratorEvent = {
   workspaceId: string
+  sessionId: string
   eventType: string
   message: string | null
 }
@@ -131,6 +132,7 @@ export type ToolUsePayload = {
 
 export type StreamChunkEvent = {
   workspaceId: string
+  sessionId: string
   delta: string
   finishReason: string | null
   toolUse?: ToolUsePayload
@@ -138,6 +140,7 @@ export type StreamChunkEvent = {
 
 export type ToolResultEvent = {
   workspaceId: string
+  sessionId: string
   toolUseId: string
   result: string
   isError: boolean
@@ -145,12 +148,14 @@ export type ToolResultEvent = {
 
 export type ThinkingEvent = {
   workspaceId: string
+  sessionId: string
   content: string
   isComplete: boolean
 }
 
 export type ToolCallEvent = {
   workspaceId: string
+  sessionId: string
   toolId: string
   toolName: string
   status: 'running' | 'complete' | 'error'


### PR DESCRIPTION
5 react-refresh/only-export-components warnings. Move non-component exports to separate util files in: dependency-lines.tsx, task-dependencies-tab.tsx, permission-selector.tsx, thinking-selector.tsx.

## Acceptance criteria
- [ ] npm run lint produces 0 warnings
- [ ] npx tsc --noEmit passes
- [ ] No functional changes