### PR TITLE
Parse LLM responses into task board actions

### DIFF
--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -13,6 +13,8 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 
 use super::events::ChatEvent;
+#[cfg(test)]
+use super::tmux_transport;
 use super::transport::TransportEvent;
 use crate::db;
 use crate::pipeline;
@@ -223,6 +225,12 @@ fn build_trigger_command(cli_command: &str, args: &[String], initial_prompt: &st
         cmd_parts.push(format!("'{}'", escaped));
     }
     cmd_parts.join(" ")
+}
+
+/// tmux session name for a task (delegates to tmux_transport for single source of truth).
+#[cfg(test)]
+fn tmux_session_name(task_id: &str) -> String {
+    tmux_transport::session_name(task_id)
 }
 
 /// Run a CLI trigger by injecting the command into the task's tmux session.
@@ -467,9 +475,11 @@ mod tests {
     #[test]
     fn test_build_trigger_command_with_args() {
         let cmd = build_trigger_command("codex", &["--model".to_string(), "gpt-5".to_string()], "hello");
-        assert_eq!(
-            cmd,
-            "codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --model gpt-5 'hello'"
-        );
+        assert_eq!(cmd, "codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --model gpt-5 'hello'");
+    }
+
+    #[test]
+    fn test_tmux_session_name() {
+        assert_eq!(tmux_session_name("task-123"), "bentoya_task-123");
     }
 }

--- a/src-tauri/src/commands/orchestrator/actions.rs
+++ b/src-tauri/src/commands/orchestrator/actions.rs
@@ -1,6 +1,6 @@
 use crate::db::{self, AppState, OrchestratorSession};
 use crate::error::AppError;
-use crate::llm::{execute_tools, parse_cli_action_blocks, ToolUse};
+use crate::llm::{execute_tools, normalize_tool_name, parse_cli_action_blocks, ToolUse};
 use tauri::{AppHandle, Emitter, State};
 
 use super::{
@@ -47,6 +47,7 @@ pub(super) fn process_orchestrator_response(
         "orchestrator:complete",
         &OrchestratorEvent {
             workspace_id: workspace_id.clone(),
+            session_id: Some(chat_session.id),
             event_type: "complete".to_string(),
             message: Some(execution_summary),
         },
@@ -64,7 +65,7 @@ fn actions_to_tool_uses(actions: &[OrchestratorAction]) -> Vec<ToolUse> {
         .iter()
         .enumerate()
         .filter_map(|(index, action)| {
-            let name = normalize_action_type(&action.action_type)?;
+            let name = normalize_tool_name(&action.action_type)?;
             let mut input = serde_json::Map::new();
 
             if let Some(title) = &action.title {
@@ -101,16 +102,6 @@ fn actions_to_tool_uses(actions: &[OrchestratorAction]) -> Vec<ToolUse> {
         .collect()
 }
 
-fn normalize_action_type(action_type: &str) -> Option<&'static str> {
-    match action_type {
-        "create_task" => Some("create_task"),
-        "update_task" | "edit_task" => Some("update_task"),
-        "move_task" => Some("move_task"),
-        "delete_task" | "remove_task" => Some("delete_task"),
-        _ => None,
-    }
-}
-
 pub(super) fn set_orchestrator_error(
     app: AppHandle,
     state: State<AppState>,
@@ -131,6 +122,7 @@ pub(super) fn set_orchestrator_error(
         "orchestrator:error",
         &OrchestratorEvent {
             workspace_id,
+            session_id: None,
             event_type: "error".to_string(),
             message: Some(error_message),
         },

--- a/src-tauri/src/commands/orchestrator/actions.rs
+++ b/src-tauri/src/commands/orchestrator/actions.rs
@@ -1,5 +1,6 @@
 use crate::db::{self, AppState, OrchestratorSession};
 use crate::error::AppError;
+use crate::llm::{execute_tools, parse_cli_action_blocks, ToolUse};
 use tauri::{AppHandle, Emitter, State};
 
 use super::{
@@ -27,37 +28,16 @@ pub(super) fn process_orchestrator_response(
     )?;
 
     let mut tasks_created = Vec::new();
+    let mut execution_summary = "No changes made".to_string();
 
-    for action in &actions {
-        match action.action_type.as_str() {
-            "create_task" => {
-                if let (Some(title), Some(column_id)) = (&action.title, &action.column_id) {
-                    let task = db::insert_task(
-                        &conn,
-                        &workspace_id,
-                        column_id,
-                        title,
-                        action.description.as_deref(),
-                    )?;
-                    tasks_created.push(task);
-                }
-            }
-            "update_task" => {
-                if let Some(task_id) = &action.task_id {
-                    let _ = db::update_task(
-                        &conn,
-                        task_id,
-                        action.title.as_deref(),
-                        action.description.as_ref().map(|d| Some(d.as_str())),
-                        action.column_id.as_deref(),
-                        None,
-                        None,
-                        None,
-                    );
-                }
-            }
-            _ => {}
-        }
+    let mut tool_uses = actions_to_tool_uses(&actions);
+    tool_uses.extend(parse_cli_action_blocks(&response_text));
+
+    if !tool_uses.is_empty() {
+        let columns = db::list_columns(&conn, &workspace_id)?;
+        let execution = execute_tools(&conn, &app, &workspace_id, &tool_uses, &columns)?;
+        tasks_created = execution.tasks_created;
+        execution_summary = execution.summary;
     }
 
     let session = db::get_or_create_orchestrator_session(&conn, &workspace_id)?;
@@ -67,9 +47,8 @@ pub(super) fn process_orchestrator_response(
         "orchestrator:complete",
         &OrchestratorEvent {
             workspace_id: workspace_id.clone(),
-            session_id: chat_session.id,
             event_type: "complete".to_string(),
-            message: Some(format!("Created {} task(s)", tasks_created.len())),
+            message: Some(execution_summary),
         },
     );
 
@@ -80,6 +59,58 @@ pub(super) fn process_orchestrator_response(
     })
 }
 
+fn actions_to_tool_uses(actions: &[OrchestratorAction]) -> Vec<ToolUse> {
+    actions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, action)| {
+            let name = normalize_action_type(&action.action_type)?;
+            let mut input = serde_json::Map::new();
+
+            if let Some(title) = &action.title {
+                input.insert(
+                    "title".to_string(),
+                    serde_json::Value::String(title.clone()),
+                );
+            }
+            if let Some(description) = &action.description {
+                input.insert(
+                    "description".to_string(),
+                    serde_json::Value::String(description.clone()),
+                );
+            }
+            if let Some(column_id) = &action.column_id {
+                input.insert(
+                    "column_id".to_string(),
+                    serde_json::Value::String(column_id.clone()),
+                );
+            }
+            if let Some(task_id) = &action.task_id {
+                input.insert(
+                    "task_id".to_string(),
+                    serde_json::Value::String(task_id.clone()),
+                );
+            }
+
+            Some(ToolUse {
+                id: format!("orchestrator_action_{}", index),
+                name: name.to_string(),
+                input: serde_json::Value::Object(input),
+            })
+        })
+        .collect()
+}
+
+fn normalize_action_type(action_type: &str) -> Option<&'static str> {
+    match action_type {
+        "create_task" => Some("create_task"),
+        "update_task" | "edit_task" => Some("update_task"),
+        "move_task" => Some("move_task"),
+        "delete_task" | "remove_task" => Some("delete_task"),
+        _ => None,
+    }
+}
+
 pub(super) fn set_orchestrator_error(
     app: AppHandle,
     state: State<AppState>,
@@ -88,7 +119,6 @@ pub(super) fn set_orchestrator_error(
 ) -> Result<OrchestratorSession, AppError> {
     let conn = db_conn(&state)?;
 
-    let chat_session = db::get_or_create_active_session(&conn, &workspace_id)?;
     let session = db::get_or_create_orchestrator_session(&conn, &workspace_id)?;
     let updated = db::update_orchestrator_session(
         &conn,
@@ -101,7 +131,6 @@ pub(super) fn set_orchestrator_error(
         "orchestrator:error",
         &OrchestratorEvent {
             workspace_id,
-            session_id: chat_session.id,
             event_type: "error".to_string(),
             message: Some(error_message),
         },

--- a/src-tauri/src/commands/orchestrator/stream.rs
+++ b/src-tauri/src/commands/orchestrator/stream.rs
@@ -62,7 +62,7 @@ pub(super) async fn stream_orchestrator_chat(
         "orchestrator:processing",
         &OrchestratorEvent {
             workspace_id: workspace_id.clone(),
-            session_id: actual_session_id.clone(),
+            session_id: Some(actual_session_id.clone()),
             event_type: "processing".to_string(),
             message: Some(message.clone()),
         },
@@ -135,7 +135,7 @@ pub(super) async fn stream_orchestrator_chat(
             "orchestrator:error",
             &OrchestratorEvent {
                 workspace_id,
-                session_id: actual_session_id,
+                session_id: Some(actual_session_id),
                 event_type: "error".to_string(),
                 message: Some(error_message),
             },
@@ -175,7 +175,7 @@ pub(super) async fn cancel_orchestrator_chat(
         "orchestrator:complete",
         &OrchestratorEvent {
             workspace_id: workspace_id.clone(),
-            session_id,
+            session_id: Some(session_id),
             event_type: "cancelled".to_string(),
             message: Some("Request cancelled".to_string()),
         },

--- a/src-tauri/src/commands/orchestrator/stream_api.rs
+++ b/src-tauri/src/commands/orchestrator/stream_api.rs
@@ -92,7 +92,6 @@ pub(super) async fn stream_via_api(
     let client = AnthropicClient::new(api_key.to_string());
     let app_clone = app.clone();
     let workspace_id_clone = workspace_id.to_string();
-    let session_id_clone = session_id.to_string();
     let mut pending_tool_calls: HashMap<String, (String, serde_json::Value)> = HashMap::new();
 
     let stream_handle = tokio::spawn(async move { client.stream_chat(request, tx).await });
@@ -109,7 +108,7 @@ pub(super) async fn stream_via_api(
                 "orchestrator:tool_call",
                 &ToolCallPayload {
                     workspace_id: workspace_id_clone.clone(),
-                    session_id: session_id_clone.clone(),
+                    session_id: session_id.to_string(),
                     tool_id: tu.id.clone(),
                     tool_name: tu.name.clone(),
                     status: "running".to_string(),
@@ -129,7 +128,7 @@ pub(super) async fn stream_via_api(
             "orchestrator:stream",
             &StreamChunkPayload {
                 workspace_id: workspace_id_clone.clone(),
-                session_id: session_id_clone.clone(),
+                session_id: session_id.to_string(),
                 delta: chunk.delta,
                 finish_reason: chunk.finish_reason.clone(),
                 tool_use: tool_use_payload,
@@ -244,7 +243,7 @@ pub(super) async fn stream_via_api(
             "orchestrator:complete",
             &OrchestratorEvent {
                 workspace_id: workspace_id.to_string(),
-                session_id: session_id.to_string(),
+                session_id: Some(session_id.to_string()),
                 event_type: "complete".to_string(),
                 message: Some(assistant_msg.id),
             },

--- a/src-tauri/src/commands/orchestrator/stream_cli.rs
+++ b/src-tauri/src/commands/orchestrator/stream_cli.rs
@@ -77,12 +77,12 @@ pub(super) async fn stream_via_unified_cli(
         let full_message = prompt_builder.augment_message(message, &workspace, &columns, &tasks);
 
         let ws_id = workspace_id.to_string();
-        let sid = session_id.to_string();
+        let chat_session_id = session_id.to_string();
         let app_for_events = app.clone();
 
         let result = session
             .send_message(&full_message, move |event| {
-                emit_orchestrator_cli_event(&app_for_events, &ws_id, &sid, event);
+                emit_orchestrator_cli_event(&app_for_events, &ws_id, &chat_session_id, event);
             })
             .await;
 
@@ -100,11 +100,16 @@ pub(super) async fn stream_via_unified_cli(
                     }
 
                     let ws_id2 = workspace_id.to_string();
-                    let sid2 = session_id.to_string();
+                    let chat_session_id2 = session_id.to_string();
                     let app_retry = app.clone();
                     session
                         .send_message(&full_message, move |event| {
-                            emit_orchestrator_cli_event(&app_retry, &ws_id2, &sid2, event);
+                            emit_orchestrator_cli_event(
+                                &app_retry,
+                                &ws_id2,
+                                &chat_session_id2,
+                                event,
+                            );
                         })
                         .await
                         .map_err(AppError::InvalidInput)?
@@ -117,11 +122,11 @@ pub(super) async fn stream_via_unified_cli(
                 session.set_resume_id(None);
 
                 let ws_id2 = workspace_id.to_string();
-                let sid2 = session_id.to_string();
+                let chat_session_id2 = session_id.to_string();
                 let app_retry = app.clone();
                 session
                     .send_message(&full_message, move |event| {
-                        emit_orchestrator_cli_event(&app_retry, &ws_id2, &sid2, event);
+                        emit_orchestrator_cli_event(&app_retry, &ws_id2, &chat_session_id2, event);
                     })
                     .await
                     .map_err(AppError::InvalidInput)?
@@ -164,7 +169,7 @@ pub(super) async fn stream_via_unified_cli(
                         "orchestrator:error",
                         &OrchestratorEvent {
                             workspace_id: workspace_id.to_string(),
-                            session_id: session_id.to_string(),
+                            session_id: Some(session_id.to_string()),
                             event_type: "warning".to_string(),
                             message: Some(format!("Action execution failed: {}", e)),
                         },
@@ -184,7 +189,7 @@ pub(super) async fn stream_via_unified_cli(
             "orchestrator:complete",
             &OrchestratorEvent {
                 workspace_id: workspace_id.to_string(),
-                session_id: session_id.to_string(),
+                session_id: Some(session_id.to_string()),
                 event_type: "complete".to_string(),
                 message: Some(assistant_msg.id.clone()),
             },

--- a/src-tauri/src/commands/orchestrator/types.rs
+++ b/src-tauri/src/commands/orchestrator/types.rs
@@ -34,7 +34,8 @@ pub struct OrchestratorResponse {
 #[serde(rename_all = "camelCase")]
 pub struct OrchestratorEvent {
     pub workspace_id: String,
-    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
     pub event_type: String,
     pub message: Option<String>,
 }
@@ -130,7 +131,7 @@ pub(super) fn api_stream_key(workspace_id: &str, session_id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{api_stream_key, ApiStreamRegistry, OrchestratorEvent, StreamChunkPayload};
+    use super::{api_stream_key, ApiStreamRegistry};
 
     #[test]
     fn test_api_stream_key() {
@@ -138,30 +139,6 @@ mod tests {
             api_stream_key("ws-1", "session-1"),
             "chef-api:ws-1:session-1"
         );
-    }
-
-    #[test]
-    fn test_orchestrator_events_include_session_id() {
-        let event = OrchestratorEvent {
-            workspace_id: "ws-1".to_string(),
-            session_id: "session-1".to_string(),
-            event_type: "complete".to_string(),
-            message: None,
-        };
-        let payload = serde_json::to_value(event).unwrap();
-        assert_eq!(payload["workspaceId"], "ws-1");
-        assert_eq!(payload["sessionId"], "session-1");
-
-        let stream = StreamChunkPayload {
-            workspace_id: "ws-1".to_string(),
-            session_id: "session-1".to_string(),
-            delta: "hello".to_string(),
-            finish_reason: None,
-            tool_use: None,
-        };
-        let payload = serde_json::to_value(stream).unwrap();
-        assert_eq!(payload["workspaceId"], "ws-1");
-        assert_eq!(payload["sessionId"], "session-1");
     }
 
     #[tokio::test]

--- a/src-tauri/src/llm/executor.rs
+++ b/src-tauri/src/llm/executor.rs
@@ -69,17 +69,17 @@ pub fn execute_tools(
     let mut tasks_created = Vec::new();
     let mut tasks_updated = Vec::new();
     let mut tasks_deleted = Vec::new();
-    let mut queued_task_count = 0usize;
-    let mut configured_trigger_count = 0usize;
 
     // Track the last created task ID for __LAST__ references
     let mut last_created_task_id: Option<String> = None;
 
     for tool_use in tool_uses {
         // Resolve __LAST__ placeholder in input (references last created task)
-        let resolved_input = resolve_last_placeholder(&tool_use.input, last_created_task_id.as_deref());
+        let resolved_input =
+            resolve_last_placeholder(&tool_use.input, last_created_task_id.as_deref());
 
-        let result = execute_single_tool(conn, workspace_id, &tool_use.name, &resolved_input, columns);
+        let result =
+            execute_single_tool(conn, workspace_id, &tool_use.name, &resolved_input, columns);
 
         match result {
             Ok(outcome) => {
@@ -100,14 +100,21 @@ pub fn execute_tools(
 
                         results.push(ToolResult {
                             tool_use_id: tool_use.id.clone(),
-                            content: format!("Created task: \"{}\" in {}", task.title, get_column_name(&task.column_id, columns)),
+                            content: format!(
+                                "Created task: \"{}\" in {}",
+                                task.title,
+                                get_column_name(&task.column_id, columns)
+                            ),
                             is_error: false,
                         });
                         // Emit event for frontend
-                        let _ = app.emit("task:created", TaskCreatedPayload {
-                            workspace_id: workspace_id.to_string(),
-                            task: task.clone(),
-                        });
+                        let _ = app.emit(
+                            "task:created",
+                            TaskCreatedPayload {
+                                workspace_id: workspace_id.to_string(),
+                                task: task.clone(),
+                            },
+                        );
                         // Emit tasks:changed so frontend refreshes
                         pipeline::emit_tasks_changed(app, workspace_id, "orchestrator_tool");
                         last_created_task_id = Some(task.id.clone());
@@ -119,10 +126,14 @@ pub fn execute_tools(
                             content: format!("Updated task: \"{}\"", task.title),
                             is_error: false,
                         });
-                        let _ = app.emit("task:updated", TaskUpdatedPayload {
-                            workspace_id: workspace_id.to_string(),
-                            task: task.clone(),
-                        });
+                        let _ = app.emit(
+                            "task:updated",
+                            TaskUpdatedPayload {
+                                workspace_id: workspace_id.to_string(),
+                                task: task.clone(),
+                            },
+                        );
+                        pipeline::emit_tasks_changed(app, workspace_id, "orchestrator_tool");
                         tasks_updated.push(task);
                     }
                     ToolOutcome::TaskMoved(task, from_col, to_col) => {
@@ -140,13 +151,19 @@ pub fn execute_tools(
 
                         results.push(ToolResult {
                             tool_use_id: tool_use.id.clone(),
-                            content: format!("Moved \"{}\" from {} to {}", task.title, from_col, to_col),
+                            content: format!(
+                                "Moved \"{}\" from {} to {}",
+                                task.title, from_col, to_col
+                            ),
                             is_error: false,
                         });
-                        let _ = app.emit("task:updated", TaskUpdatedPayload {
-                            workspace_id: workspace_id.to_string(),
-                            task: task.clone(),
-                        });
+                        let _ = app.emit(
+                            "task:updated",
+                            TaskUpdatedPayload {
+                                workspace_id: workspace_id.to_string(),
+                                task: task.clone(),
+                            },
+                        );
                         // Emit tasks:changed so frontend refreshes
                         pipeline::emit_tasks_changed(app, workspace_id, "orchestrator_tool");
                         tasks_updated.push(task);
@@ -157,37 +174,52 @@ pub fn execute_tools(
                             content: format!("Deleted task: \"{}\"", title),
                             is_error: false,
                         });
-                        let _ = app.emit("task:deleted", TaskDeletedPayload {
-                            workspace_id: workspace_id.to_string(),
-                            task_id: task_id.clone(),
-                        });
+                        let _ = app.emit(
+                            "task:deleted",
+                            TaskDeletedPayload {
+                                workspace_id: workspace_id.to_string(),
+                                task_id: task_id.clone(),
+                            },
+                        );
+                        pipeline::emit_tasks_changed(app, workspace_id, "orchestrator_tool");
                         tasks_deleted.push(task_id);
                     }
                     ToolOutcome::TasksQueued(task_ids, agent_type) => {
-                        queued_task_count += task_ids.len();
                         results.push(ToolResult {
                             tool_use_id: tool_use.id.clone(),
-                            content: format!("Queued {} task(s) for {} agent processing", task_ids.len(), agent_type),
+                            content: format!(
+                                "Queued {} task(s) for {} agent processing",
+                                task_ids.len(),
+                                agent_type
+                            ),
                             is_error: false,
                         });
                         // Emit event for frontend to handle batch agent spawning
-                        let _ = app.emit("queue:batch_requested", QueueBatchRequestedPayload {
-                            workspace_id: workspace_id.to_string(),
-                            task_ids: task_ids.clone(),
-                            agent_type: agent_type.clone(),
-                        });
+                        let _ = app.emit(
+                            "queue:batch_requested",
+                            QueueBatchRequestedPayload {
+                                workspace_id: workspace_id.to_string(),
+                                task_ids: task_ids.clone(),
+                                agent_type: agent_type.clone(),
+                            },
+                        );
                     }
                     ToolOutcome::TriggersConfigured(column_id, column_name, triggers_json) => {
-                        configured_trigger_count += 1;
                         results.push(ToolResult {
                             tool_use_id: tool_use.id.clone(),
-                            content: format!("Configured triggers for column \"{}\":\n{}", column_name, triggers_json),
+                            content: format!(
+                                "Configured triggers for column \"{}\":\n{}",
+                                column_name, triggers_json
+                            ),
                             is_error: false,
                         });
-                        let _ = app.emit("column:updated", ColumnUpdatedPayload {
-                            workspace_id: workspace_id.to_string(),
-                            column_id: column_id.clone(),
-                        });
+                        let _ = app.emit(
+                            "column:updated",
+                            ColumnUpdatedPayload {
+                                workspace_id: workspace_id.to_string(),
+                                column_id: column_id.clone(),
+                            },
+                        );
                     }
                 }
             }
@@ -212,15 +244,6 @@ pub fn execute_tools(
     if !tasks_deleted.is_empty() {
         summary_parts.push(format!("Deleted {} task(s)", tasks_deleted.len()));
     }
-    if queued_task_count > 0 {
-        summary_parts.push(format!("Queued {} task(s)", queued_task_count));
-    }
-    if configured_trigger_count > 0 {
-        summary_parts.push(format!(
-            "Configured triggers for {} column(s)",
-            configured_trigger_count
-        ));
-    }
     let summary = if summary_parts.is_empty() {
         "No changes made".to_string()
     } else {
@@ -239,7 +262,9 @@ pub fn execute_tools(
 /// Replace __LAST__ and PENDING placeholders in tool input with the actual task ID.
 /// This allows chained actions like: create_task → move_task with task_id: "__LAST__"
 fn resolve_last_placeholder(input: &serde_json::Value, last_id: Option<&str>) -> serde_json::Value {
-    let Some(id) = last_id else { return input.clone() };
+    let Some(id) = last_id else {
+        return input.clone();
+    };
 
     match input {
         serde_json::Value::String(s) => {
@@ -256,9 +281,11 @@ fn resolve_last_placeholder(input: &serde_json::Value, last_id: Option<&str>) ->
             }
             serde_json::Value::Object(new_map)
         }
-        serde_json::Value::Array(arr) => {
-            serde_json::Value::Array(arr.iter().map(|v| resolve_last_placeholder(v, Some(id))).collect())
-        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.iter()
+                .map(|v| resolve_last_placeholder(v, Some(id)))
+                .collect(),
+        ),
         _ => input.clone(),
     }
 }
@@ -267,9 +294,9 @@ fn resolve_last_placeholder(input: &serde_json::Value, last_id: Option<&str>) ->
 enum ToolOutcome {
     TaskCreated(Task),
     TaskUpdated(Task),
-    TaskMoved(Task, String, String),          // task, from_column, to_column
-    TaskDeleted(String, String),              // task_id, title
-    TasksQueued(Vec<String>, String),         // task_ids, agent_type
+    TaskMoved(Task, String, String),  // task, from_column, to_column
+    TaskDeleted(String, String),      // task_id, title
+    TasksQueued(Vec<String>, String), // task_ids, agent_type
     TriggersConfigured(String, String, String), // column_id, column_name, triggers_json
 }
 
@@ -287,12 +314,24 @@ fn execute_single_tool(
                 .get("title")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| AppError::InvalidInput("Missing title".to_string()))?;
+            let title = title.trim();
+            if title.is_empty() {
+                return Err(AppError::InvalidInput(
+                    "Task title cannot be empty".to_string(),
+                ));
+            }
 
             let description = input.get("description").and_then(|v| v.as_str());
 
-            // Find column by name, or use first column
-            let column_name = input.get("column").and_then(|v| v.as_str());
-            let column_id = find_column_id(columns, column_name)?;
+            let column_id = if let Some(column_id) = input
+                .get("column_id")
+                .or_else(|| input.get("columnId"))
+                .and_then(|v| v.as_str())
+            {
+                resolve_column_id(columns, column_id)?
+            } else {
+                find_column_id(columns, input.get("column").and_then(|v| v.as_str()))?
+            };
 
             let task = db::insert_task(conn, workspace_id, &column_id, title, description)
                 .map_err(|e| AppError::DatabaseError(e.to_string()))?;
@@ -303,10 +342,24 @@ fn execute_single_tool(
         "update_task" => {
             let task_id = input
                 .get("task_id")
+                .or_else(|| input.get("taskId"))
+                .or_else(|| input.get("id"))
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| AppError::InvalidInput("Missing task_id".to_string()))?;
 
             let title = input.get("title").and_then(|v| v.as_str());
+            let title = title
+                .map(str::trim)
+                .map(|title| {
+                    if title.is_empty() {
+                        Err(AppError::InvalidInput(
+                            "Task title cannot be empty".to_string(),
+                        ))
+                    } else {
+                        Ok(title)
+                    }
+                })
+                .transpose()?;
             let description = input.get("description").and_then(|v| v.as_str());
 
             // Convert description to the expected Option<Option<&str>> format
@@ -330,43 +383,62 @@ fn execute_single_tool(
         "move_task" => {
             let task_id = input
                 .get("task_id")
+                .or_else(|| input.get("taskId"))
+                .or_else(|| input.get("id"))
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| AppError::InvalidInput("Missing task_id".to_string()))?;
 
-            let column_name = input
-                .get("column")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| AppError::InvalidInput("Missing column".to_string()))?;
-
             // Get current task to know the source column
-            let current_task = db::get_task(conn, task_id)
-                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let current_task =
+                db::get_task(conn, task_id).map_err(|e| AppError::DatabaseError(e.to_string()))?;
             let from_column = get_column_name(&current_task.column_id, columns);
 
-            // Find target column
-            let target_column_id = find_column_id(columns, Some(column_name))?;
+            let target_column_id = if let Some(column_id) = input
+                .get("column_id")
+                .or_else(|| input.get("columnId"))
+                .or_else(|| input.get("target_column_id"))
+                .or_else(|| input.get("targetColumnId"))
+                .and_then(|v| v.as_str())
+            {
+                resolve_column_id(columns, column_id)?
+            } else {
+                let column_name = input
+                    .get("column")
+                    .or_else(|| input.get("target_column"))
+                    .or_else(|| input.get("targetColumn"))
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| AppError::InvalidInput("Missing column".to_string()))?;
+                find_column_id(columns, Some(column_name))?
+            };
             let to_column = get_column_name(&target_column_id, columns);
 
-            // Move to end of target column
-            let max_pos: i64 = conn
-                .query_row(
+            let position = if let Some(value) = input.get("position") {
+                let position = value.as_i64().ok_or_else(|| {
+                    AppError::InvalidInput("Position must be an integer".to_string())
+                })?;
+                if position < 0 {
+                    return Err(AppError::InvalidInput(
+                        "Position must be non-negative".to_string(),
+                    ));
+                }
+                position
+            } else {
+                conn.query_row(
                     "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
                     rusqlite::params![target_column_id],
-                    |row| row.get(0),
+                    |row| row.get::<_, i64>(0),
                 )
-                .unwrap_or(-1);
+                .map(|max_pos| max_pos + 1)
+                .unwrap_or(0)
+            };
 
-            let task = db::update_task(
+            let task = move_task_to_column(
                 conn,
                 task_id,
-                None,
-                None,
-                Some(&target_column_id),
-                Some(max_pos + 1),
-                None,
-                None,
-            )
-            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+                &current_task.column_id,
+                &target_column_id,
+                position,
+            )?;
 
             Ok(ToolOutcome::TaskMoved(task, from_column, to_column))
         }
@@ -374,16 +446,17 @@ fn execute_single_tool(
         "delete_task" => {
             let task_id = input
                 .get("task_id")
+                .or_else(|| input.get("taskId"))
+                .or_else(|| input.get("id"))
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| AppError::InvalidInput("Missing task_id".to_string()))?;
 
             // Get task title before deleting
-            let task = db::get_task(conn, task_id)
-                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let task =
+                db::get_task(conn, task_id).map_err(|e| AppError::DatabaseError(e.to_string()))?;
             let title = task.title.clone();
 
-            db::delete_task(conn, task_id)
-                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            db::delete_task(conn, task_id).map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
             Ok(ToolOutcome::TaskDeleted(task_id.to_string(), title))
         }
@@ -398,7 +471,9 @@ fn execute_single_tool(
                 .collect::<Vec<_>>();
 
             if task_ids.is_empty() {
-                return Err(AppError::InvalidInput("task_ids array is empty".to_string()));
+                return Err(AppError::InvalidInput(
+                    "task_ids array is empty".to_string(),
+                ));
             }
 
             let agent_type = input
@@ -426,19 +501,28 @@ fn execute_single_tool(
                 "on_exit": input.get("on_exit").cloned().unwrap_or(json!(null)),
                 "exit_criteria": input.get("exit_criteria").cloned().unwrap_or(json!({"type": "manual", "auto_advance": false})),
             });
-            let triggers_json = serde_json::to_string(&triggers)
-                .map_err(|e| AppError::InvalidInput(format!("Failed to serialize triggers: {}", e)))?;
+            let triggers_json = serde_json::to_string(&triggers).map_err(|e| {
+                AppError::InvalidInput(format!("Failed to serialize triggers: {}", e))
+            })?;
 
             // Save to database
             db::update_column(
                 conn,
                 &column_id,
-                None, None, None, None, None,
+                None,
+                None,
+                None,
+                None,
+                None,
                 Some(&triggers_json),
             )
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
-            Ok(ToolOutcome::TriggersConfigured(column_id, col_name, triggers_json))
+            Ok(ToolOutcome::TriggersConfigured(
+                column_id,
+                col_name,
+                triggers_json,
+            ))
         }
 
         _ => Err(AppError::InvalidInput(format!(
@@ -500,6 +584,39 @@ fn find_column_id(columns: &[Column], name: Option<&str>) -> Result<String, AppE
     )))
 }
 
+/// Resolve an explicit column ID, accepting a column name as a fallback.
+fn resolve_column_id(columns: &[Column], id_or_name: &str) -> Result<String, AppError> {
+    if let Some(col) = columns.iter().find(|c| c.id == id_or_name) {
+        return Ok(col.id.clone());
+    }
+
+    find_column_id(columns, Some(id_or_name))
+}
+
+fn move_task_to_column(
+    conn: &Connection,
+    task_id: &str,
+    old_column_id: &str,
+    target_column_id: &str,
+    position: i64,
+) -> Result<Task, AppError> {
+    let ts = db::now();
+    if old_column_id == target_column_id {
+        conn.execute(
+            "UPDATE tasks SET column_id = ?1, position = ?2, updated_at = ?3 WHERE id = ?4",
+            rusqlite::params![target_column_id, position, ts, task_id],
+        )
+    } else {
+        conn.execute(
+            "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
+            rusqlite::params![target_column_id, position, ts, task_id],
+        )
+    }
+    .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    db::get_task(conn, task_id).map_err(|e| AppError::DatabaseError(e.to_string()))
+}
+
 /// Get column name by ID
 fn get_column_name(column_id: &str, columns: &[Column]) -> String {
     columns
@@ -512,6 +629,7 @@ fn get_column_name(column_id: &str, columns: &[Column]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn mock_columns() -> Vec<Column> {
         vec![
@@ -594,5 +712,78 @@ mod tests {
         let columns = mock_columns();
         let result = find_column_id(&columns, Some("nonexistent"));
         assert!(result.is_err());
+    }
+
+    fn setup_db_with_columns() -> (rusqlite::Connection, String, Vec<Column>) {
+        let conn = db::init_test().unwrap();
+        let workspace = db::insert_workspace(&conn, "Test", "/tmp/test").unwrap();
+        let backlog = db::insert_column(&conn, &workspace.id, "Backlog", 0).unwrap();
+        let done = db::insert_column(&conn, &workspace.id, "Done", 1).unwrap();
+        (conn, workspace.id, vec![backlog, done])
+    }
+
+    #[test]
+    fn test_create_task_rejects_blank_title() {
+        let (conn, workspace_id, columns) = setup_db_with_columns();
+        let result = execute_single_tool(
+            &conn,
+            &workspace_id,
+            "create_task",
+            &json!({ "title": "   ", "column": "Backlog" }),
+            &columns,
+        );
+
+        assert!(
+            matches!(result, Err(AppError::InvalidInput(message)) if message == "Task title cannot be empty")
+        );
+    }
+
+    #[test]
+    fn test_move_task_resets_pipeline_state_when_column_changes() {
+        let (conn, workspace_id, columns) = setup_db_with_columns();
+        let task = db::insert_task(&conn, &workspace_id, &columns[0].id, "Task", None).unwrap();
+        db::update_task_pipeline_state(
+            &conn,
+            &task.id,
+            "error",
+            Some("2024-01-01T00:00:00Z"),
+            Some("failed"),
+        )
+        .unwrap();
+
+        let outcome = execute_single_tool(
+            &conn,
+            &workspace_id,
+            "move_task",
+            &json!({ "task_id": task.id, "column_id": columns[1].id }),
+            &columns,
+        )
+        .unwrap();
+
+        let ToolOutcome::TaskMoved(moved, _, _) = outcome else {
+            panic!("expected task move");
+        };
+        assert_eq!(moved.column_id, columns[1].id);
+        assert_eq!(moved.pipeline_state, "idle");
+        assert!(moved.pipeline_triggered_at.is_none());
+        assert!(moved.pipeline_error.is_none());
+    }
+
+    #[test]
+    fn test_move_task_rejects_non_integer_position() {
+        let (conn, workspace_id, columns) = setup_db_with_columns();
+        let task = db::insert_task(&conn, &workspace_id, &columns[0].id, "Task", None).unwrap();
+
+        let result = execute_single_tool(
+            &conn,
+            &workspace_id,
+            "move_task",
+            &json!({ "task_id": task.id, "column_id": columns[1].id, "position": "first" }),
+            &columns,
+        );
+
+        assert!(
+            matches!(result, Err(AppError::InvalidInput(message)) if message == "Position must be an integer")
+        );
     }
 }

--- a/src-tauri/src/llm/mod.rs
+++ b/src-tauri/src/llm/mod.rs
@@ -11,5 +11,5 @@ pub mod types;
 pub use anthropic::{AnthropicClient, calculate_cost, get_api_key};
 pub use context::{build_board_context, build_cli_system_prompt, build_system_prompt, format_board_context_message};
 pub use executor::{execute_tools, ExecutionResult};
-pub use tools::{orchestrator_tools, parse_cli_action_blocks, parse_tool_uses, extract_text_content, tools_to_api_format, ToolDefinition, ToolResult, ToolUse};
+pub use tools::{orchestrator_tools, normalize_tool_name, parse_cli_action_blocks, parse_tool_uses, extract_text_content, tools_to_api_format, ToolDefinition, ToolResult, ToolUse};
 pub use types::{LlmRequest, LlmResponse, Message, Provider, StreamChunk, TokenUsage, ToolUseBlock, resolve_model_id, get_model_pricing};

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -34,7 +34,7 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
             name: "create_task".to_string(),
-            description: "Create a new task on the board. Use a concise title, put longer requirements or acceptance criteria in description, and place it in an existing column by name. If no column is provided, the first column is used.".to_string(),
+            description: "Create a new task on the board. Tasks are placed in the specified column (or the first column if not specified).".to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -48,7 +48,7 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
                     },
                     "column": {
                         "type": "string",
-                        "description": "Existing column name to place the task in. Matching is case-insensitive; prefer exact names from the board."
+                        "description": "The column name to place the task in. If not provided, uses the first column (usually Backlog)"
                     }
                 },
                 "required": ["title"]
@@ -56,7 +56,7 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "update_task".to_string(),
-            description: "Update an existing task's title or description. Use only task IDs from the current board context, and preserve fields the user did not ask to change.".to_string(),
+            description: "Update an existing task's title or description.".to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -78,7 +78,7 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "move_task".to_string(),
-            description: "Move an existing task to a different board column. Use task IDs from the current board context and an existing target column name.".to_string(),
+            description: "Move a task to a different column.".to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -88,7 +88,7 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
                     },
                     "column": {
                         "type": "string",
-                        "description": "Existing target column name. Matching is case-insensitive; prefer exact names from the board."
+                        "description": "The target column name to move the task to"
                     }
                 },
                 "required": ["task_id", "column"]
@@ -96,7 +96,7 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "delete_task".to_string(),
-            description: "Delete an existing task from the board. This action cannot be undone; only use it when the user clearly asks to delete/remove a task.".to_string(),
+            description: "Delete a task from the board. This action cannot be undone.".to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -110,7 +110,7 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "queue_tasks".to_string(),
-            description: "Queue existing tasks for batch agent processing. Use task IDs from the current board context; tasks will be processed concurrently by agents (up to 5 at a time).".to_string(),
+            description: "Queue multiple tasks for batch agent processing. The tasks will be processed concurrently by agents (up to 5 at a time).".to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -130,7 +130,6 @@ pub fn orchestrator_tools() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "configure_triggers".to_string(),
             description: r#"Configure automation triggers for a column. Set what happens when tasks enter/exit a column.
-Use an existing column name from the board.
 
 Action types for on_entry/on_exit:
 - {"type": "spawn_cli", "cli": "claude"|"codex"|"aider", "command": "/start-task", "prompt_template": "{task.title}\n\n{task.description}", "use_queue": true}
@@ -215,8 +214,28 @@ pub fn extract_text_content(content: &[serde_json::Value]) -> String {
         .join("")
 }
 
-/// Parse action blocks from CLI response text
-/// Looks for ```action ... ``` blocks containing JSON arrays of actions
+/// Parse structured tool uses from response text.
+///
+/// Supports Anthropic-style `tool_use` content blocks, arrays of tool uses,
+/// wrapper objects with `tool_use`, `tool_uses`, `actions`, or `content`
+/// fields, and direct action objects.
+pub fn parse_structured_tool_uses(response: &str) -> Vec<ToolUse> {
+    parse_json_candidates(response)
+        .into_iter()
+        .flat_map(|value| tool_uses_from_value(&value))
+        .enumerate()
+        .map(|(index, mut tool_use)| {
+            if tool_use.id.is_empty() {
+                tool_use.id = format!("structured_tool_use_{}", index);
+            }
+            tool_use
+        })
+        .collect()
+}
+
+/// Parse action blocks from CLI response text.
+/// Looks for ```action ... ``` blocks containing JSON arrays of actions, and
+/// also accepts structured JSON tool_use/action payloads.
 pub fn parse_cli_action_blocks(response: &str) -> Vec<ToolUse> {
     let mut tool_uses = Vec::new();
     let mut counter = 0;
@@ -230,38 +249,13 @@ pub fn parse_cli_action_blocks(response: &str) -> Vec<ToolUse> {
         if let Some(end_idx) = after_marker.find("```") {
             let json_content = after_marker[..end_idx].trim();
 
-            // Try to parse as JSON array
-            if let Ok(actions) = serde_json::from_str::<Vec<serde_json::Value>>(json_content) {
-                for action in actions {
-                    if let Some(action_type) = action.get("action").and_then(|a| a.as_str()) {
-                        // Map CLI action format to ToolUse format
-                        let tool_name = match action_type {
-                            "create_task" => "create_task",
-                            "update_task" => "update_task",
-                            "move_task" => "move_task",
-                            "delete_task" => "delete_task",
-                            "queue_tasks" => "queue_tasks",
-                            "configure_triggers" => "configure_triggers",
-                            _ => continue,
-                        };
-
-                        // Build input from action fields (excluding "action" itself)
-                        let mut input = serde_json::Map::new();
-                        if let Some(obj) = action.as_object() {
-                            for (key, value) in obj {
-                                if key != "action" {
-                                    input.insert(key.clone(), value.clone());
-                                }
-                            }
-                        }
-
-                        tool_uses.push(ToolUse {
-                            id: format!("cli_action_{}", counter),
-                            name: tool_name.to_string(),
-                            input: serde_json::Value::Object(input),
-                        });
-                        counter += 1;
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(json_content) {
+                for mut tool_use in tool_uses_from_value(&value) {
+                    if tool_use.id.is_empty() {
+                        tool_use.id = format!("cli_action_{}", counter);
                     }
+                    tool_uses.push(tool_use);
+                    counter += 1;
                 }
             }
 
@@ -271,7 +265,171 @@ pub fn parse_cli_action_blocks(response: &str) -> Vec<ToolUse> {
         }
     }
 
+    tool_uses.extend(parse_structured_tool_uses(response));
+
     tool_uses
+}
+
+fn parse_json_candidates(response: &str) -> Vec<serde_json::Value> {
+    let mut candidates = Vec::new();
+    let trimmed = response.trim();
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        candidates.push(value);
+    }
+
+    candidates.extend(parse_fenced_json_blocks(response));
+    candidates
+}
+
+fn parse_fenced_json_blocks(response: &str) -> Vec<serde_json::Value> {
+    let mut values = Vec::new();
+    let mut remaining = response;
+
+    while let Some(start_idx) = remaining.find("```") {
+        let after_fence = &remaining[start_idx + 3..];
+        let Some(end_idx) = after_fence.find("```") else {
+            break;
+        };
+
+        let block = &after_fence[..end_idx];
+        let trimmed = block.trim_start();
+        let (language, content) = trimmed
+            .split_once('\n')
+            .map(|(language, content)| (language.trim(), content.trim()))
+            .unwrap_or(("", trimmed.trim()));
+
+        if language.eq_ignore_ascii_case("action") {
+            remaining = &after_fence[end_idx + 3..];
+            continue;
+        }
+
+        let content = if language.eq_ignore_ascii_case("json") {
+            content
+        } else {
+            trimmed.trim()
+        };
+
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
+            values.push(value);
+        }
+
+        remaining = &after_fence[end_idx + 3..];
+    }
+
+    values
+}
+
+fn tool_uses_from_value(value: &serde_json::Value) -> Vec<ToolUse> {
+    match value {
+        serde_json::Value::Array(items) => items
+            .iter()
+            .flat_map(tool_uses_from_value)
+            .collect::<Vec<_>>(),
+        serde_json::Value::Object(map) => {
+            if let Some(tool_use) = tool_use_from_object(map) {
+                return vec![tool_use];
+            }
+
+            for key in [
+                "tool_use",
+                "toolUse",
+                "tool_uses",
+                "toolUses",
+                "actions",
+                "content",
+            ] {
+                if let Some(nested) = map.get(key) {
+                    let parsed = tool_uses_from_value(nested);
+                    if !parsed.is_empty() {
+                        return parsed;
+                    }
+                }
+            }
+
+            Vec::new()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn tool_use_from_object(map: &serde_json::Map<String, serde_json::Value>) -> Option<ToolUse> {
+    if let Some(block_type) = map.get("type").and_then(|v| v.as_str()) {
+        if block_type != "tool_use"
+            && map.get("action").is_none()
+            && map.get("action_type").is_none()
+            && map.get("actionType").is_none()
+        {
+            return None;
+        }
+    }
+
+    let name = map
+        .get("name")
+        .or_else(|| map.get("tool_name"))
+        .or_else(|| map.get("toolName"))
+        .or_else(|| map.get("action"))
+        .or_else(|| map.get("action_type"))
+        .or_else(|| map.get("actionType"))
+        .and_then(|v| v.as_str())
+        .and_then(normalize_tool_name)?;
+
+    let is_action_object = map.get("action").is_some()
+        || map.get("action_type").is_some()
+        || map.get("actionType").is_some();
+    let id = if is_action_object {
+        String::new()
+    } else {
+        map.get("id")
+            .or_else(|| map.get("tool_use_id"))
+            .or_else(|| map.get("toolUseId"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+
+    let input = map.get("input").cloned().unwrap_or_else(|| {
+        let mut input = serde_json::Map::new();
+        for (key, value) in map {
+            if !matches!(
+                key.as_str(),
+                "type"
+                    | "name"
+                    | "tool_name"
+                    | "toolName"
+                    | "tool_use_id"
+                    | "toolUseId"
+                    | "action"
+                    | "action_type"
+                    | "actionType"
+            ) {
+                if key == "id" && !is_action_object {
+                    continue;
+                }
+                input.insert(key.clone(), value.clone());
+            }
+        }
+        serde_json::Value::Object(input)
+    });
+
+    Some(ToolUse {
+        id,
+        name: name.to_string(),
+        input,
+    })
+}
+
+fn normalize_tool_name(name: &str) -> Option<&'static str> {
+    let normalized = name.trim().to_ascii_lowercase().replace([' ', '-'], "_");
+    match normalized.as_str() {
+        "create_task" | "create" => Some("create_task"),
+        "update_task" | "edit_task" | "edit" | "update" => Some("update_task"),
+        "move_task" | "move" => Some("move_task"),
+        "delete_task" | "remove_task" | "delete" | "remove" => Some("delete_task"),
+        "queue_tasks" | "queue" => Some("queue_tasks"),
+        "configure_triggers" => Some("configure_triggers"),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -294,23 +452,6 @@ mod tests {
         assert!(names.contains(&"delete_task"));
         assert!(names.contains(&"queue_tasks"));
         assert!(names.contains(&"configure_triggers"));
-    }
-
-    #[test]
-    fn test_tool_descriptions_include_board_schema_guidance() {
-        let tools = orchestrator_tools();
-
-        let create_task = tools.iter().find(|t| t.name == "create_task").unwrap();
-        assert!(create_task.description.contains("concise title"));
-        assert!(create_task.description.contains("existing column"));
-
-        let update_task = tools.iter().find(|t| t.name == "update_task").unwrap();
-        assert!(update_task
-            .description
-            .contains("task IDs from the current board context"));
-
-        let delete_task = tools.iter().find(|t| t.name == "delete_task").unwrap();
-        assert!(delete_task.description.contains("clearly asks to delete"));
     }
 
     #[test]
@@ -406,5 +547,66 @@ Done! Triggers configured for "In Progress"."#;
         assert_eq!(tool_uses[0].input["column"], "In Progress");
         assert_eq!(tool_uses[0].input["on_entry"]["type"], "spawn_cli");
         assert_eq!(tool_uses[0].input["exit_criteria"]["auto_advance"], true);
+    }
+
+    #[test]
+    fn test_parse_structured_tool_uses_content_blocks() {
+        let response = r#"{
+            "content": [
+                {"type": "text", "text": "Updating the task."},
+                {"type": "tool_use", "id": "toolu_1", "name": "edit_task", "input": {"task_id": "task-1", "title": "New title"}}
+            ]
+        }"#;
+
+        let tool_uses = parse_structured_tool_uses(response);
+        assert_eq!(tool_uses.len(), 1);
+        assert_eq!(tool_uses[0].id, "toolu_1");
+        assert_eq!(tool_uses[0].name, "update_task");
+        assert_eq!(tool_uses[0].input["task_id"], "task-1");
+    }
+
+    #[test]
+    fn test_parse_structured_tool_uses_actions_array() {
+        let response = r#"{
+            "actions": [
+                {"action": "move", "task_id": "task-1", "column": "Done"},
+                {"action": "remove_task", "id": "task-2"}
+            ]
+        }"#;
+
+        let tool_uses = parse_structured_tool_uses(response);
+        assert_eq!(tool_uses.len(), 2);
+        assert_eq!(tool_uses[0].name, "move_task");
+        assert_eq!(tool_uses[0].input["column"], "Done");
+        assert_eq!(tool_uses[1].name, "delete_task");
+        assert_eq!(tool_uses[1].input["id"], "task-2");
+    }
+
+    #[test]
+    fn test_parse_structured_tool_uses_ignores_named_text_blocks() {
+        let response = r#"{
+            "content": [
+                {"type": "text", "name": "create_task", "text": "This is only an example."},
+                {"type": "tool_use", "id": "toolu_1", "name": "Create Task", "input": {"title": "Real task"}}
+            ]
+        }"#;
+
+        let tool_uses = parse_structured_tool_uses(response);
+        assert_eq!(tool_uses.len(), 1);
+        assert_eq!(tool_uses[0].name, "create_task");
+        assert_eq!(tool_uses[0].input["title"], "Real task");
+    }
+
+    #[test]
+    fn test_parse_cli_action_blocks_does_not_duplicate_action_fence() {
+        let response = r#"```action
+[
+  {"action": "create_task", "title": "One"}
+]
+```"#;
+
+        let tool_uses = parse_cli_action_blocks(response);
+        assert_eq!(tool_uses.len(), 1);
+        assert_eq!(tool_uses[0].name, "create_task");
     }
 }

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -419,7 +419,7 @@ fn tool_use_from_object(map: &serde_json::Map<String, serde_json::Value>) -> Opt
     })
 }
 
-fn normalize_tool_name(name: &str) -> Option<&'static str> {
+pub fn normalize_tool_name(name: &str) -> Option<&'static str> {
     let normalized = name.trim().to_ascii_lowercase().replace([' ', '-'], "_");
     match normalized.as_str() {
         "create_task" | "create" => Some("create_task"),

--- a/src/components/kanban/task-quick-actions.tsx
+++ b/src/components/kanban/task-quick-actions.tsx
@@ -1,80 +1,64 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useState, useCallback } from 'react'
 import type { Task } from '@/types'
 
 const CONFIRM_TIMEOUT_MS = 2000
 
+type DeleteConfirmationProps =
+  | {
+      deleteConfirmPending: boolean
+      onDeleteConfirmPendingChange: (pending: boolean) => void
+    }
+  | {
+      deleteConfirmPending?: undefined
+      onDeleteConfirmPendingChange?: undefined
+    }
+
 type TaskQuickActionsProps = {
   task: Task
   hasNextColumn: boolean
-  deleteConfirmPending?: boolean
   onOpen: () => void
   onToggleAgent: () => void
   onRetry: () => void
   onMoveNext: () => void
   onDelete: () => void
   onShowMenu: (e: React.MouseEvent) => void
-}
+} & DeleteConfirmationProps
 
 export const TaskQuickActions = memo(function TaskQuickActions({
   task,
   hasNextColumn,
-  deleteConfirmPending,
   onOpen,
   onToggleAgent,
   onRetry,
   onMoveNext,
   onDelete,
   onShowMenu,
+  deleteConfirmPending,
+  onDeleteConfirmPendingChange,
 }: TaskQuickActionsProps) {
   const isRunning = task.agentStatus === 'running'
   const hasError = !!task.pipelineError
+
   const [internalConfirmDelete, setInternalConfirmDelete] = useState(false)
-  const internalConfirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const isDeleteConfirmPending = deleteConfirmPending ?? internalConfirmDelete
+  const confirmDelete = deleteConfirmPending ?? internalConfirmDelete
+  const setConfirmDelete = onDeleteConfirmPendingChange ?? setInternalConfirmDelete
 
-  const clearInternalConfirmTimeout = useCallback(() => {
-    if (internalConfirmTimeoutRef.current) {
-      clearTimeout(internalConfirmTimeoutRef.current)
-      internalConfirmTimeoutRef.current = null
+  const handleDelete = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (confirmDelete) {
+      onDelete()
+      setConfirmDelete(false)
+    } else {
+      setConfirmDelete(true)
+      // Auto-dismiss after 2s
+      setTimeout(() => { setConfirmDelete(false) }, CONFIRM_TIMEOUT_MS)
     }
-  }, [])
-
-  useEffect(() => clearInternalConfirmTimeout, [clearInternalConfirmTimeout])
-
-  useEffect(() => {
-    clearInternalConfirmTimeout()
-    setInternalConfirmDelete(false)
-  }, [clearInternalConfirmTimeout, task.id])
-
-  const handleDelete = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation()
-      if (deleteConfirmPending !== undefined) {
-        onDelete()
-        return
-      }
-
-      if (internalConfirmDelete) {
-        onDelete()
-        setInternalConfirmDelete(false)
-      } else {
-        clearInternalConfirmTimeout()
-        setInternalConfirmDelete(true)
-        internalConfirmTimeoutRef.current = setTimeout(() => {
-          setInternalConfirmDelete(false)
-          internalConfirmTimeoutRef.current = null
-        }, CONFIRM_TIMEOUT_MS)
-      }
-    },
-    [clearInternalConfirmTimeout, deleteConfirmPending, internalConfirmDelete, onDelete],
-  )
+  }, [confirmDelete, onDelete, setConfirmDelete])
 
   return (
     <div
       className="absolute right-1 top-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10"
-      onClick={(e) => {
-        e.stopPropagation()
-      }}
+      onClick={(e) => { e.stopPropagation(); }}
     >
       {/* Open in panel */}
       <button
@@ -112,19 +96,12 @@ export const TaskQuickActions = memo(function TaskQuickActions({
       {/* Retry - visible when task has pipeline error */}
       {hasError && (
         <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onRetry()
-          }}
+          onClick={(e) => { e.stopPropagation(); onRetry(); }}
           className="flex h-6 w-6 items-center justify-center rounded text-text-secondary hover:bg-warning/20 hover:text-warning transition-colors"
           title="Retry pipeline (R)"
         >
           <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
-            <path
-              fillRule="evenodd"
-              d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H4.598a.75.75 0 0 0-.75.75v3.634a.75.75 0 0 0 1.5 0v-2.033l.312.311a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39l-.611.21ZM4.688 8.576a5.5 5.5 0 0 1 9.201-2.466l.312.311h-2.433a.75.75 0 0 0 0 1.5h3.634a.75.75 0 0 0 .75-.75V3.537a.75.75 0 0 0-1.5 0v2.033l-.312-.311A7 7 0 0 0 3.628 8.397a.75.75 0 0 0 1.449.39l-.389-.211Z"
-              clipRule="evenodd"
-            />
+            <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H4.598a.75.75 0 0 0-.75.75v3.634a.75.75 0 0 0 1.5 0v-2.033l.312.311a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39l-.611.21ZM4.688 8.576a5.5 5.5 0 0 1 9.201-2.466l.312.311h-2.433a.75.75 0 0 0 0 1.5h3.634a.75.75 0 0 0 .75-.75V3.537a.75.75 0 0 0-1.5 0v2.033l-.312-.311A7 7 0 0 0 3.628 8.397a.75.75 0 0 0 1.449.39l-.389-.211Z" clipRule="evenodd" />
           </svg>
         </button>
       )}
@@ -132,19 +109,12 @@ export const TaskQuickActions = memo(function TaskQuickActions({
       {/* Move to next column */}
       {hasNextColumn && (
         <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onMoveNext()
-          }}
+          onClick={(e) => { e.stopPropagation(); onMoveNext(); }}
           className="flex h-6 w-6 items-center justify-center rounded text-text-secondary hover:bg-surface-hover hover:text-accent transition-colors"
           title="Move to next column (→)"
         >
           <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
-            <path
-              fillRule="evenodd"
-              d="M3 10a.75.75 0 0 1 .75-.75h10.638l-3.96-4.158a.75.75 0 1 1 1.085-1.034l5.25 5.5a.75.75 0 0 1 0 1.034l-5.25 5.5a.75.75 0 1 1-1.085-1.034l3.96-4.158H3.75A.75.75 0 0 1 3 10Z"
-              clipRule="evenodd"
-            />
+            <path fillRule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638l-3.96-4.158a.75.75 0 1 1 1.085-1.034l5.25 5.5a.75.75 0 0 1 0 1.034l-5.25 5.5a.75.75 0 1 1-1.085-1.034l3.96-4.158H3.75A.75.75 0 0 1 3 10Z" clipRule="evenodd" />
           </svg>
         </button>
       )}
@@ -153,18 +123,14 @@ export const TaskQuickActions = memo(function TaskQuickActions({
       <button
         onClick={handleDelete}
         className={`flex h-6 w-6 items-center justify-center rounded transition-colors ${
-          isDeleteConfirmPending
+          confirmDelete
             ? 'text-error bg-error/20'
             : 'text-text-secondary hover:bg-error/20 hover:text-error'
         }`}
-        title={isDeleteConfirmPending ? 'Click again to confirm' : 'Delete task (Del)'}
+        title={confirmDelete ? 'Click again to confirm' : 'Delete task (Del)'}
       >
         <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
-          <path
-            fillRule="evenodd"
-            d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM7.5 3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25V4.1a40.3 40.3 0 0 0-5 0v-.35ZM9 7.75a.75.75 0 0 0-1.5 0v6.5a.75.75 0 0 0 1.5 0v-6.5Zm3.25-.75a.75.75 0 0 1 .75.75v6.5a.75.75 0 0 1-1.5 0v-6.5a.75.75 0 0 1 .75-.75Z"
-            clipRule="evenodd"
-          />
+          <path fillRule="evenodd" d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM7.5 3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25V4.1a40.3 40.3 0 0 0-5 0v-.35ZM9 7.75a.75.75 0 0 0-1.5 0v6.5a.75.75 0 0 0 1.5 0v-6.5Zm3.25-.75a.75.75 0 0 1 .75.75v6.5a.75.75 0 0 1-1.5 0v-6.5a.75.75 0 0 1 .75-.75Z" clipRule="evenodd" />
         </svg>
       </button>
 

--- a/src/hooks/chat-session/use-chat-session.ts
+++ b/src/hooks/chat-session/use-chat-session.ts
@@ -31,6 +31,10 @@ import { INITIAL_STREAMING_STATE } from './types'
 import { getErrorMessage, toUnifiedMessage, buildContextPreamble } from './helpers'
 import { useAgentStreamingStore } from '@/stores/agent-streaming-store'
 
+function toStreamingToolCallStatus(status: ToolCallEvent['status']): ToolCall['status'] {
+  return status === 'complete' ? 'completed' : status
+}
+
 // ─── Hook Implementation ───────────────────────────────────────────────────
 
 export function useChatSession(config: ChatSessionConfig): ChatSessionState & ChatSessionActions {
@@ -228,13 +232,14 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         const unlistenToolCall = await listen<ToolCallEvent>('orchestrator:tool_call', (event) => {
           if (!isCurrentOrchestratorSession(event.payload)) return
           const { toolId, toolName, status, input } = event.payload
+          const nextStatus = toStreamingToolCallStatus(status)
           setStreaming((prev) => {
             const existing = prev.toolCalls.find((t) => t.id === toolId)
             const inputStr = input ? JSON.stringify(input) : ''
             if (existing) {
-              return { ...prev, toolCalls: prev.toolCalls.map((t) => t.id === toolId ? { ...t, status: status as ToolCall['status'] } : t) }
+              return { ...prev, toolCalls: prev.toolCalls.map((t) => t.id === toolId ? { ...t, status: nextStatus } : t) }
             }
-            return { ...prev, toolCalls: [...prev.toolCalls, { id: toolId, name: toolName, input: inputStr, status: status as ToolCall['status'] }] }
+            return { ...prev, toolCalls: [...prev.toolCalls, { id: toolId, name: toolName, input: inputStr, status: nextStatus }] }
           })
         })
         listeners.push(unlistenToolCall)

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import type { Column, ColumnTriggers } from '@/types'
 import * as ipc from '@/lib/ipc'
-import { refreshWorkspaceSummary } from './workspace-refresh'
+import { useWorkspaceStore } from '@/stores/workspace-store'
 
 type ColumnUpdates = {
   name?: string
@@ -30,20 +30,10 @@ type ColumnState = {
   updateColumnAsync: (id: string, updates: ColumnUpdates) => Promise<void>
 }
 
-function parseOptimisticTriggers(
-  triggers: string,
-  fallback: Column['triggers'],
-): ColumnTriggers | undefined {
-  try {
-    const parsed: unknown = JSON.parse(triggers)
-    if (parsed && typeof parsed === 'object') {
-      return parsed as ColumnTriggers
-    }
-  } catch {
-    return fallback
+async function refreshWorkspace(workspaceId: string | undefined) {
+  if (workspaceId) {
+    await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
   }
-
-  return fallback
 }
 
 export const useColumnStore = create<ColumnState>()(
@@ -61,17 +51,17 @@ export const useColumnStore = create<ColumnState>()(
         const position = get().columns.length
         const column = await ipc.createColumn(workspaceId, name, position)
         set((s) => ({ columns: [...s.columns, column] }))
-        await refreshWorkspaceSummary(workspaceId)
+        await refreshWorkspace(workspaceId)
         return column
       },
 
       remove: async (id) => {
         const prev = get().columns
-        const workspaceId = prev.find((c) => c.id === id)?.workspaceId
         set((s) => ({ columns: s.columns.filter((c) => c.id !== id) }))
         try {
           await ipc.deleteColumn(id)
-          await refreshWorkspaceSummary(workspaceId)
+          const workspaceId = prev.find((column) => column.id === id)?.workspaceId
+          await refreshWorkspace(workspaceId)
         } catch {
           set({ columns: prev })
         }
@@ -89,7 +79,7 @@ export const useColumnStore = create<ColumnState>()(
         }))
         try {
           await ipc.reorderColumns(workspaceId, ids)
-          await refreshWorkspaceSummary(workspaceId)
+          await refreshWorkspace(workspaceId)
         } catch {
           set({ columns: prev })
         }
@@ -103,6 +93,15 @@ export const useColumnStore = create<ColumnState>()(
 
       updateColumnAsync: async (id, updates) => {
         const prev = get().columns
+        let parsedTriggers: ColumnTriggers | undefined
+        if (updates.triggers !== undefined) {
+          try {
+            parsedTriggers = JSON.parse(updates.triggers) as ColumnTriggers
+          } catch {
+            parsedTriggers = undefined
+          }
+        }
+
         // Optimistically update
         set((s) => ({
           columns: s.columns.map((c) =>
@@ -113,11 +112,9 @@ export const useColumnStore = create<ColumnState>()(
                   ...(updates.icon !== undefined && { icon: updates.icon }),
                   ...(updates.color !== undefined && { color: updates.color ?? '' }),
                   ...(updates.visible !== undefined && { visible: updates.visible }),
-                  ...(updates.triggers !== undefined && {
-                    triggers: parseOptimisticTriggers(updates.triggers, c.triggers),
-                  }),
+                  ...(parsedTriggers !== undefined && { triggers: parsedTriggers }),
                 }
-              : c,
+              : c
           ),
         }))
         try {

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -3,7 +3,7 @@ import { devtools } from 'zustand/middleware'
 import type { Task } from '@/types'
 import * as ipc from '@/lib/ipc'
 import { useUIStore } from '@/stores/ui-store'
-import { refreshWorkspaceSummary } from './workspace-refresh'
+import { useWorkspaceStore } from '@/stores/workspace-store'
 
 type TaskState = {
   tasks: Task[]
@@ -17,6 +17,12 @@ type TaskState = {
   updateTask: (id: string, updates: Partial<Task>) => void
   getByColumn: (columnId: string) => Task[]
   duplicate: (id: string) => Promise<Task | null>
+}
+
+async function refreshWorkspace(workspaceId: string | undefined) {
+  if (workspaceId) {
+    await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+  }
 }
 
 export const useTaskStore = create<TaskState>()(
@@ -33,12 +39,11 @@ export const useTaskStore = create<TaskState>()(
       add: async (workspaceId, columnId, title, description) => {
         const task = await ipc.createTask(workspaceId, columnId, title, description)
         set((s) => ({ tasks: [...s.tasks, task] }))
-        await refreshWorkspaceSummary(workspaceId)
+        await refreshWorkspace(workspaceId)
       },
 
       remove: async (id) => {
         const prev = get().tasks
-        const workspaceId = prev.find((t) => t.id === id)?.workspaceId
         set((s) => ({ tasks: s.tasks.filter((t) => t.id !== id) }))
         // Clear stale UI references to deleted task
         const ui = useUIStore.getState()
@@ -46,7 +51,8 @@ export const useTaskStore = create<TaskState>()(
         if (ui.activeTaskId === id) ui.closeChat()
         try {
           await ipc.deleteTask(id)
-          await refreshWorkspaceSummary(workspaceId)
+          const workspaceId = prev.find((task) => task.id === id)?.workspaceId
+          await refreshWorkspace(workspaceId)
         } catch {
           set({ tasks: prev })
         }
@@ -54,7 +60,6 @@ export const useTaskStore = create<TaskState>()(
 
       move: async (id, targetColumnId, position) => {
         const prev = get().tasks
-        const workspaceId = prev.find((t) => t.id === id)?.workspaceId
         set((s) => ({
           tasks: s.tasks.map((t) =>
             t.id === id ? { ...t, columnId: targetColumnId, position } : t,
@@ -62,7 +67,8 @@ export const useTaskStore = create<TaskState>()(
         }))
         try {
           await ipc.moveTask(id, targetColumnId, position)
-          await refreshWorkspaceSummary(workspaceId)
+          const workspaceId = prev.find((task) => task.id === id)?.workspaceId
+          await refreshWorkspace(workspaceId)
         } catch {
           set({ tasks: prev })
         }
@@ -109,7 +115,6 @@ export const useTaskStore = create<TaskState>()(
           original.description,
         )
         set((s) => ({ tasks: [...s.tasks, task] }))
-        await refreshWorkspaceSummary(original.workspaceId)
         return task
       },
     }),


### PR DESCRIPTION
## Description

Add structured output parsing in orchestrator to convert LLM tool_use responses into actual task mutations (create, move, edit, delete).

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/parse-llm-responses-into-task-board-actions` → `main`

## Commits

```
f8e81da Polish orchestrator action quality
26a75aa Fix orchestrator tool action edge cases
fda3cc0 Parse orchestrator tool-use task actions
```

## Changes

```
src-tauri/src/chat/bridge.rs                      |   8 +-
 src-tauri/src/commands/orchestrator/actions.rs    |  86 ++++--
 src-tauri/src/commands/orchestrator/stream.rs     |   3 +
 src-tauri/src/commands/orchestrator/stream_api.rs |   5 +
 src-tauri/src/commands/orchestrator/stream_cli.rs |  28 +-
 src-tauri/src/commands/orchestrator/types.rs      |   6 +
 src-tauri/src/llm/executor.rs                     | 350 +++++++++++++++++-----
 src-tauri/src/llm/mod.rs                          |   2 +-
 src-tauri/src/llm/tools.rs                        | 286 ++++++++++++++++--
 src/components/kanban/task-card.tsx               |  16 +-
 src/components/kanban/task-quick-actions.tsx      |  20 +-
 src/hooks/chat-session/use-chat-session.ts        |  28 +-
 src/stores/column-store.ts                        |  24 +-
 src/stores/task-store.ts                          |  12 +
 14 files changed, 712 insertions(+), 162 deletions(-)
```