### PR TITLE
Enforce workspace settings in pipeline

### DIFF
--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -25,10 +25,12 @@ fn gen_nonce() -> String {
     use std::hash::{BuildHasher, Hasher};
     let s = RandomState::new();
     let mut h = s.build_hasher();
-    h.write_u64(std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos() as u64);
+    h.write_u64(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64,
+    );
     format!("{:016x}", h.finish())
 }
 
@@ -43,11 +45,7 @@ pub struct ManagedBridge {
 impl ManagedBridge {
     /// Start a new bridge that subscribes to the PTY broadcast channel and
     /// forwards events to the frontend via Tauri events.
-    pub fn start(
-        app: AppHandle,
-        task_id: String,
-        rx: broadcast::Receiver<TransportEvent>,
-    ) -> Self {
+    pub fn start(app: AppHandle, task_id: String, rx: broadcast::Receiver<TransportEvent>) -> Self {
         let handle = tokio::spawn(bridge_broadcast_to_tauri(app, task_id, rx));
         Self { handle }
     }
@@ -135,28 +133,45 @@ async fn handle_bridge_event(
         }
         TransportEvent::Chat(ChatEvent::TextContent(ref text)) => {
             accumulated_text.push_str(text);
-            let _ = app.emit("agent:stream", &serde_json::json!({
-                "taskId": task_id,
-                "content": text,
-            }));
+            let _ = app.emit(
+                "agent:stream",
+                &serde_json::json!({
+                    "taskId": task_id,
+                    "content": text,
+                }),
+            );
             false
         }
-        TransportEvent::Chat(ChatEvent::ThinkingContent { ref content, is_complete }) => {
-            let _ = app.emit("agent:thinking", &serde_json::json!({
-                "taskId": task_id,
-                "content": content,
-                "isComplete": is_complete,
-            }));
+        TransportEvent::Chat(ChatEvent::ThinkingContent {
+            ref content,
+            is_complete,
+        }) => {
+            let _ = app.emit(
+                "agent:thinking",
+                &serde_json::json!({
+                    "taskId": task_id,
+                    "content": content,
+                    "isComplete": is_complete,
+                }),
+            );
             false
         }
-        TransportEvent::Chat(ChatEvent::ToolUse { ref id, ref name, ref input, ref status }) => {
-            let _ = app.emit("agent:tool_call", &serde_json::json!({
-                "taskId": task_id,
-                "toolId": id,
-                "toolName": name,
-                "toolInput": input.clone().unwrap_or_default(),
-                "status": format!("{:?}", status).to_lowercase(),
-            }));
+        TransportEvent::Chat(ChatEvent::ToolUse {
+            ref id,
+            ref name,
+            ref input,
+            ref status,
+        }) => {
+            let _ = app.emit(
+                "agent:tool_call",
+                &serde_json::json!({
+                    "taskId": task_id,
+                    "toolId": id,
+                    "toolName": name,
+                    "toolInput": input.clone().unwrap_or_default(),
+                    "status": format!("{:?}", status).to_lowercase(),
+                }),
+            );
             false
         }
         TransportEvent::Chat(ChatEvent::Complete) => {
@@ -164,16 +179,25 @@ async fn handle_bridge_event(
                 if let Ok(conn) = Connection::open(db::db_path()) {
                     let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
                     let _ = db::insert_agent_message(
-                        &conn, task_id, "assistant", accumulated_text,
-                        None, None, None, None,
+                        &conn,
+                        task_id,
+                        "assistant",
+                        accumulated_text,
+                        None,
+                        None,
+                        None,
+                        None,
                     );
                 }
                 accumulated_text.clear();
             }
-            let _ = app.emit("agent:complete", &serde_json::json!({
-                "taskId": task_id,
-                "success": true,
-            }));
+            let _ = app.emit(
+                "agent:complete",
+                &serde_json::json!({
+                    "taskId": task_id,
+                    "success": true,
+                }),
+            );
             false
         }
         TransportEvent::Exited(exit_code) => {
@@ -181,8 +205,14 @@ async fn handle_bridge_event(
                 if let Ok(conn) = Connection::open(db::db_path()) {
                     let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
                     let _ = db::insert_agent_message(
-                        &conn, task_id, "assistant", accumulated_text,
-                        None, None, None, None,
+                        &conn,
+                        task_id,
+                        "assistant",
+                        accumulated_text,
+                        None,
+                        None,
+                        None,
+                        None,
                     );
                 }
             }
@@ -254,8 +284,14 @@ pub fn spawn_cli_trigger_task(
             match db::insert_agent_session(&conn, &task_id, &cli_command, Some(&working_dir)) {
                 Ok(session) => {
                     let _ = db::update_agent_session(
-                        &conn, &session.id,
-                        None, Some("running"), None, None, None, None,
+                        &conn,
+                        &session.id,
+                        None,
+                        Some("running"),
+                        None,
+                        None,
+                        None,
+                        None,
                     );
                     let _ = db::update_task_agent_status(&conn, &task_id, Some("running"), None);
                     let ts = db::now();
@@ -288,7 +324,11 @@ pub fn spawn_cli_trigger_task(
     tokio::spawn(async move {
         let start_time = std::time::Instant::now();
         let full_cmd = build_trigger_command(&cli_command, &args, &initial_prompt);
-        let log_file = format!("{}/trigger_{}.log", crate::db::data_dir().display(), gen_nonce());
+        let log_file = format!(
+            "{}/trigger_{}.log",
+            crate::db::data_dir().display(),
+            gen_nonce()
+        );
 
         let result: Result<(), String> = async {
             // ── Direct process execution (no tmux) ─────────────────────
@@ -303,7 +343,8 @@ pub fn spawn_cli_trigger_task(
             // Open log file for stdout/stderr capture
             let log_out = std::fs::File::create(&log_file)
                 .map_err(|e| format!("Failed to create log file: {}", e))?;
-            let log_err = log_out.try_clone()
+            let log_err = log_out
+                .try_clone()
                 .map_err(|e| format!("Failed to clone log file: {}", e))?;
 
             // Build the command — use shell to handle the full command string
@@ -318,42 +359,54 @@ pub fn spawn_cli_trigger_task(
                 .map_err(|e| format!("Failed to spawn CLI process: {}", e))?;
 
             let child_pid = child.id().unwrap_or(0);
-            eprintln!("[bridge] Process spawned for task {}: PID {}", task_id, child_pid);
+            eprintln!(
+                "[bridge] Process spawned for task {}: PID {}",
+                task_id, child_pid
+            );
 
             // Update PID in agent session record
             if let Some(ref sid) = session_id {
                 if let Ok(conn) = Connection::open(db::db_path()) {
                     let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
                     let _ = db::update_agent_session(
-                        &conn, sid,
-                        Some(Some(child_pid as i64)), None, None, None, None, None,
+                        &conn,
+                        sid,
+                        Some(Some(child_pid as i64)),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
                     );
                 }
             }
 
             // Wait for process to complete with 2-hour timeout
-            let status = tokio::time::timeout(
-                std::time::Duration::from_secs(7200),
-                child.wait(),
-            )
-            .await
-            .map_err(|_| {
-                // Kill the process on timeout
-                let _ = child.start_kill();
-                format!("Trigger timed out after 2 hours for task {}", task_id)
-            })?
-            .map_err(|e| format!("Process wait failed: {}", e))?;
+            let status = tokio::time::timeout(std::time::Duration::from_secs(7200), child.wait())
+                .await
+                .map_err(|_| {
+                    // Kill the process on timeout
+                    let _ = child.start_kill();
+                    format!("Trigger timed out after 2 hours for task {}", task_id)
+                })?
+                .map_err(|e| format!("Process wait failed: {}", e))?;
 
             let exit_code = status.code().unwrap_or(1);
             // Keep log file on failure for debugging; clean up on success
             if exit_code == 0 {
                 let _ = tokio::fs::remove_file(&log_file).await;
             } else {
-                eprintln!("[bridge] Keeping log file for failed task {}: {}", task_id, log_file);
+                eprintln!(
+                    "[bridge] Keeping log file for failed task {}: {}",
+                    task_id, log_file
+                );
             }
 
             let success = exit_code == 0;
-            eprintln!("[bridge] Trigger completed for task {}: exit_code={}, success={}", task_id, exit_code, success);
+            eprintln!(
+                "[bridge] Trigger completed for task {}: exit_code={}, success={}",
+                task_id, exit_code, success
+            );
 
             // Update agent session + task status — but only if task hasn't moved columns
             if let Ok(conn) = Connection::open(db::db_path()) {
@@ -366,7 +419,10 @@ pub fn spawn_cli_trigger_task(
                     .unwrap_or(false);
 
                 if !task_still_here {
-                    eprintln!("[bridge] Task {} moved columns during trigger — skipping mark_complete", task_id);
+                    eprintln!(
+                        "[bridge] Task {} moved columns during trigger — skipping mark_complete",
+                        task_id
+                    );
                 } else {
                     let status = if success { "completed" } else { "failed" };
                     let _ = db::update_task_agent_status(&conn, &task_id, Some(status), None);
@@ -375,8 +431,14 @@ pub fn spawn_cli_trigger_task(
                     if let Ok(task) = db::get_task(&conn, &task_id) {
                         if let Some(ref sid) = task.agent_session_id {
                             let _ = db::update_agent_session(
-                                &conn, sid,
-                                None, Some(status), Some(Some(exit_code as i64)), None, None, None,
+                                &conn,
+                                sid,
+                                None,
+                                Some(status),
+                                Some(Some(exit_code as i64)),
+                                None,
+                                None,
+                                None,
                             );
                         }
                     }
@@ -386,23 +448,42 @@ pub fn spawn_cli_trigger_task(
                     if let Ok(task) = db::get_task(&conn, &task_id) {
                         let model_name = task.model.as_deref().unwrap_or("unknown");
                         let column_name = db::get_column(&conn, &task.column_id)
-                            .map(|c| c.name).unwrap_or_default();
+                            .map(|c| c.name)
+                            .unwrap_or_default();
                         // Insert usage record with duration (tokens TBD — requires parsing CLI output)
                         let _ = db::insert_usage_record(
-                            &conn, &task.workspace_id,
-                            Some(&task_id), session_id.as_deref(),
-                            "anthropic", model_name, 0, 0, 0.0,
-                            Some(&column_name), duration_secs,
+                            &conn,
+                            &task.workspace_id,
+                            Some(&task_id),
+                            session_id.as_deref(),
+                            "anthropic",
+                            model_name,
+                            0,
+                            0,
+                            0.0,
+                            Some(&column_name),
+                            duration_secs,
                         );
-                        eprintln!("[bridge] Usage recorded: task={} column={} model={} duration={}s",
-                            &task_id[..8], column_name, model_name, duration_secs);
+                        eprintln!(
+                            "[bridge] Usage recorded: task={} column={} model={} duration={}s",
+                            &task_id[..8],
+                            column_name,
+                            model_name,
+                            duration_secs
+                        );
                     }
 
                     if success {
                         let _ = pipeline::mark_complete(&conn, &app, &task_id, true);
                     } else {
                         let detail = format!("Agent exited with code {}", exit_code);
-                        let _ = pipeline::mark_complete_with_error(&conn, &app, &task_id, false, Some(&detail));
+                        let _ = pipeline::mark_complete_with_error(
+                            &conn,
+                            &app,
+                            &task_id,
+                            false,
+                            Some(&detail),
+                        );
                     }
                 }
             }
@@ -413,7 +494,10 @@ pub fn spawn_cli_trigger_task(
         .await;
 
         if let Err(e) = result {
-            let error_detail = format!("CLI trigger '{}' failed for task {}: {}", cli_command, task_id, e);
+            let error_detail = format!(
+                "CLI trigger '{}' failed for task {}: {}",
+                cli_command, task_id, e
+            );
             eprintln!("[bridge] {}", error_detail);
             if let Ok(conn) = Connection::open(db::db_path()) {
                 let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
@@ -425,16 +509,27 @@ pub fn spawn_cli_trigger_task(
 
                 if let Some(ref sid) = session_id {
                     let _ = db::update_agent_session(
-                        &conn, sid,
-                        None, Some("failed"), Some(Some(1)), None, None, None,
+                        &conn,
+                        sid,
+                        None,
+                        Some("failed"),
+                        Some(Some(1)),
+                        None,
+                        None,
+                        None,
                     );
                     let _ = db::update_task_agent_status(&conn, &task_id, Some("failed"), None);
                 }
 
                 if let Ok(task) = db::get_task(&conn, &task_id) {
                     if let Ok(col) = db::get_column(&conn, &task.column_id) {
-                        let _ =
-                            pipeline::handle_trigger_failure(&conn, &app, &task, &col, &error_detail);
+                        let _ = pipeline::handle_trigger_failure(
+                            &conn,
+                            &app,
+                            &task,
+                            &col,
+                            &error_detail,
+                        );
                     }
                 }
             }
@@ -474,8 +569,15 @@ mod tests {
 
     #[test]
     fn test_build_trigger_command_with_args() {
-        let cmd = build_trigger_command("codex", &["--model".to_string(), "gpt-5".to_string()], "hello");
-        assert_eq!(cmd, "codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --model gpt-5 'hello'");
+        let cmd = build_trigger_command(
+            "codex",
+            &["--model".to_string(), "gpt-5".to_string()],
+            "hello",
+        );
+        assert_eq!(
+            cmd,
+            "codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --model gpt-5 'hello'"
+        );
     }
 
     #[test]

--- a/src-tauri/src/chat/gc.rs
+++ b/src-tauri/src/chat/gc.rs
@@ -36,7 +36,10 @@ pub fn collect(conn: &Connection) {
             Ok(t) => t,
             Err(_) => {
                 // Task doesn't exist — orphaned session
-                eprintln!("[gc] Killing orphaned tmux session: {} (task not in DB)", session_name);
+                eprintln!(
+                    "[gc] Killing orphaned tmux session: {} (task not in DB)",
+                    session_name
+                );
                 let _ = std::process::Command::new("tmux")
                     .args(["kill-session", "-t", session_name])
                     .output();
@@ -45,20 +48,21 @@ pub fn collect(conn: &Connection) {
             }
         };
 
-        eprintln!("[gc] Evaluating session {} — task {} pipeline_state={} agent_status={:?}", session_name, task_id, task.pipeline_state, task.agent_status);
+        eprintln!(
+            "[gc] Evaluating session {} — task {} pipeline_state={} agent_status={:?}",
+            session_name, task_id, task.pipeline_state, task.agent_status
+        );
 
         // Check for finished agents — candidate for session cleanup.
         // Never kill sessions for tasks with an active pipeline (state = running/triggered)
         // since the pipeline's tmux wait-for completion detection needs the session alive.
-        let pipeline_active = matches!(
-            task.pipeline_state.as_str(),
-            "running" | "triggered"
-        );
+        let pipeline_active = matches!(task.pipeline_state.as_str(), "running" | "triggered");
 
-        let agent_finished = !pipeline_active && matches!(
-            task.agent_status.as_deref(),
-            Some("completed") | Some("failed") | Some("cancelled") | Some("idle")
-        );
+        let agent_finished = !pipeline_active
+            && matches!(
+                task.agent_status.as_deref(),
+                Some("completed") | Some("failed") | Some("cancelled") | Some("idle")
+            );
 
         if agent_finished {
             // Check if the agent session has been idle long enough to kill
@@ -69,12 +73,16 @@ pub fn collect(conn: &Connection) {
                         .map(|dt| dt.with_timezone(&chrono::Utc))
                         .or_else(|_| {
                             chrono::NaiveDateTime::parse_from_str(
-                                &session.updated_at, "%Y-%m-%d %H:%M:%S%.f%:z"
-                            ).map(|ndt| ndt.and_utc())
+                                &session.updated_at,
+                                "%Y-%m-%d %H:%M:%S%.f%:z",
+                            )
+                            .map(|ndt| ndt.and_utc())
                             .or_else(|_| {
                                 chrono::NaiveDateTime::parse_from_str(
-                                    &session.updated_at, "%Y-%m-%d %H:%M:%S"
-                                ).map(|ndt| ndt.and_utc())
+                                    &session.updated_at,
+                                    "%Y-%m-%d %H:%M:%S",
+                                )
+                                .map(|ndt| ndt.and_utc())
                             })
                         });
 
@@ -105,9 +113,9 @@ pub fn collect(conn: &Connection) {
 
     // Also check for tasks marked "running" whose tmux session has died
     // (e.g., OOM kill, manual tmux kill-session)
-    if let Ok(mut stmt) = conn.prepare(
-        "SELECT id, agent_session_id FROM tasks WHERE agent_status = 'running'"
-    ) {
+    if let Ok(mut stmt) =
+        conn.prepare("SELECT id, agent_session_id FROM tasks WHERE agent_status = 'running'")
+    {
         let stale: Vec<(String, Option<String>)> = stmt
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
             .ok()
@@ -117,12 +125,24 @@ pub fn collect(conn: &Connection) {
         for (task_id, session_id) in stale {
             let session_name = tmux_transport::session_name(&task_id);
             // Check if tmux session actually exists
-            let session_exists = sessions.iter().any(|s| *s == session_name);
+            let session_exists = sessions.contains(&session_name);
             if !session_exists {
-                eprintln!("[gc] Task {} marked running but tmux session gone — marking failed", task_id);
+                eprintln!(
+                    "[gc] Task {} marked running but tmux session gone — marking failed",
+                    task_id
+                );
                 let _ = db::update_task_agent_status(conn, &task_id, Some("failed"), None);
                 if let Some(ref sid) = session_id {
-                    let _ = db::update_agent_session(conn, sid, None, Some("failed"), None, None, None, None);
+                    let _ = db::update_agent_session(
+                        conn,
+                        sid,
+                        None,
+                        Some("failed"),
+                        None,
+                        None,
+                        None,
+                        None,
+                    );
                 }
             }
         }

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1,10 +1,10 @@
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
+use crate::chat::events::{ChatEvent, ToolStatus};
 use crate::chat::registry::SharedSessionRegistry;
 use crate::chat::session::{SessionConfig, SessionState, TransportType, UnifiedChatSession};
-use crate::chat::events::{ChatEvent, ToolStatus};
-use crate::db::{self, AppState, AgentMessage};
+use crate::db::{self, AgentMessage, AppState};
 use crate::error::AppError;
 
 // ─── Types ────────────────────────────────────────────────────────────────
@@ -96,9 +96,7 @@ pub async fn start_agent(
 
     // Start managed bridge via broadcast
     if let Some(rx) = session.resubscribe() {
-        let bridge = crate::chat::bridge::ManagedBridge::start(
-            app_handle, task_id.clone(), rx,
-        );
+        let bridge = crate::chat::bridge::ManagedBridge::start(app_handle, task_id.clone(), rx);
         registry.set_bridge(&task_id, bridge);
     }
 
@@ -186,6 +184,7 @@ pub async fn list_active_agents(
 // ─── Agent Message Commands ────────────────────────────────────────────────
 
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub fn save_agent_message(
     state: State<AppState>,
     task_id: String,
@@ -196,7 +195,10 @@ pub fn save_agent_message(
     tool_calls: Option<String>,
     thinking_content: Option<String>,
 ) -> Result<AgentMessage, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::insert_agent_message(
         &conn,
         &task_id,
@@ -214,16 +216,19 @@ pub fn get_agent_messages(
     state: State<AppState>,
     task_id: String,
 ) -> Result<Vec<AgentMessage>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_agent_messages(&conn, &task_id)?)
 }
 
 #[tauri::command(rename_all = "camelCase")]
-pub fn clear_agent_messages(
-    state: State<AppState>,
-    task_id: String,
-) -> Result<(), AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+pub fn clear_agent_messages(state: State<AppState>, task_id: String) -> Result<(), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::clear_agent_messages(&conn, &task_id)?;
     Ok(())
 }
@@ -234,6 +239,7 @@ pub fn clear_agent_messages(
 ///
 /// Uses `UnifiedChatSession` from the `SessionRegistry`.
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub async fn stream_agent_chat(
     app: AppHandle,
     state: State<'_, AppState>,
@@ -303,7 +309,9 @@ Be concise and helpful."#,
         } else {
             // Create new session (check capacity)
             if registry.is_at_capacity() {
-                return Err(AppError::InvalidInput("Maximum concurrent sessions reached".to_string()));
+                return Err(AppError::InvalidInput(
+                    "Maximum concurrent sessions reached".to_string(),
+                ));
             }
             UnifiedChatSession::new(config.clone(), TransportType::Pipe)
         };
@@ -325,7 +333,7 @@ Be concise and helpful."#,
             emit_agent_event(&app_for_events, &task_id_for_events, event);
         })
         .await
-        .map_err(|e| AppError::InvalidInput(e))?;
+        .map_err(AppError::InvalidInput)?;
 
     // Put session back into registry
     {
@@ -341,8 +349,12 @@ Be concise and helpful."#,
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
         if let Some(cli_sid) = &captured_cli_session_id {
-            let agent_session =
-                db::get_or_create_agent_session_for_task(&conn, &task_id, "claude", Some(&working_dir))?;
+            let agent_session = db::get_or_create_agent_session_for_task(
+                &conn,
+                &task_id,
+                "claude",
+                Some(&working_dir),
+            )?;
             db::update_agent_session_cli(
                 &conn,
                 &agent_session.id,
@@ -383,6 +395,7 @@ Be concise and helpful."#,
 /// If no session exists and switching to PTY: creates a new PTY session.
 /// Uses managed bridge for PTY event forwarding.
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub async fn switch_agent_transport(
     app: AppHandle,
     session_registry: State<'_, SharedSessionRegistry>,
@@ -396,7 +409,12 @@ pub async fn switch_agent_transport(
     let target_type = match transport_type.as_str() {
         "pipe" => TransportType::Pipe,
         "pty" => TransportType::Pty,
-        _ => return Err(AppError::InvalidInput(format!("Invalid transport type: {}", transport_type))),
+        _ => {
+            return Err(AppError::InvalidInput(format!(
+                "Invalid transport type: {}",
+                transport_type
+            )))
+        }
     };
 
     let c = cols.unwrap_or(120);
@@ -417,17 +435,15 @@ pub async fn switch_agent_transport(
         registry.cancel_bridge(&task_id);
 
         let session = registry.get_mut(&task_id).unwrap();
-        session.suspend().map_err(|e| AppError::InvalidInput(e))?;
+        session.suspend().map_err(AppError::InvalidInput)?;
         session.set_transport_type(target_type);
 
         if target_type == TransportType::Pty {
-            let _mpsc_rx = session.start_pty(c, r).map_err(|e| AppError::InvalidInput(e))?;
+            let _mpsc_rx = session.start_pty(c, r).map_err(AppError::InvalidInput)?;
             let rx = session.resubscribe();
 
             if let Some(rx) = rx {
-                let bridge = crate::chat::bridge::ManagedBridge::start(
-                    app, task_id.clone(), rx,
-                );
+                let bridge = crate::chat::bridge::ManagedBridge::start(app, task_id.clone(), rx);
                 registry.set_bridge(&task_id, bridge);
             }
         }
@@ -443,14 +459,12 @@ pub async fn switch_agent_transport(
 
         let session = registry
             .get_or_create(&task_id, config, TransportType::Pty)
-            .map_err(|e| AppError::InvalidInput(e))?;
+            .map_err(AppError::InvalidInput)?;
 
-        let _mpsc_rx = session.start_pty(c, r).map_err(|e| AppError::InvalidInput(e))?;
+        let _mpsc_rx = session.start_pty(c, r).map_err(AppError::InvalidInput)?;
 
         if let Some(rx) = session.resubscribe() {
-            let bridge = crate::chat::bridge::ManagedBridge::start(
-                app, task_id.clone(), rx,
-            );
+            let bridge = crate::chat::bridge::ManagedBridge::start(app, task_id.clone(), rx);
             registry.set_bridge(&task_id, bridge);
         }
     }
@@ -476,7 +490,10 @@ pub async fn ensure_pty_session(
     let mut registry = session_registry.lock().await;
 
     // Case 1: Session is alive
-    let session_alive = registry.get(&task_id).map(|s| s.is_alive()).unwrap_or(false);
+    let session_alive = registry
+        .get(&task_id)
+        .map(|s| s.is_alive())
+        .unwrap_or(false);
     if session_alive {
         let needs_bridge = !registry.has_active_bridge(&task_id);
 
@@ -487,14 +504,17 @@ pub async fn ensure_pty_session(
             let _ = session.resize_pty(cols, rows);
             let scrollback = session.scrollback();
             let pid = session.pid();
-            let rx = if needs_bridge { session.resubscribe() } else { None };
+            let rx = if needs_bridge {
+                session.resubscribe()
+            } else {
+                None
+            };
             (scrollback, pid, rx)
         }; // session borrow ends
 
         if let Some(rx) = resubscribe_rx {
-            let bridge = crate::chat::bridge::ManagedBridge::start(
-                app.clone(), task_id.clone(), rx,
-            );
+            let bridge =
+                crate::chat::bridge::ManagedBridge::start(app.clone(), task_id.clone(), rx);
             registry.set_bridge(&task_id, bridge);
         }
 
@@ -504,7 +524,11 @@ pub async fn ensure_pty_session(
             status: "Running".to_string(),
             pid,
             working_dir,
-            scrollback: if scrollback.is_empty() { None } else { Some(scrollback) },
+            scrollback: if scrollback.is_empty() {
+                None
+            } else {
+                Some(scrollback)
+            },
         });
     }
 
@@ -531,9 +555,7 @@ pub async fn ensure_pty_session(
 
     // Start managed bridge via broadcast
     if let Some(rx) = session.resubscribe() {
-        let bridge = crate::chat::bridge::ManagedBridge::start(
-            app.clone(), task_id.clone(), rx,
-        );
+        let bridge = crate::chat::bridge::ManagedBridge::start(app.clone(), task_id.clone(), rx);
         registry.set_bridge(&task_id, bridge);
     }
 
@@ -543,7 +565,11 @@ pub async fn ensure_pty_session(
         status: "Running".to_string(),
         pid,
         working_dir,
-        scrollback: if cached_scrollback.is_empty() { None } else { Some(cached_scrollback) },
+        scrollback: if cached_scrollback.is_empty() {
+            None
+        } else {
+            Some(cached_scrollback)
+        },
     })
 }
 
@@ -600,7 +626,10 @@ pub fn queue_agent_tasks(
     state: State<AppState>,
     task_ids: Vec<String>,
 ) -> Result<Vec<db::Task>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let queued_at = crate::db::now();
     let mut updated_tasks = Vec::new();
 
@@ -619,7 +648,10 @@ pub fn update_task_agent_status(
     agent_status: Option<String>,
     queued_at: Option<String>,
 ) -> Result<db::Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::update_task_agent_status(
         &conn,
         &task_id,
@@ -633,7 +665,10 @@ pub fn get_queue_status(
     state: State<AppState>,
     workspace_id: String,
 ) -> Result<QueueStatus, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let queued_tasks = db::get_queued_tasks(&conn, &workspace_id)?;
     let running_count = db::get_running_agent_count(&conn, &workspace_id)?;
 
@@ -650,7 +685,10 @@ pub fn get_next_queued_task(
     state: State<AppState>,
     workspace_id: String,
 ) -> Result<Option<db::Task>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let running_count = db::get_running_agent_count(&conn, &workspace_id)?;
 
     if running_count >= get_max_concurrent(&conn, &workspace_id) {
@@ -675,7 +713,10 @@ fn emit_agent_event(app: &AppHandle, task_id: &str, event: ChatEvent) {
                 },
             );
         }
-        ChatEvent::ThinkingContent { content, is_complete } => {
+        ChatEvent::ThinkingContent {
+            content,
+            is_complete,
+        } => {
             let _ = app.emit(
                 "agent:thinking",
                 &AgentThinkingPayload {
@@ -706,6 +747,10 @@ fn emit_agent_event(app: &AppHandle, task_id: &str, event: ChatEvent) {
                 },
             );
         }
-        ChatEvent::Complete | ChatEvent::Result(_) | ChatEvent::SessionId(_) | ChatEvent::RawOutput(_) | ChatEvent::Unknown => {}
+        ChatEvent::Complete
+        | ChatEvent::Result(_)
+        | ChatEvent::SessionId(_)
+        | ChatEvent::RawOutput(_)
+        | ChatEvent::Unknown => {}
     }
 }

--- a/src-tauri/src/commands/column.rs
+++ b/src-tauri/src/commands/column.rs
@@ -11,26 +11,39 @@ pub fn create_column(
     position: i64,
 ) -> Result<Column, AppError> {
     if name.trim().is_empty() {
-        return Err(AppError::InvalidInput("Column name cannot be empty".to_string()));
+        return Err(AppError::InvalidInput(
+            "Column name cannot be empty".to_string(),
+        ));
     }
     if position < 0 {
-        return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+        return Err(AppError::InvalidInput(
+            "Position must be non-negative".to_string(),
+        ));
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    Ok(db::insert_column(&conn, &workspace_id, name.trim(), position)?)
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::insert_column(
+        &conn,
+        &workspace_id,
+        name.trim(),
+        position,
+    )?)
 }
 
 #[tauri::command]
-pub fn list_columns(
-    state: State<AppState>,
-    workspace_id: String,
-) -> Result<Vec<Column>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+pub fn list_columns(state: State<AppState>, workspace_id: String) -> Result<Vec<Column>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_columns(&conn, &workspace_id)?)
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn update_column(
     state: State<AppState>,
     id: String,
@@ -43,12 +56,16 @@ pub fn update_column(
 ) -> Result<Column, AppError> {
     if let Some(ref n) = name {
         if n.trim().is_empty() {
-            return Err(AppError::InvalidInput("Column name cannot be empty".to_string()));
+            return Err(AppError::InvalidInput(
+                "Column name cannot be empty".to_string(),
+            ));
         }
     }
     if let Some(pos) = position {
         if pos < 0 {
-            return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+            return Err(AppError::InvalidInput(
+                "Position must be non-negative".to_string(),
+            ));
         }
     }
 
@@ -67,7 +84,10 @@ pub fn update_column(
         }
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let color_ref = color.as_ref().map(|c| c.as_deref());
     Ok(db::update_column(
         &conn,
@@ -87,20 +107,29 @@ pub fn reorder_columns(
     workspace_id: String,
     column_ids: Vec<String>,
 ) -> Result<Vec<Column>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     for (i, col_id) in column_ids.iter().enumerate() {
         db::update_column(&conn, col_id, None, None, Some(i as i64), None, None, None)?;
     }
 
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_columns(&conn, &workspace_id)?)
 }
 
 #[tauri::command]
 pub fn delete_column(state: State<AppState>, id: String) -> Result<(), AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Check if column has tasks
     let task_count: i64 = conn

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,10 +1,9 @@
-use tauri::{State, Emitter};
-use crate::db::{
-    self, AppState, SessionSnapshot,
-};
+use crate::db::{self, AppState, SessionSnapshot};
 use crate::error::AppError;
+use tauri::{Emitter, State};
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn create_snapshot(
     state: State<AppState>,
     session_id: String,
@@ -16,7 +15,10 @@ pub fn create_snapshot(
     files_modified: String,
     duration_ms: i64,
 ) -> Result<SessionSnapshot, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::insert_session_snapshot(
         &conn,
         &session_id,
@@ -32,11 +34,11 @@ pub fn create_snapshot(
 }
 
 #[tauri::command]
-pub fn get_snapshot(
-    state: State<AppState>,
-    id: String,
-) -> Result<SessionSnapshot, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+pub fn get_snapshot(state: State<AppState>, id: String) -> Result<SessionSnapshot, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::get_session_snapshot(&conn, &id).map_err(AppError::from)
 }
 
@@ -45,7 +47,10 @@ pub fn get_session_history(
     state: State<AppState>,
     session_id: String,
 ) -> Result<Vec<SessionSnapshot>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::list_session_snapshots(&conn, &session_id).map_err(AppError::from)
 }
 
@@ -55,7 +60,10 @@ pub fn get_workspace_history(
     workspace_id: String,
     limit: Option<i64>,
 ) -> Result<Vec<SessionSnapshot>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::list_workspace_history(&conn, &workspace_id, limit).map_err(AppError::from)
 }
 
@@ -64,16 +72,19 @@ pub fn get_task_history(
     state: State<AppState>,
     task_id: String,
 ) -> Result<Vec<SessionSnapshot>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::list_task_history(&conn, &task_id).map_err(AppError::from)
 }
 
 #[tauri::command]
-pub fn clear_session_history(
-    state: State<AppState>,
-    session_id: String,
-) -> Result<(), AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+pub fn clear_session_history(state: State<AppState>, session_id: String) -> Result<(), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::delete_session_snapshots(&conn, &session_id).map_err(AppError::from)
 }
 
@@ -97,6 +108,7 @@ struct RestoreEventPayload {
 
 /// Restore a snapshot - creates a backup first, restores scrollback to session, returns result
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub fn restore_snapshot(
     state: State<AppState>,
     app: tauri::AppHandle,
@@ -109,7 +121,10 @@ pub fn restore_snapshot(
     current_files_modified: String,
     current_duration_ms: i64,
 ) -> Result<RestoreResult, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // First, create a backup snapshot of current state
     let backup = db::insert_session_snapshot(
@@ -122,7 +137,8 @@ pub fn restore_snapshot(
         &current_command_history,
         &current_files_modified,
         current_duration_ms,
-    ).map_err(AppError::from)?;
+    )
+    .map_err(AppError::from)?;
 
     // Emit event with backup ID so frontend can notify user
     let _ = app.emit("history:backup-created", &backup.id);
@@ -136,17 +152,19 @@ pub fn restore_snapshot(
         let _ = db::update_agent_session(
             &conn,
             &session.id,
-            None, // pid
-            Some("idle"), // status
-            None, // exit_code
-            None, // last_output
+            None,                                          // pid
+            Some("idle"),                                  // status
+            None,                                          // exit_code
+            None,                                          // last_output
             Some(snapshot.scrollback_snapshot.as_deref()), // scrollback
-            Some(true), // resumable
+            Some(true),                                    // resumable
         );
         true
     } else if let Some(ref task_id) = snapshot.task_id {
         // Original session gone, try to create/update session for the task
-        if let Ok(session) = db::get_or_create_agent_session_for_task(&conn, task_id, "claude", None) {
+        if let Ok(session) =
+            db::get_or_create_agent_session_for_task(&conn, task_id, "claude", None)
+        {
             let _ = db::update_agent_session(
                 &conn,
                 &session.id,
@@ -166,12 +184,15 @@ pub fn restore_snapshot(
     };
 
     // Emit restore complete event
-    let _ = app.emit("history:restored", RestoreEventPayload {
-        snapshot_id: snapshot.id.clone(),
-        session_id: snapshot.session_id.clone(),
-        task_id: snapshot.task_id.clone(),
-        session_updated,
-    });
+    let _ = app.emit(
+        "history:restored",
+        RestoreEventPayload {
+            snapshot_id: snapshot.id.clone(),
+            session_id: snapshot.session_id.clone(),
+            task_id: snapshot.task_id.clone(),
+            session_updated,
+        },
+    );
 
     Ok(RestoreResult {
         snapshot,

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use tauri::{AppHandle, State};
 
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub async fn create_task(
     app: AppHandle,
     state: State<'_, AppState>,
@@ -17,10 +18,15 @@ pub async fn create_task(
     dependencies: Option<String>,
 ) -> Result<Task, AppError> {
     if title.trim().is_empty() {
-        return Err(AppError::InvalidInput("Task title cannot be empty".to_string()));
+        return Err(AppError::InvalidInput(
+            "Task title cannot be empty".to_string(),
+        ));
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let task = db::insert_task(
         &conn,
         &workspace_id,
@@ -32,7 +38,10 @@ pub async fn create_task(
     // Set trigger prompt and dependencies if provided
     let ts = db::now();
     if trigger_prompt.is_some() || dependencies.is_some() {
-        let has_deps = dependencies.as_ref().map(|d| d != "[]" && !d.is_empty()).unwrap_or(false);
+        let has_deps = dependencies
+            .as_ref()
+            .map(|d| d != "[]" && !d.is_empty())
+            .unwrap_or(false);
         conn.execute(
             "UPDATE tasks SET trigger_prompt = COALESCE(?1, trigger_prompt), dependencies = COALESCE(?2, dependencies), blocked = ?3, updated_at = ?4 WHERE id = ?5",
             rusqlite::params![
@@ -63,17 +72,24 @@ pub async fn create_task(
 
 #[tauri::command]
 pub fn get_task(state: State<AppState>, id: String) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::get_task(&conn, &id)?)
 }
 
 #[tauri::command]
 pub fn list_tasks(state: State<AppState>, workspace_id: String) -> Result<Vec<Task>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_tasks(&conn, &workspace_id)?)
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn update_task(
     _app: AppHandle,
     state: State<AppState>,
@@ -88,16 +104,23 @@ pub fn update_task(
 ) -> Result<Task, AppError> {
     if let Some(ref t) = title {
         if t.trim().is_empty() {
-            return Err(AppError::InvalidInput("Task title cannot be empty".to_string()));
+            return Err(AppError::InvalidInput(
+                "Task title cannot be empty".to_string(),
+            ));
         }
     }
     if let Some(pos) = position {
         if pos < 0 {
-            return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+            return Err(AppError::InvalidInput(
+                "Position must be non-negative".to_string(),
+            ));
         }
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     let desc_ref = description.as_ref().map(|d| d.as_deref());
     let mode_ref = agent_mode.as_ref().map(|m| m.as_deref());
@@ -136,7 +159,10 @@ pub fn update_task_triggers(
     dependencies: Option<String>,
     blocked: Option<bool>,
 ) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Validate dependencies won't create a cycle before saving
     if let Some(ref deps_json) = dependencies {
@@ -181,7 +207,8 @@ pub fn update_task_triggers(
     let sql = format!("UPDATE tasks SET {} WHERE id = ?", set_clause);
     params_vec.push(Box::new(id.clone()));
 
-    let params_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+    let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+        params_vec.iter().map(|p| p.as_ref()).collect();
     conn.execute(&sql, params_refs.as_slice())
         .map_err(AppError::from)?;
 
@@ -197,17 +224,24 @@ pub async fn move_task(
     position: i64,
 ) -> Result<Task, AppError> {
     if position < 0 {
-        return Err(AppError::InvalidInput("Position must be non-negative".to_string()));
+        return Err(AppError::InvalidInput(
+            "Position must be non-negative".to_string(),
+        ));
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Get the task's current column to check if it changed
     let task_before = db::get_task(&conn, &id)?;
     let old_column_id = task_before.column_id.clone();
     let column_changed = old_column_id != target_column_id;
 
-    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Update column and position atomically
     // Also reset pipeline state when moving to a new column
@@ -226,7 +260,8 @@ pub async fn move_task(
         .map_err(AppError::from)?;
     }
 
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     let task = db::get_task(&conn, &id)?;
 
@@ -239,17 +274,27 @@ pub async fn move_task(
         // Cancel running agent if target column has no spawn_cli trigger.
         // If target also has a trigger, it replaces the old agent — no cancel needed.
         if task_before.agent_status.as_deref() == Some("running") {
-            let target_has_trigger = target_column.triggers.as_deref()
+            let target_has_trigger = target_column
+                .triggers
+                .as_deref()
                 .map(|t| t.contains("spawn_cli"))
                 .unwrap_or(false);
 
             if !target_has_trigger {
                 crate::chat::tmux_transport::cancel_task_agent(
-                    &conn, &id, task_before.agent_session_id.as_deref(),
+                    &conn,
+                    &id,
+                    task_before.agent_session_id.as_deref(),
                 );
             }
         }
-        let _ = pipeline::triggers::fire_on_exit(&conn, &app, &task_before, &old_column, Some(&target_column));
+        let _ = pipeline::triggers::fire_on_exit(
+            &conn,
+            &app,
+            &task_before,
+            &old_column,
+            Some(&target_column),
+        );
 
         // Notify frontend to refresh task store
         pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_moved");
@@ -267,8 +312,13 @@ pub fn reorder_tasks(
     column_id: String,
     task_ids: Vec<String>,
 ) -> Result<Vec<Task>, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn.unchecked_transaction().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let ts = db::now();
 
     for (i, task_id) in task_ids.iter().enumerate() {
@@ -279,7 +329,8 @@ pub fn reorder_tasks(
         .map_err(AppError::from)?;
     }
 
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Get the workspace_id from the column to list tasks
     let col = db::get_column(&conn, &column_id)?;
@@ -287,19 +338,20 @@ pub fn reorder_tasks(
 }
 
 #[tauri::command]
-pub fn delete_task(
-    app: AppHandle,
-    state: State<AppState>,
-    id: String,
-) -> Result<(), AppError> {
+pub fn delete_task(app: AppHandle, state: State<AppState>, id: String) -> Result<(), AppError> {
     use crate::git::branch_manager;
 
     // Read task + workspace info, then release lock before filesystem I/O
     let (task, repo_path) = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let task = db::get_task(&conn, &id)?;
         let repo_path = if task.worktree_path.is_some() {
-            db::get_workspace(&conn, &task.workspace_id).ok().map(|ws| ws.repo_path)
+            db::get_workspace(&conn, &task.workspace_id)
+                .ok()
+                .map(|ws| ws.repo_path)
         } else {
             None
         };
@@ -317,7 +369,10 @@ pub fn delete_task(
 
     // Re-acquire lock for deletion
     {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         db::delete_task(&conn, &id)?;
     }
 
@@ -334,19 +389,22 @@ pub async fn approve_task(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
     // Set review_status to approved
     let task = db::update_task_review_status(&conn, &id, Some("approved"))?;
-    
+
     // Get the column to check if we should try auto-advance
     let column = db::get_column(&conn, &task.column_id)?;
-    
+
     // Try to auto-advance (checks V2 triggers internally)
     if let Some(advanced_task) = pipeline::try_auto_advance(&conn, &app, &task, &column)? {
         return Ok(advanced_task);
     }
-    
+
     Ok(task)
 }
 
@@ -357,7 +415,10 @@ pub fn reject_task(
     id: String,
     reason: Option<String>,
 ) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Set review_status to rejected
     let mut task = db::update_task_review_status(&conn, &id, Some("rejected"))?;
@@ -395,20 +456,24 @@ pub async fn create_pr(
 ) -> Result<CreatePrResult, AppError> {
     // Get the task to retrieve title, description, and branch
     let task = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         db::get_task(&conn, &task_id)?
     };
 
     // Verify task has a branch
-    let branch_name = task.branch_name.clone().ok_or_else(|| {
-        AppError::InvalidInput("Task has no associated branch".to_string())
-    })?;
+    let branch_name = task
+        .branch_name
+        .clone()
+        .ok_or_else(|| AppError::InvalidInput("Task has no associated branch".to_string()))?;
 
     // Check if PR already exists
-    if task.pr_number.is_some() {
+    if let Some(pr_number) = task.pr_number {
         return Err(AppError::InvalidInput(format!(
             "Task already has PR #{}",
-            task.pr_number.unwrap()
+            pr_number
         )));
     }
 
@@ -418,44 +483,59 @@ pub async fn create_pr(
     let base = base_branch.unwrap_or_else(|| "main".to_string());
 
     // Run gh pr create command
-    let (pr_number, pr_url) = tokio::task::spawn_blocking(move || -> Result<(i64, String), AppError> {
-        let output = Command::new("gh")
-            .args([
-                "pr", "create",
-                "--title", &pr_title,
-                "--body", &pr_body,
-                "--base", &base,
-                "--head", &branch_name,
-            ])
-            .current_dir(&repo_path)
-            .output()
-            .map_err(|e| AppError::CommandError(format!("Failed to run gh CLI: {}", e)))?;
+    let (pr_number, pr_url) =
+        tokio::task::spawn_blocking(move || -> Result<(i64, String), AppError> {
+            let output = Command::new("gh")
+                .args([
+                    "pr",
+                    "create",
+                    "--title",
+                    &pr_title,
+                    "--body",
+                    &pr_body,
+                    "--base",
+                    &base,
+                    "--head",
+                    &branch_name,
+                ])
+                .current_dir(&repo_path)
+                .output()
+                .map_err(|e| AppError::CommandError(format!("Failed to run gh CLI: {}", e)))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(AppError::CommandError(format!("gh pr create failed: {}", stderr)));
-        }
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(AppError::CommandError(format!(
+                    "gh pr create failed: {}",
+                    stderr
+                )));
+            }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let pr_url = stdout.trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let pr_url = stdout.trim().to_string();
 
-        // Parse PR number from URL (e.g., https://github.com/owner/repo/pull/123)
-        let pr_number = pr_url
-            .rsplit('/')
-            .next()
-            .and_then(|s| s.parse::<i64>().ok())
-            .ok_or_else(|| AppError::CommandError(format!(
-                "Failed to parse PR number from URL: {}", pr_url
-            )))?;
+            // Parse PR number from URL (e.g., https://github.com/owner/repo/pull/123)
+            let pr_number = pr_url
+                .rsplit('/')
+                .next()
+                .and_then(|s| s.parse::<i64>().ok())
+                .ok_or_else(|| {
+                    AppError::CommandError(format!(
+                        "Failed to parse PR number from URL: {}",
+                        pr_url
+                    ))
+                })?;
 
-        Ok((pr_number, pr_url))
-    })
-    .await
-    .map_err(|e| AppError::CommandError(format!("Task join error: {}", e)))??;
+            Ok((pr_number, pr_url))
+        })
+        .await
+        .map_err(|e| AppError::CommandError(format!("Task join error: {}", e)))??;
 
     // Update task with PR info
     let updated_task = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         db::update_task_pr_info(&conn, &task_id, Some(pr_number), Some(&pr_url))?
     };
 
@@ -475,27 +555,34 @@ pub fn update_task_stakeholders(
     id: String,
     stakeholders: Option<String>,
 ) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    Ok(db::update_task_stakeholders(&conn, &id, stakeholders.as_deref())?)
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::update_task_stakeholders(
+        &conn,
+        &id,
+        stakeholders.as_deref(),
+    )?)
 }
 
 /// Mark a task's notification as sent
 #[tauri::command]
-pub fn mark_task_notification_sent(
-    state: State<AppState>,
-    id: String,
-) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+pub fn mark_task_notification_sent(state: State<AppState>, id: String) -> Result<Task, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::mark_task_notification_sent(&conn, &id)?)
 }
 
 /// Clear the notification sent timestamp
 #[tauri::command]
-pub fn clear_task_notification_sent(
-    state: State<AppState>,
-    id: String,
-) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+pub fn clear_task_notification_sent(state: State<AppState>, id: String) -> Result<Task, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::clear_task_notification_sent(&conn, &id)?)
 }
 
@@ -525,11 +612,13 @@ pub async fn generate_test_checklist(
 ) -> Result<GenerateTestChecklistResult, AppError> {
     // Get task to check PR number
     let pr_number = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let task = db::get_task(&conn, &task_id)?;
-        task.pr_number.ok_or_else(|| AppError::InvalidInput(
-            "Task has no PR associated".to_string()
-        ))?
+        task.pr_number
+            .ok_or_else(|| AppError::InvalidInput("Task has no PR associated".to_string()))?
     };
 
     // Get PR diff using gh CLI
@@ -544,7 +633,10 @@ pub async fn generate_test_checklist(
 
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                return Err(AppError::CommandError(format!("gh pr diff failed: {}", stderr)));
+                return Err(AppError::CommandError(format!(
+                    "gh pr diff failed: {}",
+                    stderr
+                )));
             }
 
             Ok(String::from_utf8_lossy(&output.stdout).to_string())
@@ -555,7 +647,11 @@ pub async fn generate_test_checklist(
 
     // Truncate diff if too long (keep first 10KB)
     let truncated_diff = if diff.len() > 10000 {
-        format!("{}...\n\n[Diff truncated - {} more bytes]", &diff[..10000], diff.len() - 10000)
+        format!(
+            "{}...\n\n[Diff truncated - {} more bytes]",
+            &diff[..10000],
+            diff.len() - 10000
+        )
     } else {
         diff.clone()
     };
@@ -595,18 +691,17 @@ Return ONLY the JSON array, no other text."#,
         let repo_path = repo_path.clone();
         move || -> Result<Vec<GeneratedTestItem>, AppError> {
             let output = Command::new(&cli)
-                .args([
-                    "--print",
-                    "--output-format", "text",
-                    "-p", &prompt,
-                ])
+                .args(["--print", "--output-format", "text", "-p", &prompt])
                 .current_dir(&repo_path)
                 .output()
                 .map_err(|e| AppError::CommandError(format!("Failed to run Claude CLI: {}", e)))?;
 
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                return Err(AppError::CommandError(format!("Claude CLI failed: {}", stderr)));
+                return Err(AppError::CommandError(format!(
+                    "Claude CLI failed: {}",
+                    stderr
+                )));
             }
 
             let stdout = String::from_utf8_lossy(&output.stdout);
@@ -620,11 +715,12 @@ Return ONLY the JSON array, no other text."#,
                 .trim();
 
             // Parse JSON array
-            let items: Vec<GeneratedTestItem> = serde_json::from_str(json_str)
-                .map_err(|e| AppError::CommandError(format!(
+            let items: Vec<GeneratedTestItem> = serde_json::from_str(json_str).map_err(|e| {
+                AppError::CommandError(format!(
                     "Failed to parse Claude response as JSON: {}. Response was: {}",
                     e, json_str
-                )))?;
+                ))
+            })?;
 
             Ok(items)
         }
@@ -636,14 +732,18 @@ Return ONLY the JSON array, no other text."#,
     let files_changed: Vec<&str> = diff
         .lines()
         .filter(|l| l.starts_with("diff --git"))
-        .filter_map(|l| l.split(' ').last())
+        .filter_map(|l| l.split(' ').next_back())
         .take(5)
         .collect();
 
     let diff_summary = if files_changed.is_empty() {
         "No files changed".to_string()
     } else {
-        format!("{} files: {}", files_changed.len(), files_changed.join(", "))
+        format!(
+            "{} files: {}",
+            files_changed.len(),
+            files_changed.join(", ")
+        )
     };
 
     Ok(GenerateTestChecklistResult {
@@ -665,11 +765,16 @@ pub async fn queue_backlog(
         return Err(AppError::InvalidInput("Count must be positive".to_string()));
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Find the Backlog column
     let columns = db::list_columns(&conn, &workspace_id)?;
-    let backlog_column = columns.iter().find(|c| c.name == "Backlog")
+    let backlog_column = columns
+        .iter()
+        .find(|c| c.name == "Backlog")
         .ok_or_else(|| AppError::InvalidInput("No 'Backlog' column found".to_string()))?;
 
     // Get first N tasks from Backlog ordered by position
@@ -677,7 +782,9 @@ pub async fn queue_backlog(
     let to_queue: Vec<&Task> = backlog_tasks.iter().take(count as usize).collect();
 
     if to_queue.is_empty() {
-        return Err(AppError::InvalidInput("No tasks in Backlog to queue".to_string()));
+        return Err(AppError::InvalidInput(
+            "No tasks in Backlog to queue".to_string(),
+        ));
     }
 
     // Set queued_at on each task
@@ -687,12 +794,15 @@ pub async fn queue_backlog(
         conn.execute(
             "UPDATE tasks SET queued_at = ?1, updated_at = ?2 WHERE id = ?3",
             rusqlite::params![ts, ts, task.id],
-        ).map_err(AppError::from)?;
+        )
+        .map_err(AppError::from)?;
         queued_tasks.push(db::get_task(&conn, &task.id)?);
     }
 
     // Move the first task to Plan and fire trigger
-    let plan_column = columns.iter().find(|c| c.name == "Plan")
+    let plan_column = columns
+        .iter()
+        .find(|c| c.name == "Plan")
         .ok_or_else(|| AppError::InvalidInput("No 'Plan' column found".to_string()))?;
 
     let moved_task = db::append_task_to_column(&conn, &queued_tasks[0].id, &plan_column.id)
@@ -716,7 +826,10 @@ pub fn validate_task_dependencies(
     task_id: String,
     dependencies: String,
 ) -> Result<(), AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let deps: Vec<pipeline::dependencies::TaskDependency> = serde_json::from_str(&dependencies)
         .map_err(|e| AppError::InvalidInput(format!("Invalid dependencies JSON: {}", e)))?;
     pipeline::dependencies::validate_dependencies(&conn, &task_id, &deps)
@@ -752,10 +865,12 @@ pub fn reset_task_to_backlog(
     if task.worktree_path.is_some() {
         if let Ok(workspace) = db::get_workspace(conn, &task.workspace_id) {
             if !workspace.repo_path.is_empty() {
-                if let Err(e) = branch_manager::remove_task_worktree(&workspace.repo_path, task_id) {
+                if let Err(e) = branch_manager::remove_task_worktree(&workspace.repo_path, task_id)
+                {
                     log::warn!(
                         "[reset_task_to_backlog] Failed to remove worktree for task {}: {}",
-                        task_id, e
+                        task_id,
+                        e
                     );
                 }
             }
@@ -781,7 +896,9 @@ pub fn reset_task_to_backlog(
 
     log::info!(
         "[reset_task_to_backlog] Task {} reset to column '{}' after {} failed attempts",
-        task_id, first_col.name, attempts
+        task_id,
+        first_col.name,
+        attempts
     );
 
     pipeline::emit_tasks_changed(app, &task.workspace_id, "task_reset_to_backlog");
@@ -802,7 +919,10 @@ pub async fn retry_pipeline(
     // Clean the worktree before re-firing so the new agent starts fresh.
     // Done outside the DB lock — filesystem I/O can block.
     let worktree_path = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let task = db::get_task(&conn, &task_id)?;
         task.worktree_path.clone()
     };
@@ -811,11 +931,10 @@ pub async fn retry_pipeline(
         if !wt.is_empty() && std::path::Path::new(wt).exists() {
             let wt_owned = wt.to_string();
             let task_id_for_log = task_id.clone();
-            let clean_result = tokio::task::spawn_blocking(move || {
-                branch_manager::clean_worktree(&wt_owned)
-            })
-            .await
-            .map_err(|e| AppError::CommandError(e.to_string()))?;
+            let clean_result =
+                tokio::task::spawn_blocking(move || branch_manager::clean_worktree(&wt_owned))
+                    .await
+                    .map_err(|e| AppError::CommandError(e.to_string()))?;
 
             match clean_result {
                 Ok(summary) => log::info!(
@@ -832,7 +951,10 @@ pub async fn retry_pipeline(
         }
     }
 
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Get the task
     let task = db::get_task(&conn, &task_id)?;
@@ -841,7 +963,13 @@ pub async fn retry_pipeline(
     let column = db::get_column(&conn, &task.column_id)?;
 
     // Clear the error and reset state to idle
-    db::update_task_pipeline_state(&conn, &task_id, pipeline::PipelineState::Idle.as_str(), None, None)?;
+    db::update_task_pipeline_state(
+        &conn,
+        &task_id,
+        pipeline::PipelineState::Idle.as_str(),
+        None,
+        None,
+    )?;
 
     // Re-fire the trigger
     let task = db::get_task(&conn, &task_id)?;
@@ -859,14 +987,19 @@ pub async fn retry_from_start(
     state: State<'_, AppState>,
     task_id: String,
 ) -> Result<Task, AppError> {
-    let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     // Cancel any running agent for this task
     {
         let task = db::get_task(&conn, &task_id)?;
         if task.agent_status.as_deref() == Some("running") {
             crate::chat::tmux_transport::cancel_task_agent(
-                &conn, &task_id, task.agent_session_id.as_deref(),
+                &conn,
+                &task_id,
+                task.agent_session_id.as_deref(),
             );
         }
     }
@@ -876,7 +1009,9 @@ pub async fn retry_from_start(
 
     // Find the first column in this workspace
     let columns = db::list_columns(&conn, &task.workspace_id)?;
-    let first_column = columns.into_iter().next()
+    let first_column = columns
+        .into_iter()
+        .next()
         .ok_or_else(|| AppError::InvalidInput("No columns found in workspace".into()))?;
 
     let column_changed = old_column_id != first_column.id;
@@ -888,12 +1023,14 @@ pub async fn retry_from_start(
          pipeline_triggered_at = NULL, pipeline_error = NULL, retry_count = 0, \
          review_status = NULL, updated_at = ?2 WHERE id = ?3",
         rusqlite::params![first_column.id, ts, task_id],
-    ).map_err(AppError::from)?;
+    )
+    .map_err(AppError::from)?;
 
     // Fire on_exit for old column if changed
     if column_changed {
         let old_column = db::get_column(&conn, &old_column_id)?;
-        let _ = pipeline::triggers::fire_on_exit(&conn, &app, &task, &old_column, Some(&first_column));
+        let _ =
+            pipeline::triggers::fire_on_exit(&conn, &app, &task, &old_column, Some(&first_column));
     }
 
     // Notify frontend
@@ -920,7 +1057,10 @@ pub async fn create_task_worktree(
     use crate::git::branch_manager;
 
     let (task, workspace) = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let task = db::get_task(&conn, &task_id)?;
         let workspace = db::get_workspace(&conn, &task.workspace_id)?;
         (task, workspace)
@@ -953,7 +1093,10 @@ pub async fn create_task_worktree(
             .map_err(|e| AppError::CommandError(e.to_string()))?
             .map_err(AppError::CommandError)?;
 
-            let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let conn = state
+                .db
+                .lock()
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
             db::update_task_branch(&conn, &task_id, Some(&branch))?;
             branch
         }
@@ -972,7 +1115,10 @@ pub async fn create_task_worktree(
 
     // Update task with worktree path
     let updated = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         db::update_task_worktree_path(&conn, &task_id, Some(&worktree_path))?
     };
 
@@ -991,7 +1137,10 @@ pub async fn remove_task_worktree(
     use crate::git::branch_manager;
 
     let (task, workspace) = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let task = db::get_task(&conn, &task_id)?;
         let workspace = db::get_workspace(&conn, &task.workspace_id)?;
         (task, workspace)
@@ -1012,7 +1161,10 @@ pub async fn remove_task_worktree(
     .map_err(AppError::CommandError)?;
 
     let updated = {
-        let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         db::update_task_worktree_path(&conn, &task_id, None)?
     };
 

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -10,6 +10,9 @@ use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
+pub const DEFAULT_PIPELINE_MAX_CONCURRENT_AGENTS: i64 = 5;
+pub const DEFAULT_BRANCH_PREFIX: &str = "bentoya/";
+
 /// Global cached settings instance. Reloaded on save.
 static CACHED_SETTINGS: OnceLock<Mutex<AppSettings>> = OnceLock::new();
 
@@ -46,6 +49,130 @@ pub struct AppSettings {
     pub default_session_strategy: String,
     /// Default advance mode: "auto" or "manual"
     pub default_advance_mode: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectivePipelineSettings {
+    pub default_agent_cli: String,
+    pub default_model: Option<String>,
+    pub max_concurrent_agents: i64,
+    pub branch_prefix: String,
+}
+
+fn workspace_config_value<'a>(config: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = config;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn workspace_config_string(config: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths.iter().find_map(|path| {
+        workspace_config_value(config, path)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+    })
+}
+
+fn workspace_config_i64(config: &Value, paths: &[&[&str]]) -> Option<i64> {
+    paths.iter().find_map(|path| {
+        let value = workspace_config_value(config, path)?;
+        if let Some(n) = value.as_i64() {
+            return Some(n);
+        }
+        value.as_str()?.trim().parse::<i64>().ok()
+    })
+}
+
+pub(crate) fn normalize_branch_prefix(prefix: &str) -> String {
+    let trimmed = prefix.trim();
+    if trimmed.is_empty() {
+        DEFAULT_BRANCH_PREFIX.to_string()
+    } else if trimmed.ends_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("{}/", trimmed)
+    }
+}
+
+fn effective_pipeline_settings_with_app_settings(
+    workspace_config_json: &str,
+    settings: &AppSettings,
+) -> EffectivePipelineSettings {
+    let workspace_config = serde_json::from_str::<Value>(workspace_config_json)
+        .unwrap_or_else(|_| Value::Object(Default::default()));
+
+    let default_agent_cli = workspace_config_string(
+        &workspace_config,
+        &[
+            &["defaultAgentCli"],
+            &["default_agent_cli"],
+            &["agent", "defaultAgentCli"],
+            &["agent", "default_agent_cli"],
+        ],
+    )
+    .unwrap_or_else(|| settings.default_agent_cli.clone());
+
+    let default_model = workspace_config_string(
+        &workspace_config,
+        &[
+            &["defaultModel"],
+            &["default_model"],
+            &["agent", "modelSelection"],
+            &["agent", "defaultModel"],
+            &["agent", "default_model"],
+        ],
+    )
+    .filter(|model| model != "auto")
+    .or_else(|| {
+        let model = settings.default_model.trim();
+        if model.is_empty() {
+            None
+        } else {
+            Some(model.to_string())
+        }
+    });
+
+    let max_concurrent_agents = workspace_config_i64(
+        &workspace_config,
+        &[
+            &["maxConcurrentAgents"],
+            &["max_concurrent_agents"],
+            &["agent", "maxConcurrentAgents"],
+            &["agent", "max_concurrent_agents"],
+        ],
+    )
+    .filter(|n| *n > 0)
+    .unwrap_or(DEFAULT_PIPELINE_MAX_CONCURRENT_AGENTS);
+
+    let branch_prefix = workspace_config_string(
+        &workspace_config,
+        &[
+            &["branchPrefix"],
+            &["branch_prefix"],
+            &["git", "branchPrefix"],
+            &["git", "branch_prefix"],
+            &["workspaceDefaults", "branchPrefix"],
+            &["workspace_defaults", "branch_prefix"],
+        ],
+    )
+    .map(|prefix| normalize_branch_prefix(&prefix))
+    .unwrap_or_else(|| DEFAULT_BRANCH_PREFIX.to_string());
+
+    EffectivePipelineSettings {
+        default_agent_cli,
+        default_model,
+        max_concurrent_agents,
+        branch_prefix,
+    }
+}
+
+pub fn effective_pipeline_settings(workspace_config_json: &str) -> EffectivePipelineSettings {
+    let settings = AppSettings::load();
+    effective_pipeline_settings_with_app_settings(workspace_config_json, &settings)
 }
 
 impl Default for AppSettings {
@@ -90,8 +217,7 @@ impl AppSettings {
         let path = Self::file_path();
         let json = serde_json::to_string_pretty(self)
             .map_err(|e| format!("Failed to serialize settings: {}", e))?;
-        std::fs::write(&path, json)
-            .map_err(|e| format!("Failed to write settings: {}", e))?;
+        std::fs::write(&path, json).map_err(|e| format!("Failed to write settings: {}", e))?;
 
         // Update cache
         if let Ok(mut cache) = cached().lock() {
@@ -137,7 +263,11 @@ impl AppSettings {
 
     /// Resolve a setting value with workspace override.
     /// Workspace config takes precedence over global settings.
-    pub fn resolve_with_workspace<'a>(&'a self, workspace_config: Option<&'a str>, key: &str) -> Option<String> {
+    pub fn resolve_with_workspace<'a>(
+        &'a self,
+        workspace_config: Option<&'a str>,
+        key: &str,
+    ) -> Option<String> {
         // Check workspace override first
         if let Some(config_json) = workspace_config {
             if let Ok(config) = serde_json::from_str::<Value>(config_json) {
@@ -240,5 +370,67 @@ mod tests {
         let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.max_agent_sessions, settings.max_agent_sessions);
         assert_eq!(deserialized.default_agent_cli, settings.default_agent_cli);
+    }
+
+    #[test]
+    fn test_effective_pipeline_settings_flat_workspace_config() {
+        let cfg = r#"{
+            "defaultAgentCli": "claude",
+            "defaultModel": "sonnet",
+            "maxConcurrentAgents": 7,
+            "branchPrefix": "work"
+        }"#;
+
+        let effective = effective_pipeline_settings_with_app_settings(cfg, &AppSettings::default());
+
+        assert_eq!(effective.default_agent_cli, "claude");
+        assert_eq!(effective.default_model.as_deref(), Some("sonnet"));
+        assert_eq!(effective.max_concurrent_agents, 7);
+        assert_eq!(effective.branch_prefix, "work/");
+    }
+
+    #[test]
+    fn test_effective_pipeline_settings_nested_workspace_config() {
+        let cfg = r#"{
+            "agent": {"modelSelection": "opus", "maxConcurrentAgents": 4},
+            "git": {"branchPrefix": "feature/"}
+        }"#;
+
+        let effective = effective_pipeline_settings_with_app_settings(cfg, &AppSettings::default());
+
+        assert_eq!(effective.default_model.as_deref(), Some("opus"));
+        assert_eq!(effective.max_concurrent_agents, 4);
+        assert_eq!(effective.branch_prefix, "feature/");
+    }
+
+    #[test]
+    fn test_effective_pipeline_settings_ignores_auto_model_and_bad_limit() {
+        let cfg = r#"{
+            "agent": {"modelSelection": "auto"},
+            "maxConcurrentAgents": 0,
+            "branchPrefix": ""
+        }"#;
+
+        let effective = effective_pipeline_settings_with_app_settings(cfg, &AppSettings::default());
+
+        assert_eq!(effective.default_model, None);
+        assert_eq!(
+            effective.max_concurrent_agents,
+            DEFAULT_PIPELINE_MAX_CONCURRENT_AGENTS
+        );
+        assert_eq!(effective.branch_prefix, DEFAULT_BRANCH_PREFIX);
+    }
+
+    #[test]
+    fn test_effective_pipeline_settings_auto_is_only_special_for_model() {
+        let cfg = r#"{
+            "defaultAgentCli": "auto",
+            "branchPrefix": "auto"
+        }"#;
+
+        let effective = effective_pipeline_settings_with_app_settings(cfg, &AppSettings::default());
+
+        assert_eq!(effective.default_agent_cli, "auto");
+        assert_eq!(effective.branch_prefix, "auto/");
     }
 }

--- a/src-tauri/src/db/usage.rs
+++ b/src-tauri/src/db/usage.rs
@@ -25,6 +25,7 @@ fn map_usage_record_row(row: &rusqlite::Row) -> rusqlite::Result<UsageRecord> {
 
 const USAGE_RECORD_COLUMNS: &str = "id, workspace_id, task_id, session_id, provider, model, input_tokens, output_tokens, cost_usd, column_name, duration_seconds, created_at";
 
+#[allow(clippy::too_many_arguments)]
 pub fn insert_usage_record(
     conn: &Connection,
     workspace_id: &str,
@@ -70,30 +71,42 @@ pub fn estimate_cost(model: &str, input_tokens: i64, output_tokens: i64) -> f64 
 
 pub fn get_usage_record(conn: &Connection, id: &str) -> SqlResult<UsageRecord> {
     conn.query_row(
-        &format!("SELECT {} FROM usage_records WHERE id = ?1", USAGE_RECORD_COLUMNS),
+        &format!(
+            "SELECT {} FROM usage_records WHERE id = ?1",
+            USAGE_RECORD_COLUMNS
+        ),
         params![id],
         map_usage_record_row,
     )
 }
 
-pub fn list_usage_records(conn: &Connection, workspace_id: &str, limit: Option<i64>) -> SqlResult<Vec<UsageRecord>> {
+pub fn list_usage_records(
+    conn: &Connection,
+    workspace_id: &str,
+    limit: Option<i64>,
+) -> SqlResult<Vec<UsageRecord>> {
     let limit_val = limit.unwrap_or(100);
-    let mut stmt = conn.prepare(
-        &format!("SELECT {} FROM usage_records WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT ?2", USAGE_RECORD_COLUMNS),
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {} FROM usage_records WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT ?2",
+        USAGE_RECORD_COLUMNS
+    ))?;
     let rows = stmt.query_map(params![workspace_id, limit_val], map_usage_record_row)?;
     rows.collect()
 }
 
 pub fn list_task_usage(conn: &Connection, task_id: &str) -> SqlResult<Vec<UsageRecord>> {
-    let mut stmt = conn.prepare(
-        &format!("SELECT {} FROM usage_records WHERE task_id = ?1 ORDER BY created_at DESC", USAGE_RECORD_COLUMNS),
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {} FROM usage_records WHERE task_id = ?1 ORDER BY created_at DESC",
+        USAGE_RECORD_COLUMNS
+    ))?;
     let rows = stmt.query_map(params![task_id], map_usage_record_row)?;
     rows.collect()
 }
 
-pub fn get_workspace_usage_summary(conn: &Connection, workspace_id: &str) -> SqlResult<UsageSummary> {
+pub fn get_workspace_usage_summary(
+    conn: &Connection,
+    workspace_id: &str,
+) -> SqlResult<UsageSummary> {
     conn.query_row(
         "SELECT COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cost_usd), 0.0), COUNT(*) FROM usage_records WHERE workspace_id = ?1",
         params![workspace_id],
@@ -120,7 +133,10 @@ pub fn get_task_usage_summary(conn: &Connection, task_id: &str) -> SqlResult<Usa
 }
 
 pub fn delete_workspace_usage(conn: &Connection, workspace_id: &str) -> SqlResult<()> {
-    conn.execute("DELETE FROM usage_records WHERE workspace_id = ?1", params![workspace_id])?;
+    conn.execute(
+        "DELETE FROM usage_records WHERE workspace_id = ?1",
+        params![workspace_id],
+    )?;
     Ok(())
 }
 

--- a/src-tauri/src/git/branch_manager.rs
+++ b/src-tauri/src/git/branch_manager.rs
@@ -45,6 +45,16 @@ pub fn create_task_branch(
     task_slug: &str,
     base_branch: Option<&str>,
 ) -> Result<String, String> {
+    create_task_branch_with_prefix(repo_path, task_slug, base_branch, BRANCH_PREFIX)
+}
+
+/// Create a task branch using a caller-provided prefix.
+pub fn create_task_branch_with_prefix(
+    repo_path: &str,
+    task_slug: &str,
+    base_branch: Option<&str>,
+    branch_prefix: &str,
+) -> Result<String, String> {
     let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
 
     let base = match base_branch {
@@ -53,7 +63,15 @@ pub fn create_task_branch(
     };
 
     let slug = slugify(task_slug);
-    let branch_name = format!("{}{}", BRANCH_PREFIX, slug);
+    let trimmed_prefix = branch_prefix.trim();
+    let prefix = if trimmed_prefix.is_empty() {
+        BRANCH_PREFIX.to_string()
+    } else if trimmed_prefix.ends_with('/') {
+        trimmed_prefix.to_string()
+    } else {
+        format!("{}/", trimmed_prefix)
+    };
+    let branch_name = format!("{}{}", prefix, slug);
 
     let base_ref = repo
         .find_branch(&base, BranchType::Local)
@@ -470,6 +488,30 @@ mod tests {
         assert!(!tmp.join(".task.md").exists());
         // Summary mentions what happened
         assert!(summary.contains(".task.md"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_create_task_branch_with_custom_prefix() {
+        let tmp = std::env::temp_dir().join(format!("bentoya-branch-prefix-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        init_test_repo(&tmp);
+
+        let branch = create_task_branch_with_prefix(
+            tmp.to_str().unwrap(),
+            "Add Billing Flow",
+            None,
+            " feature ",
+        )
+        .expect("create_task_branch_with_prefix failed");
+
+        assert_eq!(branch, "feature/add-billing-flow");
+
+        let repo = Repository::open(&tmp).unwrap();
+        assert!(repo.find_branch(&branch, BranchType::Local).is_ok());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/src/git/branch_manager.rs
+++ b/src-tauri/src/git/branch_manager.rs
@@ -1,8 +1,8 @@
+use crate::config::{normalize_branch_prefix, DEFAULT_BRANCH_PREFIX};
 use git2::{BranchType, Repository, Signature, StashFlags, WorktreeAddOptions};
 use serde::Serialize;
 use std::path::PathBuf;
 
-const BRANCH_PREFIX: &str = "bentoya/";
 const AUTO_STASH_PREFIX: &str = "bentoya-auto-stash-";
 
 #[derive(Debug, Serialize)]
@@ -18,7 +18,13 @@ pub fn slugify(input: &str) -> String {
     let slug: String = input
         .to_lowercase()
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '-' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect();
     let collapsed: String = slug
         .split('-')
@@ -45,7 +51,7 @@ pub fn create_task_branch(
     task_slug: &str,
     base_branch: Option<&str>,
 ) -> Result<String, String> {
-    create_task_branch_with_prefix(repo_path, task_slug, base_branch, BRANCH_PREFIX)
+    create_task_branch_with_prefix(repo_path, task_slug, base_branch, DEFAULT_BRANCH_PREFIX)
 }
 
 /// Create a task branch using a caller-provided prefix.
@@ -63,24 +69,14 @@ pub fn create_task_branch_with_prefix(
     };
 
     let slug = slugify(task_slug);
-    let trimmed_prefix = branch_prefix.trim();
-    let prefix = if trimmed_prefix.is_empty() {
-        BRANCH_PREFIX.to_string()
-    } else if trimmed_prefix.ends_with('/') {
-        trimmed_prefix.to_string()
-    } else {
-        format!("{}/", trimmed_prefix)
-    };
+    let prefix = normalize_branch_prefix(branch_prefix);
     let branch_name = format!("{}{}", prefix, slug);
 
     let base_ref = repo
         .find_branch(&base, BranchType::Local)
         .map_err(|e| format!("Base branch '{}' not found: {}", base, e))?;
 
-    let commit = base_ref
-        .get()
-        .peel_to_commit()
-        .map_err(|e| e.to_string())?;
+    let commit = base_ref.get().peel_to_commit().map_err(|e| e.to_string())?;
 
     repo.branch(&branch_name, &commit, false)
         .map_err(|e| format!("Failed to create branch '{}': {}", branch_name, e))?;
@@ -170,9 +166,7 @@ pub fn list_task_branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
         .map_err(|e| e.to_string())?;
 
     let head = repo.head().ok();
-    let head_name = head
-        .as_ref()
-        .and_then(|h| h.shorthand().map(String::from));
+    let head_name = head.as_ref().and_then(|h| h.shorthand().map(String::from));
 
     let mut result = Vec::new();
 
@@ -184,7 +178,7 @@ pub fn list_task_branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
             .unwrap_or("")
             .to_string();
 
-        if name.starts_with(BRANCH_PREFIX) {
+        if name.starts_with(DEFAULT_BRANCH_PREFIX) {
             let upstream = branch
                 .upstream()
                 .ok()
@@ -240,7 +234,9 @@ fn worktree_name(task_id: &str) -> String {
 
 /// On-disk worktree path: `<repo>/.worktrees/bentoya-<task_id>/`.
 fn worktree_path(repo_path: &str, task_id: &str) -> PathBuf {
-    PathBuf::from(repo_path).join(".worktrees").join(worktree_name(task_id))
+    PathBuf::from(repo_path)
+        .join(".worktrees")
+        .join(worktree_name(task_id))
 }
 
 /// Create a git worktree for a task, checked out to the given branch.
@@ -384,8 +380,7 @@ pub fn clean_worktree(worktree_path: &str) -> Result<String, String> {
 
     let task_md = path.join(".task.md");
     let task_md_removed = if task_md.exists() {
-        std::fs::remove_file(&task_md)
-            .map_err(|e| format!("Failed to remove .task.md: {}", e))?;
+        std::fs::remove_file(&task_md).map_err(|e| format!("Failed to remove .task.md: {}", e))?;
         true
     } else {
         false
@@ -408,7 +403,8 @@ pub fn clean_worktree(worktree_path: &str) -> Result<String, String> {
 pub fn list_worktrees(repo_path: &str) -> Result<Vec<String>, String> {
     let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
 
-    let names = repo.worktrees()
+    let names = repo
+        .worktrees()
         .map_err(|e| format!("Failed to list worktrees: {}", e))?;
 
     Ok(names
@@ -453,13 +449,37 @@ mod tests {
     #[cfg(test)]
     fn init_test_repo(path: &std::path::Path) {
         use std::process::Command;
-        Command::new("git").args(["init", "-q"]).current_dir(path).output().unwrap();
-        Command::new("git").args(["config", "user.email", "test@example.com"]).current_dir(path).output().unwrap();
-        Command::new("git").args(["config", "user.name", "Test"]).current_dir(path).output().unwrap();
-        Command::new("git").args(["config", "commit.gpgsign", "false"]).current_dir(path).output().unwrap();
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(path)
+            .output()
+            .unwrap();
         std::fs::write(path.join("README.md"), "baseline\n").unwrap();
-        Command::new("git").args(["add", "."]).current_dir(path).output().unwrap();
-        Command::new("git").args(["commit", "-q", "-m", "init"]).current_dir(path).output().unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(path)
+            .output()
+            .unwrap();
     }
 
     #[test]
@@ -480,7 +500,10 @@ mod tests {
         let summary = clean_worktree(tmp.to_str().unwrap()).expect("clean_worktree failed");
 
         // Tracked file restored
-        assert_eq!(std::fs::read_to_string(tmp.join("README.md")).unwrap(), "baseline\n");
+        assert_eq!(
+            std::fs::read_to_string(tmp.join("README.md")).unwrap(),
+            "baseline\n"
+        );
         // Untracked file and directory removed
         assert!(!tmp.join("scratch.txt").exists());
         assert!(!tmp.join("build").exists());
@@ -494,7 +517,8 @@ mod tests {
 
     #[test]
     fn test_create_task_branch_with_custom_prefix() {
-        let tmp = std::env::temp_dir().join(format!("bentoya-branch-prefix-test-{}", std::process::id()));
+        let tmp =
+            std::env::temp_dir().join(format!("bentoya-branch-prefix-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
 
@@ -526,7 +550,10 @@ mod tests {
 
         let summary = clean_worktree(tmp.to_str().unwrap()).expect("clean_worktree failed");
         assert!(summary.contains("no changes"));
-        assert_eq!(std::fs::read_to_string(tmp.join("README.md")).unwrap(), "baseline\n");
+        assert_eq!(
+            std::fs::read_to_string(tmp.join("README.md")).unwrap(),
+            "baseline\n"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/src/models/metadata.rs
+++ b/src-tauri/src/models/metadata.rs
@@ -2,151 +2,194 @@
 //! Updated with app releases but NOT required for new models to appear.
 
 use std::collections::HashMap;
-use std::sync::LazyLock;
+use std::sync::OnceLock;
 
 use super::types::{ModelMetadata, ModelTier};
 
 /// Known model metadata keyed by full API model ID.
 /// New models without an entry here still appear — they just get inferred defaults.
-static KNOWN_METADATA: LazyLock<HashMap<&'static str, ModelMetadata>> = LazyLock::new(|| {
-    let mut m = HashMap::new();
+static KNOWN_METADATA: OnceLock<HashMap<&'static str, ModelMetadata>> = OnceLock::new();
 
-    // ── Anthropic ────────────────────────────────────────────────────────
-    m.insert("claude-opus-4-6-20260217", ModelMetadata {
-        alias: Some("opus".into()),
-        tier: ModelTier::Flagship,
-        context_window: 200_000,
-        supports_extended_context: true,
-        max_output_tokens: 32_000,
-        input_cost_per_m: Some(15.0),
-        output_cost_per_m: Some(75.0),
-        capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
-    });
-    m.insert("claude-sonnet-4-6-20260217", ModelMetadata {
-        alias: Some("sonnet".into()),
-        tier: ModelTier::Standard,
-        context_window: 200_000,
-        supports_extended_context: false,
-        max_output_tokens: 16_000,
-        input_cost_per_m: Some(3.0),
-        output_cost_per_m: Some(15.0),
-        capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
-    });
-    m.insert("claude-haiku-4-5-20251001", ModelMetadata {
-        alias: Some("haiku".into()),
-        tier: ModelTier::Fast,
-        context_window: 200_000,
-        supports_extended_context: false,
-        max_output_tokens: 8_192,
-        input_cost_per_m: Some(0.80),
-        output_cost_per_m: Some(4.0),
-        capabilities: vec!["vision".into(), "tools".into()],
-    });
+fn known_metadata() -> &'static HashMap<&'static str, ModelMetadata> {
+    KNOWN_METADATA.get_or_init(|| {
+        let mut m = HashMap::new();
 
-    // ── OpenAI ───────────────────────────────────────────────────────────
-    m.insert("gpt-5.4", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Flagship,
-        context_window: 256_000,
-        supports_extended_context: false,
-        max_output_tokens: 32_000,
-        input_cost_per_m: Some(10.0),
-        output_cost_per_m: Some(30.0),
-        capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
-    });
-    m.insert("gpt-5", ModelMetadata {
-        alias: Some("gpt5".into()),
-        tier: ModelTier::Flagship,
-        context_window: 256_000,
-        supports_extended_context: false,
-        max_output_tokens: 32_000,
-        input_cost_per_m: Some(10.0),
-        output_cost_per_m: Some(30.0),
-        capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
-    });
-    m.insert("gpt-4.1", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Standard,
-        context_window: 1_048_576,
-        supports_extended_context: false,
-        max_output_tokens: 32_768,
-        input_cost_per_m: Some(2.0),
-        output_cost_per_m: Some(8.0),
-        capabilities: vec!["vision".into(), "tools".into()],
-    });
-    m.insert("gpt-4.1-mini", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Fast,
-        context_window: 1_048_576,
-        supports_extended_context: false,
-        max_output_tokens: 32_768,
-        input_cost_per_m: Some(0.40),
-        output_cost_per_m: Some(1.60),
-        capabilities: vec!["vision".into(), "tools".into()],
-    });
-    m.insert("o3", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Flagship,
-        context_window: 200_000,
-        supports_extended_context: false,
-        max_output_tokens: 100_000,
-        input_cost_per_m: Some(10.0),
-        output_cost_per_m: Some(40.0),
-        capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
-    });
-    m.insert("o3-mini", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Fast,
-        context_window: 200_000,
-        supports_extended_context: false,
-        max_output_tokens: 100_000,
-        input_cost_per_m: Some(1.10),
-        output_cost_per_m: Some(4.40),
-        capabilities: vec!["tools".into(), "thinking".into()],
-    });
-    m.insert("o1", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Standard,
-        context_window: 200_000,
-        supports_extended_context: false,
-        max_output_tokens: 100_000,
-        input_cost_per_m: Some(15.0),
-        output_cost_per_m: Some(60.0),
-        capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
-    });
-    m.insert("codex-5.3", ModelMetadata {
-        alias: Some("codex".into()),
-        tier: ModelTier::Standard,
-        context_window: 192_000,
-        supports_extended_context: false,
-        max_output_tokens: 16_000,
-        input_cost_per_m: Some(2.0),
-        output_cost_per_m: Some(8.0),
-        capabilities: vec!["tools".into()],
-    });
-    m.insert("codex-5.3-spark", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Fast,
-        context_window: 192_000,
-        supports_extended_context: false,
-        max_output_tokens: 16_000,
-        input_cost_per_m: Some(0.50),
-        output_cost_per_m: Some(2.0),
-        capabilities: vec!["tools".into()],
-    });
-    m.insert("codex-5.2", ModelMetadata {
-        alias: None,
-        tier: ModelTier::Standard,
-        context_window: 128_000,
-        supports_extended_context: false,
-        max_output_tokens: 16_000,
-        input_cost_per_m: Some(2.0),
-        output_cost_per_m: Some(8.0),
-        capabilities: vec!["tools".into()],
-    });
+        // ── Anthropic ────────────────────────────────────────────────────────
+        m.insert(
+            "claude-opus-4-6-20260217",
+            ModelMetadata {
+                alias: Some("opus".into()),
+                tier: ModelTier::Flagship,
+                context_window: 200_000,
+                supports_extended_context: true,
+                max_output_tokens: 32_000,
+                input_cost_per_m: Some(15.0),
+                output_cost_per_m: Some(75.0),
+                capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
+            },
+        );
+        m.insert(
+            "claude-sonnet-4-6-20260217",
+            ModelMetadata {
+                alias: Some("sonnet".into()),
+                tier: ModelTier::Standard,
+                context_window: 200_000,
+                supports_extended_context: false,
+                max_output_tokens: 16_000,
+                input_cost_per_m: Some(3.0),
+                output_cost_per_m: Some(15.0),
+                capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
+            },
+        );
+        m.insert(
+            "claude-haiku-4-5-20251001",
+            ModelMetadata {
+                alias: Some("haiku".into()),
+                tier: ModelTier::Fast,
+                context_window: 200_000,
+                supports_extended_context: false,
+                max_output_tokens: 8_192,
+                input_cost_per_m: Some(0.80),
+                output_cost_per_m: Some(4.0),
+                capabilities: vec!["vision".into(), "tools".into()],
+            },
+        );
 
-    m
-});
+        // ── OpenAI ───────────────────────────────────────────────────────────
+        m.insert(
+            "gpt-5.4",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Flagship,
+                context_window: 256_000,
+                supports_extended_context: false,
+                max_output_tokens: 32_000,
+                input_cost_per_m: Some(10.0),
+                output_cost_per_m: Some(30.0),
+                capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
+            },
+        );
+        m.insert(
+            "gpt-5",
+            ModelMetadata {
+                alias: Some("gpt5".into()),
+                tier: ModelTier::Flagship,
+                context_window: 256_000,
+                supports_extended_context: false,
+                max_output_tokens: 32_000,
+                input_cost_per_m: Some(10.0),
+                output_cost_per_m: Some(30.0),
+                capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
+            },
+        );
+        m.insert(
+            "gpt-4.1",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Standard,
+                context_window: 1_048_576,
+                supports_extended_context: false,
+                max_output_tokens: 32_768,
+                input_cost_per_m: Some(2.0),
+                output_cost_per_m: Some(8.0),
+                capabilities: vec!["vision".into(), "tools".into()],
+            },
+        );
+        m.insert(
+            "gpt-4.1-mini",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Fast,
+                context_window: 1_048_576,
+                supports_extended_context: false,
+                max_output_tokens: 32_768,
+                input_cost_per_m: Some(0.40),
+                output_cost_per_m: Some(1.60),
+                capabilities: vec!["vision".into(), "tools".into()],
+            },
+        );
+        m.insert(
+            "o3",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Flagship,
+                context_window: 200_000,
+                supports_extended_context: false,
+                max_output_tokens: 100_000,
+                input_cost_per_m: Some(10.0),
+                output_cost_per_m: Some(40.0),
+                capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
+            },
+        );
+        m.insert(
+            "o3-mini",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Fast,
+                context_window: 200_000,
+                supports_extended_context: false,
+                max_output_tokens: 100_000,
+                input_cost_per_m: Some(1.10),
+                output_cost_per_m: Some(4.40),
+                capabilities: vec!["tools".into(), "thinking".into()],
+            },
+        );
+        m.insert(
+            "o1",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Standard,
+                context_window: 200_000,
+                supports_extended_context: false,
+                max_output_tokens: 100_000,
+                input_cost_per_m: Some(15.0),
+                output_cost_per_m: Some(60.0),
+                capabilities: vec!["vision".into(), "tools".into(), "thinking".into()],
+            },
+        );
+        m.insert(
+            "codex-5.3",
+            ModelMetadata {
+                alias: Some("codex".into()),
+                tier: ModelTier::Standard,
+                context_window: 192_000,
+                supports_extended_context: false,
+                max_output_tokens: 16_000,
+                input_cost_per_m: Some(2.0),
+                output_cost_per_m: Some(8.0),
+                capabilities: vec!["tools".into()],
+            },
+        );
+        m.insert(
+            "codex-5.3-spark",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Fast,
+                context_window: 192_000,
+                supports_extended_context: false,
+                max_output_tokens: 16_000,
+                input_cost_per_m: Some(0.50),
+                output_cost_per_m: Some(2.0),
+                capabilities: vec!["tools".into()],
+            },
+        );
+        m.insert(
+            "codex-5.2",
+            ModelMetadata {
+                alias: None,
+                tier: ModelTier::Standard,
+                context_window: 128_000,
+                supports_extended_context: false,
+                max_output_tokens: 16_000,
+                input_cost_per_m: Some(2.0),
+                output_cost_per_m: Some(8.0),
+                capabilities: vec!["tools".into()],
+            },
+        );
+
+        m
+    })
+}
 
 /// Look up known metadata for a model ID.
 /// Tries exact match first, then strips date suffixes for fuzzy match.
@@ -154,18 +197,20 @@ static KNOWN_METADATA: LazyLock<HashMap<&'static str, ModelMetadata>> = LazyLock
 /// but "claude-opus-4-5-20251101" will match "claude-opus-4-5" entry if one existed.
 pub fn get_known_metadata(model_id: &str) -> Option<&'static ModelMetadata> {
     // Exact match
-    if let Some(m) = KNOWN_METADATA.get(model_id) {
+    let known_metadata = known_metadata();
+
+    if let Some(m) = known_metadata.get(model_id) {
         return Some(m);
     }
     // Try fuzzy: strip date suffix (8-digit number at end)
     if let Some(base) = strip_date_suffix(model_id) {
-        if let Some(m) = KNOWN_METADATA.get(base.as_str()) {
+        if let Some(m) = known_metadata.get(base.as_str()) {
             return Some(m);
         }
     }
     // Reverse fuzzy: find a metadata entry whose base matches this ID
     // e.g. scan finds "claude-opus-4-6", metadata has "claude-opus-4-6-20260217"
-    for (known_id, meta) in KNOWN_METADATA.iter() {
+    for (known_id, meta) in known_metadata.iter() {
         if let Some(known_base) = strip_date_suffix(known_id) {
             if known_base == model_id {
                 return Some(meta);
@@ -217,7 +262,7 @@ pub fn default_metadata(model_id: &str) -> ModelMetadata {
 /// Resolve a model alias (e.g. "opus") to a full API model ID.
 /// Searches known metadata for matching aliases.
 pub fn resolve_alias(alias: &str) -> Option<&'static str> {
-    for (id, meta) in KNOWN_METADATA.iter() {
+    for (id, meta) in known_metadata().iter() {
         if meta.alias.as_deref() == Some(alias) {
             return Some(id);
         }
@@ -228,10 +273,8 @@ pub fn resolve_alias(alias: &str) -> Option<&'static str> {
 /// Get pricing for a model (input_cost_per_m, output_cost_per_m).
 /// Returns None if model is unknown.
 pub fn get_pricing(model_id: &str) -> Option<(f64, f64)> {
-    get_known_metadata(model_id).and_then(|m| {
-        match (m.input_cost_per_m, m.output_cost_per_m) {
-            (Some(input), Some(output)) => Some((input, output)),
-            _ => None,
-        }
+    get_known_metadata(model_id).and_then(|m| match (m.input_cost_per_m, m.output_cost_per_m) {
+        (Some(input), Some(output)) => Some((input, output)),
+        _ => None,
     })
 }

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -46,7 +46,7 @@ impl PipelineState {
         }
     }
 
-    pub fn from_str(s: &str) -> Self {
+    pub fn from_db_str(s: &str) -> Self {
         match s {
             "triggered" => PipelineState::Triggered,
             "running" => PipelineState::Running,
@@ -95,21 +95,27 @@ pub fn emit_pipeline(
     state: PipelineState,
     message: Option<String>,
 ) {
-    let _ = app.emit(event_name, &PipelineEvent {
-        task_id: task_id.to_string(),
-        column_id: column_id.to_string(),
-        event_type: event_name.trim_start_matches("pipeline:").to_string(),
-        state: state.as_str().to_string(),
-        message,
-    });
+    let _ = app.emit(
+        event_name,
+        &PipelineEvent {
+            task_id: task_id.to_string(),
+            column_id: column_id.to_string(),
+            event_type: event_name.trim_start_matches("pipeline:").to_string(),
+            state: state.as_str().to_string(),
+            message,
+        },
+    );
 }
 
 /// Emit a global tasks:changed event so the frontend re-fetches.
 pub fn emit_tasks_changed(app: &AppHandle, workspace_id: &str, reason: &str) {
-    let _ = app.emit("tasks:changed", &TasksChangedEvent {
-        workspace_id: workspace_id.to_string(),
-        reason: reason.to_string(),
-    });
+    let _ = app.emit(
+        "tasks:changed",
+        &TasksChangedEvent {
+            workspace_id: workspace_id.to_string(),
+            reason: reason.to_string(),
+        },
+    );
 }
 
 /// Payload sent to webhook URLs
@@ -210,7 +216,10 @@ pub fn check_exit_met(task: &Task, exit_type: &str) -> Option<bool> {
         "agent_complete" => {
             // If no session ID, check pipeline state as fallback
             if task.agent_session_id.is_none() {
-                Some(task.pipeline_state == PipelineState::Running.as_str() || task.pipeline_state == "complete")
+                Some(
+                    task.pipeline_state == PipelineState::Running.as_str()
+                        || task.pipeline_state == "complete",
+                )
             } else {
                 None // Needs DB lookup — caller handles
             }
@@ -250,8 +259,7 @@ fn parse_trigger_field_u64(triggers_json: Option<&str>, field: &str) -> u64 {
 
 /// Parse an i64 field from exit_criteria in triggers JSON.
 fn parse_trigger_field_i64(triggers_json: Option<&str>, field: &str) -> Option<i64> {
-    get_exit_criteria_field(triggers_json, field)
-        .and_then(|v| v.as_i64())
+    get_exit_criteria_field(triggers_json, field).and_then(|v| v.as_i64())
 }
 
 /// Check if a siege retry has exceeded the time cap.
@@ -264,7 +272,8 @@ fn is_siege_timed_out(triggered_at: Option<&str>) -> bool {
     let Ok(started) = chrono::DateTime::parse_from_rfc3339(ts) else {
         return false;
     };
-    chrono::Utc::now().signed_duration_since(started) >= chrono::Duration::seconds(SIEGE_TIMEOUT_SECS)
+    chrono::Utc::now().signed_duration_since(started)
+        >= chrono::Duration::seconds(SIEGE_TIMEOUT_SECS)
 }
 
 // ─── Pipeline Engine ────────────────────────────────────────────────────────
@@ -280,19 +289,29 @@ pub fn fire_trigger(
 ) -> Result<Task, AppError> {
     // Verify column still exists (may have been deleted while trigger was queued)
     if db::get_column(conn, &column.id).is_err() {
-        log::warn!("Column {} deleted before trigger could fire for task {}", column.id, task.id);
+        log::warn!(
+            "Column {} deleted before trigger could fire for task {}",
+            column.id,
+            task.id
+        );
         return Ok(task.clone());
     }
 
     // Record timing: task entering this column
     if let Err(e) = db::insert_pipeline_timing(conn, &task.id, &column.id, &column.name) {
-        log::warn!("Failed to insert pipeline timing for task {}: {}", task.id, e);
+        log::warn!(
+            "Failed to insert pipeline timing for task {}: {}",
+            task.id,
+            e
+        );
     }
 
     // Check for V2 triggers
     if let Some(ref triggers_json) = column.triggers {
         if triggers_json != "{}" && !triggers_json.is_empty() {
-            if let Ok(col_triggers) = serde_json::from_str::<triggers::ColumnTriggersV2>(triggers_json) {
+            if let Ok(col_triggers) =
+                serde_json::from_str::<triggers::ColumnTriggersV2>(triggers_json)
+            {
                 if col_triggers.on_entry.is_some() {
                     return triggers::fire_on_entry(conn, app, task, column, &col_triggers, None);
                 }
@@ -319,11 +338,21 @@ pub fn evaluate_exit_criteria(
 
     // Set state to evaluating
     let _ = db::update_task_pipeline_state(
-        conn, &task.id, PipelineState::Evaluating.as_str(),
-        task.pipeline_triggered_at.as_deref(), None,
+        conn,
+        &task.id,
+        PipelineState::Evaluating.as_str(),
+        task.pipeline_triggered_at.as_deref(),
+        None,
     );
 
-    emit_pipeline(app, "pipeline:evaluating", &task.id, &column.id, PipelineState::Evaluating, Some(format!("Exit type: {}", exit_type.as_str())));
+    emit_pipeline(
+        app,
+        "pipeline:evaluating",
+        &task.id,
+        &column.id,
+        PipelineState::Evaluating,
+        Some(format!("Exit type: {}", exit_type.as_str())),
+    );
 
     // Try pure check first, fall back to external checks
     let exit_met = match check_exit_met(task, exit_type.as_str()) {
@@ -340,7 +369,8 @@ pub fn evaluate_exit_criteria(
                                     || (session.status == "stopped" && session.exit_code == Some(0))
                             }
                             Err(_) => {
-                                task.pipeline_state == PipelineState::Running.as_str() || task.pipeline_state == "complete"
+                                task.pipeline_state == PipelineState::Running.as_str()
+                                    || task.pipeline_state == "complete"
                             }
                         }
                     } else {
@@ -348,10 +378,13 @@ pub fn evaluate_exit_criteria(
                     }
                 }
                 triggers::ExitCriteriaTypeV2::TimeElapsed => {
-                    let timeout_secs = parse_trigger_field_u64(column.triggers.as_deref(), "timeout");
+                    let timeout_secs =
+                        parse_trigger_field_u64(column.triggers.as_deref(), "timeout");
                     let timeout_secs = if timeout_secs == 0 { 300 } else { timeout_secs };
                     if let Some(ref triggered_at) = task.pipeline_triggered_at {
-                        if let Ok(triggered_time) = chrono::DateTime::parse_from_rfc3339(triggered_at) {
+                        if let Ok(triggered_time) =
+                            chrono::DateTime::parse_from_rfc3339(triggered_at)
+                        {
                             let elapsed = chrono::Utc::now().signed_duration_since(triggered_time);
                             elapsed.num_seconds() >= timeout_secs as i64
                         } else {
@@ -365,21 +398,37 @@ pub fn evaluate_exit_criteria(
                     if let Some(pr_number) = task.pr_number {
                         if let Ok(workspace) = db::get_workspace(conn, &task.workspace_id) {
                             let output = std::process::Command::new("gh")
-                                .args(["pr", "view", &pr_number.to_string(), "--json", "reviewDecision"])
+                                .args([
+                                    "pr",
+                                    "view",
+                                    &pr_number.to_string(),
+                                    "--json",
+                                    "reviewDecision",
+                                ])
                                 .current_dir(&workspace.repo_path)
                                 .output();
                             if let Ok(output) = output {
                                 if output.status.success() {
                                     #[derive(serde::Deserialize)]
                                     #[serde(rename_all = "camelCase")]
-                                    struct PrReview { review_decision: Option<String> }
+                                    struct PrReview {
+                                        review_decision: Option<String>,
+                                    }
                                     serde_json::from_slice::<PrReview>(&output.stdout)
                                         .map(|pr| pr.review_decision.as_deref() == Some("APPROVED"))
                                         .unwrap_or(false)
-                                } else { false }
-                            } else { false }
-                        } else { false }
-                    } else { false }
+                                } else {
+                                    false
+                                }
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
                 }
                 _ => false,
             }
@@ -387,21 +436,31 @@ pub fn evaluate_exit_criteria(
     };
 
     if exit_met {
-        emit_pipeline(app, "pipeline:exit_met", &task.id, &column.id, PipelineState::Evaluating, Some(format!("Exit criteria met: {}", exit_type.as_str())));
+        emit_pipeline(
+            app,
+            "pipeline:exit_met",
+            &task.id,
+            &column.id,
+            PipelineState::Evaluating,
+            Some(format!("Exit criteria met: {}", exit_type.as_str())),
+        );
     }
 
     // Reset state to running or idle
     let new_state = if exit_met {
         PipelineState::Idle
-    } else if PipelineState::from_str(&task.pipeline_state) == PipelineState::Running {
+    } else if PipelineState::from_db_str(&task.pipeline_state) == PipelineState::Running {
         PipelineState::Running
     } else {
         PipelineState::Idle
     };
 
     let _ = db::update_task_pipeline_state(
-        conn, &task.id, new_state.as_str(),
-        task.pipeline_triggered_at.as_deref(), None,
+        conn,
+        &task.id,
+        new_state.as_str(),
+        task.pipeline_triggered_at.as_deref(),
+        None,
     );
 
     Ok(exit_met)
@@ -451,7 +510,14 @@ pub fn try_auto_advance(
                 None,
             );
 
-            emit_pipeline(app, "pipeline:advancing", &task.id, &current_column.id, PipelineState::Advancing, Some(format!("Moving to column: {}", next_col.name)));
+            emit_pipeline(
+                app,
+                "pipeline:advancing",
+                &task.id,
+                &current_column.id,
+                PipelineState::Advancing,
+                Some(format!("Moving to column: {}", next_col.name)),
+            );
 
             // Get next position in target column
             let max_pos: i64 = conn
@@ -471,7 +537,17 @@ pub fn try_auto_advance(
 
             let updated_task = db::get_task(conn, &task.id)?;
 
-            emit_pipeline(app, "pipeline:advanced", &updated_task.id, &next_col.id, PipelineState::Idle, Some(format!("Moved from {} to {}", current_column.name, next_col.name)));
+            emit_pipeline(
+                app,
+                "pipeline:advanced",
+                &updated_task.id,
+                &next_col.id,
+                PipelineState::Idle,
+                Some(format!(
+                    "Moved from {} to {}",
+                    current_column.name, next_col.name
+                )),
+            );
 
             // Notify frontend that tasks changed
             emit_tasks_changed(app, &task.workspace_id, "pipeline_advanced");
@@ -511,7 +587,14 @@ pub fn handle_trigger_failure(
         Some(error_message),
     )?;
 
-    emit_pipeline(app, "pipeline:error", &task.id, &column.id, PipelineState::Idle, Some(error_message.to_string()));
+    emit_pipeline(
+        app,
+        "pipeline:error",
+        &task.id,
+        &column.id,
+        PipelineState::Idle,
+        Some(error_message.to_string()),
+    );
 
     Ok(updated_task)
 }
@@ -521,7 +604,8 @@ fn increment_retry_count(conn: &Connection, task_id: &str) -> Result<(), AppErro
     conn.execute(
         "UPDATE tasks SET retry_count = retry_count + 1 WHERE id = ?1",
         rusqlite::params![task_id],
-    ).map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    )
+    .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(())
 }
 
@@ -547,8 +631,14 @@ pub fn mark_complete_with_error(
     let column = db::get_column(conn, &task.column_id)?;
 
     // Record timing: task exiting this column
-    if let Err(e) = db::complete_pipeline_timing(conn, task_id, &column.id, success, task.retry_count) {
-        log::warn!("Failed to complete pipeline timing for task {}: {}", task_id, e);
+    if let Err(e) =
+        db::complete_pipeline_timing(conn, task_id, &column.id, success, task.retry_count)
+    {
+        log::warn!(
+            "Failed to complete pipeline timing for task {}: {}",
+            task_id,
+            e
+        );
     }
 
     let action = decide_completion(&task, column.triggers.as_deref(), success);
@@ -559,7 +649,8 @@ pub fn mark_complete_with_error(
             conn.execute(
                 "UPDATE tasks SET retry_count = 0 WHERE id = ?1",
                 rusqlite::params![task_id],
-            ).map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            )
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
             // Check dependents - tasks waiting on this one
             let _ = dependencies::check_dependents(conn, app, &task);
@@ -571,7 +662,11 @@ pub fn mark_complete_with_error(
 
             // Auto-advance not possible (no next column), fall through to complete
             let updated_task = db::update_task_pipeline_state(
-                conn, task_id, PipelineState::Idle.as_str(), None, None,
+                conn,
+                task_id,
+                PipelineState::Idle.as_str(),
+                None,
+                None,
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, true);
             Ok(updated_task)
@@ -581,13 +676,18 @@ pub fn mark_complete_with_error(
             conn.execute(
                 "UPDATE tasks SET retry_count = 0 WHERE id = ?1",
                 rusqlite::params![task_id],
-            ).map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            )
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
             // Check dependents
             let _ = dependencies::check_dependents(conn, app, &task);
 
             let updated_task = db::update_task_pipeline_state(
-                conn, task_id, PipelineState::Idle.as_str(), None, None,
+                conn,
+                task_id,
+                PipelineState::Idle.as_str(),
+                None,
+                None,
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, true);
             Ok(updated_task)
@@ -600,7 +700,14 @@ pub fn mark_complete_with_error(
             };
             log::info!("[pipeline] {}: {}", task_id, retry_msg);
 
-            emit_pipeline(app, "pipeline:error", task_id, &column.id, PipelineState::Idle, Some(retry_msg));
+            emit_pipeline(
+                app,
+                "pipeline:error",
+                task_id,
+                &column.id,
+                PipelineState::Idle,
+                Some(retry_msg),
+            );
             let msg = if max == -1 {
                 format!("Siege retry #{}", attempt)
             } else {
@@ -608,7 +715,14 @@ pub fn mark_complete_with_error(
             };
             log::info!("[pipeline] {} task {}", msg, task_id);
 
-            emit_pipeline(app, "pipeline:error", task_id, &column.id, PipelineState::Idle, Some(msg));
+            emit_pipeline(
+                app,
+                "pipeline:error",
+                task_id,
+                &column.id,
+                PipelineState::Idle,
+                Some(msg),
+            );
 
             let updated_task = db::get_task(conn, task_id)?;
             fire_trigger(conn, app, &updated_task, &column)
@@ -633,7 +747,11 @@ pub fn mark_complete_with_error(
 
             let error_msg = error_detail.unwrap_or("Execution failed");
             let updated_task = db::update_task_pipeline_state(
-                conn, task_id, PipelineState::Idle.as_str(), None, Some(error_msg),
+                conn,
+                task_id,
+                PipelineState::Idle.as_str(),
+                None,
+                Some(error_msg),
             )?;
             emit_completion_event(app, task_id, &column.id, &task.workspace_id, false);
             Ok(updated_task)
@@ -641,8 +759,21 @@ pub fn mark_complete_with_error(
     }
 }
 
-fn emit_completion_event(app: &AppHandle, task_id: &str, column_id: &str, workspace_id: &str, success: bool) {
-    emit_pipeline(app, "pipeline:complete", task_id, column_id, PipelineState::Idle, Some(if success { "Success" } else { "Failed" }.to_string()));
+fn emit_completion_event(
+    app: &AppHandle,
+    task_id: &str,
+    column_id: &str,
+    workspace_id: &str,
+    success: bool,
+) {
+    emit_pipeline(
+        app,
+        "pipeline:complete",
+        task_id,
+        column_id,
+        PipelineState::Idle,
+        Some(if success { "Success" } else { "Failed" }.to_string()),
+    );
     emit_tasks_changed(app, workspace_id, "pipeline_complete");
 
     // Promote queued tasks now that a slot may have opened up
@@ -676,7 +807,9 @@ fn promote_queued_tasks(app: &AppHandle, workspace_id: &str) {
     if let Some(next) = queued.first() {
         log::info!(
             "[pipeline] Promoting queued task {} (slot opened: {}/{})",
-            next.id, running, max
+            next.id,
+            running,
+            max
         );
         // Clear queued status so the trigger can fire
         let _ = db::update_task_agent_status(&conn, &next.id, Some("idle"), None);
@@ -684,9 +817,13 @@ fn promote_queued_tasks(app: &AppHandle, workspace_id: &str) {
         if let Ok(columns) = db::list_columns(&conn, workspace_id) {
             if let Some(col) = columns.iter().find(|c| c.id == next.column_id) {
                 let parsed_triggers = triggers::parse_column_triggers(col.triggers.as_deref());
-                match triggers::fire_on_entry(&conn, app, &next, col, &parsed_triggers, None) {
+                match triggers::fire_on_entry(&conn, app, next, col, &parsed_triggers, None) {
                     Ok(_) => log::info!("[pipeline] Queued task {} promoted successfully", next.id),
-                    Err(e) => log::warn!("[pipeline] Failed to promote queued task {}: {}", next.id, e),
+                    Err(e) => log::warn!(
+                        "[pipeline] Failed to promote queued task {}: {}",
+                        next.id,
+                        e
+                    ),
                 }
             }
         }
@@ -698,7 +835,6 @@ fn promote_queued_tasks(app: &AppHandle, workspace_id: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db;
 
     /// Create a minimal task for testing decision logic.
     fn make_task(retry_count: i64, pipeline_state: &str) -> Task {
@@ -758,7 +894,8 @@ mod tests {
                 "auto_advance": auto_advance,
                 "max_retries": max_retries
             }
-        }).to_string()
+        })
+        .to_string()
     }
 
     // ─── decide_completion tests ──────────────────────────────────────
@@ -835,28 +972,33 @@ mod tests {
                 "auto_advance": auto_advance,
                 "max_retries": -1
             }
-        }).to_string()
+        })
+        .to_string()
     }
 
     #[test]
     fn test_decide_siege_retries_when_recent() {
         let mut task = make_task(3, "running");
         // Started 5 minutes ago — well within 30-min cap
-        task.pipeline_triggered_at = Some(
-            (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339()
-        );
+        task.pipeline_triggered_at =
+            Some((chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339());
         let triggers = siege_triggers_json(true);
         let action = decide_completion(&task, Some(&triggers), false);
-        assert_eq!(action, CompletionAction::Retry { attempt: 4, max: -1 });
+        assert_eq!(
+            action,
+            CompletionAction::Retry {
+                attempt: 4,
+                max: -1
+            }
+        );
     }
 
     #[test]
     fn test_decide_siege_fails_when_timed_out() {
         let mut task = make_task(50, "running");
         // Started 31 minutes ago — past the 30-min cap
-        task.pipeline_triggered_at = Some(
-            (chrono::Utc::now() - chrono::Duration::minutes(31)).to_rfc3339()
-        );
+        task.pipeline_triggered_at =
+            Some((chrono::Utc::now() - chrono::Duration::minutes(31)).to_rfc3339());
         let triggers = siege_triggers_json(true);
         let action = decide_completion(&task, Some(&triggers), false);
         assert_eq!(action, CompletionAction::Failed);
@@ -868,7 +1010,13 @@ mod tests {
         task.pipeline_triggered_at = None; // No timestamp — allow retry
         let triggers = siege_triggers_json(false);
         let action = decide_completion(&task, Some(&triggers), false);
-        assert_eq!(action, CompletionAction::Retry { attempt: 6, max: -1 });
+        assert_eq!(
+            action,
+            CompletionAction::Retry {
+                attempt: 6,
+                max: -1
+            }
+        );
     }
 
     #[test]
@@ -1052,14 +1200,20 @@ mod tests {
 
     #[test]
     fn test_pipeline_state_roundtrip() {
-        for state in [PipelineState::Idle, PipelineState::Triggered, PipelineState::Running, PipelineState::Evaluating, PipelineState::Advancing] {
-            assert_eq!(PipelineState::from_str(state.as_str()), state);
+        for state in [
+            PipelineState::Idle,
+            PipelineState::Triggered,
+            PipelineState::Running,
+            PipelineState::Evaluating,
+            PipelineState::Advancing,
+        ] {
+            assert_eq!(PipelineState::from_db_str(state.as_str()), state);
         }
     }
 
     #[test]
     fn test_pipeline_state_unknown_defaults_idle() {
-        assert_eq!(PipelineState::from_str("garbage"), PipelineState::Idle);
-        assert_eq!(PipelineState::from_str(""), PipelineState::Idle);
+        assert_eq!(PipelineState::from_db_str("garbage"), PipelineState::Idle);
+        assert_eq!(PipelineState::from_db_str(""), PipelineState::Idle);
     }
 }

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use tauri::{AppHandle, Emitter};
 
 use super::template::{self, TemplateContext};
-use super::{emit_pipeline, PipelineState, EVT_TRIGGERED, EVT_RUNNING, EVT_ADVANCED};
+use super::{emit_pipeline, PipelineState, EVT_ADVANCED, EVT_RUNNING, EVT_TRIGGERED};
 
 // ─── V2 Trigger Types ─────────────────────────────────────────────────────
 
@@ -165,7 +165,13 @@ impl ResolvedStep {
 
     fn step_type(&self) -> &str {
         match self {
-            ResolvedStep::Shell { is_check, .. } => if *is_check { "check" } else { "bash" },
+            ResolvedStep::Shell { is_check, .. } => {
+                if *is_check {
+                    "check"
+                } else {
+                    "bash"
+                }
+            }
             ResolvedStep::Agent { .. } => "agent",
         }
     }
@@ -259,7 +265,14 @@ pub fn fire_on_entry(
         Option::None,
     )?;
 
-    emit_pipeline(app, EVT_TRIGGERED, &task.id, &column.id, PipelineState::Triggered, Some("V2 trigger fired".to_string()));
+    emit_pipeline(
+        app,
+        EVT_TRIGGERED,
+        &task.id,
+        &column.id,
+        PipelineState::Triggered,
+        Some("V2 trigger fired".to_string()),
+    );
 
     execute_action(conn, app, &updated_task, column, &action, prev_column)
 }
@@ -298,15 +311,43 @@ fn execute_action(
     other_column: Option<&Column>,
 ) -> Result<Task, AppError> {
     match action {
-        TriggerActionV2::SpawnCli { cli, command, prompt_template, prompt, flags, use_queue: _, model } => {
-            execute_spawn_cli(conn, app, task, column, other_column, cli.as_deref(), command.as_deref(), prompt_template.as_deref(), prompt.as_deref(), flags.as_deref(), model.as_deref())
-        }
-        TriggerActionV2::MoveColumn { target } => {
-            execute_move_column(conn, app, task, target)
-        }
-        TriggerActionV2::TriggerTask { target_task, action: task_action, target_column, inject_prompt } => {
-            execute_trigger_task(conn, app, task, column, target_task, task_action, target_column.as_deref(), inject_prompt.as_deref())
-        }
+        TriggerActionV2::SpawnCli {
+            cli,
+            command,
+            prompt_template,
+            prompt,
+            flags,
+            use_queue: _,
+            model,
+        } => execute_spawn_cli(
+            conn,
+            app,
+            task,
+            column,
+            other_column,
+            cli.as_deref(),
+            command.as_deref(),
+            prompt_template.as_deref(),
+            prompt.as_deref(),
+            flags.as_deref(),
+            model.as_deref(),
+        ),
+        TriggerActionV2::MoveColumn { target } => execute_move_column(conn, app, task, target),
+        TriggerActionV2::TriggerTask {
+            target_task,
+            action: task_action,
+            target_column,
+            inject_prompt,
+        } => execute_trigger_task(
+            conn,
+            app,
+            task,
+            column,
+            target_task,
+            task_action,
+            target_column.as_deref(),
+            inject_prompt.as_deref(),
+        ),
         TriggerActionV2::RunScript { script_id } => {
             execute_run_script(conn, app, task, column, other_column, script_id)
         }
@@ -370,12 +411,20 @@ fn ensure_task_worktree(
         ) {
             Ok(branch_name) => {
                 task = db::update_task_branch(conn, &task.id, Some(&branch_name))?;
-                log::info!("[triggers] Auto-created branch '{}' for task {}", branch_name, task.id);
+                log::info!(
+                    "[triggers] Auto-created branch '{}' for task {}",
+                    branch_name,
+                    task.id
+                );
             }
             Err(e) => {
                 // Branch may already exist (e.g. from a previous attempt)
                 let branch_name = format!("{}{}", settings.branch_prefix, slug);
-                log::warn!("[triggers] Branch creation failed ({}), trying existing '{}'", e, branch_name);
+                log::warn!(
+                    "[triggers] Branch creation failed ({}), trying existing '{}'",
+                    e,
+                    branch_name
+                );
                 task = db::update_task_branch(conn, &task.id, Some(&branch_name))?;
             }
         }
@@ -383,7 +432,10 @@ fn ensure_task_worktree(
 
     let branch_name = task.branch_name.as_deref().unwrap_or("");
     if branch_name.is_empty() {
-        log::warn!("[triggers] Could not determine branch for task {}, skipping worktree", task.id);
+        log::warn!(
+            "[triggers] Could not determine branch for task {}, skipping worktree",
+            task.id
+        );
         return Ok(task);
     }
 
@@ -392,10 +444,18 @@ fn ensure_task_worktree(
         Ok(wt_path) => {
             task = db::update_task_worktree_path(conn, &task.id, Some(&wt_path))?;
             super::emit_tasks_changed(app, &task.workspace_id, "worktree_auto_created");
-            log::info!("[triggers] Auto-created worktree at '{}' for task {}", wt_path, task.id);
+            log::info!(
+                "[triggers] Auto-created worktree at '{}' for task {}",
+                wt_path,
+                task.id
+            );
         }
         Err(e) => {
-            log::error!("[triggers] Failed to create worktree for task {}: {}", task.id, e);
+            log::error!(
+                "[triggers] Failed to create worktree for task {}: {}",
+                task.id,
+                e
+            );
             // Continue without worktree — agent falls back to repo root
         }
     }
@@ -408,6 +468,7 @@ fn ensure_task_worktree(
 /// Default max concurrent agents per workspace (when not configured in workspace settings).
 pub const DEFAULT_MAX_CONCURRENT_AGENTS: i64 = config::DEFAULT_PIPELINE_MAX_CONCURRENT_AGENTS;
 
+#[allow(clippy::too_many_arguments)]
 fn execute_spawn_cli(
     conn: &Connection,
     app: &AppHandle,
@@ -433,7 +494,9 @@ fn execute_spawn_cli(
     if running_count >= max_concurrent {
         log::info!(
             "[triggers] Concurrency limit reached ({}/{}) — queuing task {} instead of spawning",
-            running_count, max_concurrent, task.id
+            running_count,
+            max_concurrent,
+            task.id
         );
         let ts = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
         db::update_task_agent_status(conn, &task.id, Some("queued"), Some(&ts))?;
@@ -444,18 +507,29 @@ fn execute_spawn_cli(
     // Auto-create worktree for trigger-spawned agents to sandbox them.
     // Check both: DB field is unset OR the path no longer exists on disk
     // (can happen after retry cleanup deletes the worktree directory).
-    let needs_worktree = task.worktree_path.as_ref()
+    let needs_worktree = task
+        .worktree_path
+        .as_ref()
         .map(|p| p.is_empty() || !std::path::Path::new(p).exists())
         .unwrap_or(true);
 
     let task = if needs_worktree && !workspace.repo_path.is_empty() {
         // Clear stale worktree_path so ensure_task_worktree creates a fresh one
         if task.worktree_path.is_some() {
-            log::warn!("[triggers] Worktree path set but directory missing for task {} — recreating", task.id);
+            log::warn!(
+                "[triggers] Worktree path set but directory missing for task {} — recreating",
+                task.id
+            );
             let _ = db::update_task_worktree_path(conn, &task.id, None);
         }
         let fresh_task = db::get_task(conn, &task.id)?;
-        ensure_task_worktree(conn, app, &fresh_task, &workspace.repo_path, &pipeline_settings)?
+        ensure_task_worktree(
+            conn,
+            app,
+            &fresh_task,
+            &workspace.repo_path,
+            &pipeline_settings,
+        )?
     } else {
         task.clone()
     };
@@ -463,13 +537,18 @@ fn execute_spawn_cli(
     let working_dir = resolve_working_dir(&task, &workspace.repo_path);
 
     if !working_dir.is_empty() && !std::path::Path::new(&working_dir).exists() {
-        log::warn!("Working dir '{}' does not exist, agent may fail", working_dir);
+        log::warn!(
+            "Working dir '{}' does not exist, agent may fail",
+            working_dir
+        );
     }
 
     // Write .task.md to worktree — agent reads this instead of getting full spec in prompt
     if !working_dir.is_empty() {
         let task_md_path = std::path::Path::new(&working_dir).join(".task.md");
-        let checklist_section = task.checklist.as_deref()
+        let checklist_section = task
+            .checklist
+            .as_deref()
             .filter(|c| !c.is_empty() && *c != "[]")
             .map(|c| format!("\n## Checklist\n{}\n", c))
             .unwrap_or_default();
@@ -489,26 +568,40 @@ fn execute_spawn_cli(
         }
 
         // Exclude .task.md from git (avoid agent committing it)
-        let exclude_path = std::path::Path::new(&working_dir).join(".git").join("info").join("exclude");
+        let exclude_path = std::path::Path::new(&working_dir)
+            .join(".git")
+            .join("info")
+            .join("exclude");
         if exclude_path.exists() {
             if let Ok(content) = std::fs::read_to_string(&exclude_path) {
                 if !content.contains(".task.md") {
-                    let _ = std::fs::write(&exclude_path, format!("{}\n.task.md\n.task-handoff.md\n", content.trim_end()));
+                    let _ = std::fs::write(
+                        &exclude_path,
+                        format!("{}\n.task.md\n.task-handoff.md\n", content.trim_end()),
+                    );
                 }
             }
         }
     }
 
     let ctx = TemplateContext {
-        task: &task, column, workspace: &workspace,
-        prev_column: other_column, next_column: Option::None, dep_tasks: HashMap::new(),
+        task: &task,
+        column,
+        workspace: &workspace,
+        prev_column: other_column,
+        next_column: Option::None,
+        dep_tasks: HashMap::new(),
     };
 
     // Resolve prompt: direct prompt > template > .task.md pointer (token-optimized default)
     let resolved_prompt = if let Some(p) = prompt {
-        if !p.is_empty() { template::interpolate(p, &ctx) }
-        else if let Some(tmpl) = prompt_template { template::interpolate(tmpl, &ctx) }
-        else { format!("{}\n\nSee .task.md for full spec.", task.title) }
+        if !p.is_empty() {
+            template::interpolate(p, &ctx)
+        } else if let Some(tmpl) = prompt_template {
+            template::interpolate(tmpl, &ctx)
+        } else {
+            format!("{}\n\nSee .task.md for full spec.", task.title)
+        }
     } else if let Some(tmpl) = prompt_template {
         template::interpolate(tmpl, &ctx)
     } else {
@@ -538,7 +631,11 @@ fn execute_spawn_cli(
     }
 
     let updated_task = db::update_task_pipeline_state(
-        conn, &task.id, PipelineState::Running.as_str(), Some(&ts), Option::None,
+        conn,
+        &task.id,
+        PipelineState::Running.as_str(),
+        Some(&ts),
+        Option::None,
     )?;
 
     // Build env vars
@@ -552,7 +649,14 @@ fn execute_spawn_cli(
         env_vars.insert("TRIGGER_FLAGS".to_string(), f.join(" "));
     }
 
-    emit_pipeline(app, EVT_RUNNING, &task.id, &column.id, PipelineState::Running, Some(format!("CLI trigger: {}", cli_type)));
+    emit_pipeline(
+        app,
+        EVT_RUNNING,
+        &task.id,
+        &column.id,
+        PipelineState::Running,
+        Some(format!("CLI trigger: {}", cli_type)),
+    );
 
     // Resolve model: task override > trigger config > workspace config > global settings
     let resolved_model = resolve_model_override(
@@ -567,8 +671,13 @@ fn execute_spawn_cli(
     }
 
     bridge::spawn_cli_trigger_task(
-        app.clone(), task.id.clone(), cli_type, cli_args,
-        working_dir, initial_prompt, Some(env_vars),
+        app.clone(),
+        task.id.clone(),
+        cli_type,
+        cli_args,
+        working_dir,
+        initial_prompt,
+        Some(env_vars),
     );
 
     Ok(updated_task)
@@ -586,7 +695,8 @@ fn execute_move_column(
         let max_pos: i64 = conn
             .query_row(
                 "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
-                rusqlite::params![col.id], |row| row.get(0),
+                rusqlite::params![col.id],
+                |row| row.get(0),
             )
             .unwrap_or(-1);
 
@@ -595,7 +705,14 @@ fn execute_move_column(
             rusqlite::params![col.id, max_pos + 1, ts, task.id],
         ).map_err(AppError::from)?;
 
-        emit_pipeline(app, EVT_ADVANCED, &task.id, &col.id, PipelineState::Idle, Some(format!("Moved to {}", col.name)));
+        emit_pipeline(
+            app,
+            EVT_ADVANCED,
+            &task.id,
+            &col.id,
+            PipelineState::Idle,
+            Some(format!("Moved to {}", col.name)),
+        );
 
         let moved_task = db::get_task(conn, &task.id)?;
         super::emit_tasks_changed(app, &task.workspace_id, "trigger_move_column");
@@ -605,6 +722,7 @@ fn execute_move_column(
     Ok(task.clone())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_trigger_task(
     conn: &Connection,
     app: &AppHandle,
@@ -638,7 +756,8 @@ fn execute_trigger_task(
                 conn.execute(
                     "UPDATE tasks SET blocked = 0, updated_at = ?1 WHERE id = ?2",
                     rusqlite::params![db::now(), target.id],
-                ).map_err(AppError::from)?;
+                )
+                .map_err(AppError::from)?;
             }
             TriggerTaskActionTypeV2::Start => {
                 let col = db::get_column(conn, &target.column_id)?;
@@ -650,14 +769,19 @@ fn execute_trigger_task(
         if let Some(inject) = inject_prompt {
             let workspace = db::get_workspace(conn, &task.workspace_id)?;
             let ctx = TemplateContext {
-                task, column, workspace: &workspace,
-                prev_column: Option::None, next_column: Option::None, dep_tasks: HashMap::new(),
+                task,
+                column,
+                workspace: &workspace,
+                prev_column: Option::None,
+                next_column: Option::None,
+                dep_tasks: HashMap::new(),
             };
             let resolved = template::interpolate(inject, &ctx);
             conn.execute(
                 "UPDATE tasks SET trigger_prompt = ?1, updated_at = ?2 WHERE id = ?3",
                 rusqlite::params![resolved, db::now(), target.id],
-            ).map_err(AppError::from)?;
+            )
+            .map_err(AppError::from)?;
         }
     }
     Ok(task.clone())
@@ -744,16 +868,27 @@ fn execute_create_pr(
         Some(b) if !b.is_empty() => b.clone(),
         _ => {
             return super::handle_trigger_failure(
-                conn, app, task, column,
+                conn,
+                app,
+                task,
+                column,
                 "Cannot create PR: task has no branch_name",
             );
         }
     };
 
     if let Some(pr_num) = task.pr_number {
-        log::info!("[create_pr] Task {} already has PR #{}, skipping", task.id, pr_num);
+        log::info!(
+            "[create_pr] Task {} already has PR #{}, skipping",
+            task.id,
+            pr_num
+        );
         let updated = db::update_task_pipeline_state(
-            conn, &task.id, PipelineState::Idle.as_str(), None, None,
+            conn,
+            &task.id,
+            PipelineState::Idle.as_str(),
+            None,
+            None,
         )?;
         return Ok(updated);
     }
@@ -766,11 +901,21 @@ fn execute_create_pr(
     let column_id = column.id.clone();
 
     let updated_task = db::update_task_pipeline_state(
-        conn, &task.id, PipelineState::Running.as_str(),
-        Some(&db::now()), None,
+        conn,
+        &task.id,
+        PipelineState::Running.as_str(),
+        Some(&db::now()),
+        None,
     )?;
 
-    emit_pipeline(app, EVT_RUNNING, &task.id, &column.id, PipelineState::Running, Some("Creating PR".to_string()));
+    emit_pipeline(
+        app,
+        EVT_RUNNING,
+        &task.id,
+        &column.id,
+        PipelineState::Running,
+        Some("Creating PR".to_string()),
+    );
 
     let app_handle = app.clone();
 
@@ -790,7 +935,10 @@ fn execute_create_pr(
                     // Fallback: force-push if regular push fails (e.g. stale remote branch)
                     // Safety: only force-push bentoya/* branches, never main/master
                     if branch_name.starts_with("bentoya/") {
-                        log::warn!("[pipeline] Regular push failed, trying force-push: {}", stderr.trim());
+                        log::warn!(
+                            "[pipeline] Regular push failed, trying force-push: {}",
+                            stderr.trim()
+                        );
                         let force_output = std::process::Command::new("git")
                             .args(["push", "-u", "origin", &branch_name, "--force"])
                             .current_dir(&repo_path)
@@ -798,21 +946,33 @@ fn execute_create_pr(
                             .map_err(|e| format!("Failed to force-push branch: {}", e))?;
                         if !force_output.status.success() {
                             let force_stderr = String::from_utf8_lossy(&force_output.stderr);
-                            return Err(format!("git push --force failed: {}", force_stderr.trim()));
+                            return Err(format!(
+                                "git push --force failed: {}",
+                                force_stderr.trim()
+                            ));
                         }
                     } else {
-                        return Err(format!("git push failed (force-push not allowed on '{}'): {}", branch_name, stderr.trim()));
+                        return Err(format!(
+                            "git push failed (force-push not allowed on '{}'): {}",
+                            branch_name,
+                            stderr.trim()
+                        ));
                     }
                 }
             }
 
             let output = std::process::Command::new("gh")
                 .args([
-                    "pr", "create",
-                    "--title", &pr_title,
-                    "--body", &pr_body,
-                    "--base", &base,
-                    "--head", &branch_name,
+                    "pr",
+                    "create",
+                    "--title",
+                    &pr_title,
+                    "--body",
+                    &pr_body,
+                    "--base",
+                    &base,
+                    "--head",
+                    &branch_name,
                 ])
                 .current_dir(&repo_path)
                 .output()
@@ -832,17 +992,29 @@ fn execute_create_pr(
                 .ok_or_else(|| format!("Failed to parse PR number from URL: {}", pr_url))?;
 
             Ok((pr_number, pr_url))
-        }).await;
+        })
+        .await;
 
         let db_path = crate::db::db_path();
         let conn = match rusqlite::Connection::open(&db_path) {
-            Ok(c) => { let _ = c.execute_batch("PRAGMA journal_mode=WAL;"); Some(c) }
-            Err(e) => { log::error!("[create_pr] Failed to open DB: {}", e); None }
+            Ok(c) => {
+                let _ = c.execute_batch("PRAGMA journal_mode=WAL;");
+                Some(c)
+            }
+            Err(e) => {
+                log::error!("[create_pr] Failed to open DB: {}", e);
+                None
+            }
         };
 
         let success = match result {
             Ok(Ok((pr_number, pr_url))) => {
-                log::info!("[create_pr] Created PR #{} for task {}: {}", pr_number, task_id, pr_url);
+                log::info!(
+                    "[create_pr] Created PR #{} for task {}: {}",
+                    pr_number,
+                    task_id,
+                    pr_url
+                );
                 if let Some(ref conn) = conn {
                     let _ = db::update_task_pr_info(conn, &task_id, Some(pr_number), Some(&pr_url));
                 }
@@ -850,13 +1022,16 @@ fn execute_create_pr(
             }
             Ok(Err(e)) => {
                 log::error!("[create_pr] Failed for task {}: {}", task_id, e);
-                let _ = app_handle.emit("pipeline:error", &super::PipelineEvent {
-                    task_id: task_id.clone(),
-                    column_id: column_id.clone(),
-                    event_type: "error".to_string(),
-                    state: PipelineState::Idle.as_str().to_string(),
-                    message: Some(e),
-                });
+                let _ = app_handle.emit(
+                    "pipeline:error",
+                    &super::PipelineEvent {
+                        task_id: task_id.clone(),
+                        column_id: column_id.clone(),
+                        event_type: "error".to_string(),
+                        state: PipelineState::Idle.as_str().to_string(),
+                        message: Some(e),
+                    },
+                );
                 false
             }
             Err(e) => {
@@ -884,221 +1059,271 @@ fn execute_run_script(
     other_column: Option<&Column>,
     script_id: &str,
 ) -> Result<Task, AppError> {
-            // Load script from DB and execute steps sequentially
-            let script = db::get_script(conn, script_id)
-                .map_err(|_| AppError::NotFound(format!("Script '{}' not found", script_id)))?;
-            let workspace = db::get_workspace(conn, &task.workspace_id)?;
-            let pipeline_settings = config::effective_pipeline_settings(&workspace.config);
-            let working_dir = resolve_working_dir(task, &workspace.repo_path);
+    // Load script from DB and execute steps sequentially
+    let script = db::get_script(conn, script_id)
+        .map_err(|_| AppError::NotFound(format!("Script '{}' not found", script_id)))?;
+    let workspace = db::get_workspace(conn, &task.workspace_id)?;
+    let pipeline_settings = config::effective_pipeline_settings(&workspace.config);
+    let working_dir = resolve_working_dir(task, &workspace.repo_path);
 
-            // Validate working dir exists
-            if !working_dir.is_empty() && !std::path::Path::new(&working_dir).exists() {
-                log::warn!("Working dir '{}' does not exist, script may fail", working_dir);
-            }
+    // Validate working dir exists
+    if !working_dir.is_empty() && !std::path::Path::new(&working_dir).exists() {
+        log::warn!(
+            "Working dir '{}' does not exist, script may fail",
+            working_dir
+        );
+    }
 
-            let ts = db::now();
-            let updated_task = db::update_task_pipeline_state(
-                conn,
-                &task.id,
-                PipelineState::Running.as_str(),
-                Some(&ts),
-                Option::None,
-            )?;
+    let ts = db::now();
+    let updated_task = db::update_task_pipeline_state(
+        conn,
+        &task.id,
+        PipelineState::Running.as_str(),
+        Some(&ts),
+        Option::None,
+    )?;
 
-            emit_pipeline(app, EVT_RUNNING, &task.id, &column.id, PipelineState::Running, Some(format!("Running script: {}", script.name)));
+    emit_pipeline(
+        app,
+        EVT_RUNNING,
+        &task.id,
+        &column.id,
+        PipelineState::Running,
+        Some(format!("Running script: {}", script.name)),
+    );
 
-            // Parse steps
-            let steps: Vec<serde_json::Value> = serde_json::from_str(&script.steps)
-                .unwrap_or_default();
+    // Parse steps
+    let steps: Vec<serde_json::Value> = serde_json::from_str(&script.steps).unwrap_or_default();
 
-            // Pre-interpolate all template variables before moving into async block
-            let ctx = TemplateContext {
-                task,
-                column,
-                workspace: &workspace,
-                prev_column: other_column,
-                next_column: Option::None,
-                dep_tasks: HashMap::new(),
-            };
+    // Pre-interpolate all template variables before moving into async block
+    let ctx = TemplateContext {
+        task,
+        column,
+        workspace: &workspace,
+        prev_column: other_column,
+        next_column: Option::None,
+        dep_tasks: HashMap::new(),
+    };
 
-            // Resolve all steps into owned data
-            let resolved_steps: Vec<ResolvedStep> = steps.iter().map(|step| {
-                let step_type = step.get("type").and_then(|v| v.as_str()).unwrap_or("bash").to_string();
-                let step_name = step.get("name").and_then(|v| v.as_str()).unwrap_or("Step").to_string();
+    // Resolve all steps into owned data
+    let resolved_steps: Vec<ResolvedStep> = steps
+        .iter()
+        .map(|step| {
+            let step_type = step
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("bash")
+                .to_string();
+            let step_name = step
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Step")
+                .to_string();
 
-                match step_type.as_str() {
-                    "bash" | "check" => {
-                        let command = step.get("command").and_then(|v| v.as_str()).unwrap_or("");
-                        let command = template::interpolate(command, &ctx);
-                        let work_dir = step.get("workDir")
-                            .and_then(|v| v.as_str())
-                            .map(|d| template::interpolate(d, &ctx))
-                            .unwrap_or_else(|| working_dir.clone());
-                        let continue_on_error = step.get("continueOnError")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        let fail_message = step.get("failMessage")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
+            match step_type.as_str() {
+                "bash" | "check" => {
+                    let command = step.get("command").and_then(|v| v.as_str()).unwrap_or("");
+                    let command = template::interpolate(command, &ctx);
+                    let work_dir = step
+                        .get("workDir")
+                        .and_then(|v| v.as_str())
+                        .map(|d| template::interpolate(d, &ctx))
+                        .unwrap_or_else(|| working_dir.clone());
+                    let continue_on_error = step
+                        .get("continueOnError")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let fail_message = step
+                        .get("failMessage")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
 
-                        ResolvedStep::Shell {
-                            name: step_name,
-                            is_check: step_type == "check",
-                            command,
-                            work_dir,
-                            continue_on_error,
-                            fail_message,
-                        }
-                    }
-                    "agent" => {
-                        let prompt = step.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
-                        let prompt = template::interpolate(prompt, &ctx);
-                        let model = step.get("model").and_then(|v| v.as_str()).map(|s| s.to_string());
-                        let command = step.get("command").and_then(|v| v.as_str()).map(|s| s.to_string());
-
-                        ResolvedStep::Agent {
-                            name: step_name,
-                            prompt,
-                            model,
-                            command,
-                        }
-                    }
-                    _ => ResolvedStep::Shell {
+                    ResolvedStep::Shell {
                         name: step_name,
-                        is_check: false,
-                        command: String::new(),
-                        work_dir: working_dir.clone(),
-                        continue_on_error: true,
-                        fail_message: None,
-                    },
+                        is_check: step_type == "check",
+                        command,
+                        work_dir,
+                        continue_on_error,
+                        fail_message,
+                    }
                 }
-            }).collect();
+                "agent" => {
+                    let prompt = step.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
+                    let prompt = template::interpolate(prompt, &ctx);
+                    let model = step
+                        .get("model")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let command = step
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
 
-            let task_id = task.id.clone();
-            let app_handle = app.clone();
-            let column_id = column.id.clone();
-            let workspace_path = working_dir.clone();
-            let default_agent_cli = pipeline_settings.default_agent_cli.clone();
-            let default_model = pipeline_settings.default_model.clone();
+                    ResolvedStep::Agent {
+                        name: step_name,
+                        prompt,
+                        model,
+                        command,
+                    }
+                }
+                _ => ResolvedStep::Shell {
+                    name: step_name,
+                    is_check: false,
+                    command: String::new(),
+                    work_dir: working_dir.clone(),
+                    continue_on_error: true,
+                    fail_message: None,
+                },
+            }
+        })
+        .collect();
 
-            // Execute steps in a background task (all data is owned)
-            tokio::spawn(async move {
-                let mut success = true;
-                let total = resolved_steps.len();
+    let task_id = task.id.clone();
+    let app_handle = app.clone();
+    let column_id = column.id.clone();
+    let workspace_path = working_dir.clone();
+    let default_agent_cli = pipeline_settings.default_agent_cli.clone();
+    let default_model = pipeline_settings.default_model.clone();
 
-                for (i, step) in resolved_steps.iter().enumerate() {
-                    let step_name = step.name();
+    // Execute steps in a background task (all data is owned)
+    tokio::spawn(async move {
+        let mut success = true;
+        let total = resolved_steps.len();
 
-                    // Emit progress
-                    let _ = app_handle.emit(
-                        "pipeline:step_progress",
-                        &serde_json::json!({
-                            "taskId": task_id,
-                            "columnId": column_id,
-                            "step": i + 1,
-                            "total": total,
-                            "name": step_name,
-                            "type": step.step_type(),
-                        }),
+        for (i, step) in resolved_steps.iter().enumerate() {
+            let step_name = step.name();
+
+            // Emit progress
+            let _ = app_handle.emit(
+                "pipeline:step_progress",
+                &serde_json::json!({
+                    "taskId": task_id,
+                    "columnId": column_id,
+                    "step": i + 1,
+                    "total": total,
+                    "name": step_name,
+                    "type": step.step_type(),
+                }),
+            );
+
+            match step {
+                ResolvedStep::Shell {
+                    name,
+                    is_check,
+                    command,
+                    work_dir,
+                    continue_on_error,
+                    fail_message,
+                } => {
+                    let output = tokio::process::Command::new("sh")
+                        .arg("-c")
+                        .arg(command)
+                        .current_dir(work_dir)
+                        .output()
+                        .await;
+
+                    match output {
+                        Ok(out) => {
+                            let stdout = String::from_utf8_lossy(&out.stdout);
+                            let stderr = String::from_utf8_lossy(&out.stderr);
+                            log::info!(
+                                "[script:{}] Step {}/{} '{}': exit={}, stdout={} bytes",
+                                task_id,
+                                i + 1,
+                                total,
+                                name,
+                                out.status.code().unwrap_or(-1),
+                                stdout.len()
+                            );
+                            if !stderr.is_empty() {
+                                log::warn!(
+                                    "[script:{}] stderr: {}",
+                                    task_id,
+                                    stderr.chars().take(500).collect::<String>()
+                                );
+                            }
+                            if !out.status.success() {
+                                if *is_check {
+                                    let msg = fail_message.as_deref().unwrap_or("Check failed");
+                                    log::warn!("[script:{}] Check failed: {}", task_id, msg);
+                                }
+                                if !continue_on_error {
+                                    success = false;
+                                    break;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            log::error!(
+                                "[script:{}] Failed to run step '{}': {}",
+                                task_id,
+                                name,
+                                e
+                            );
+                            if !continue_on_error {
+                                success = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+                ResolvedStep::Agent {
+                    prompt,
+                    model,
+                    command,
+                    ..
+                } => {
+                    let initial_prompt = if let Some(cmd) = command {
+                        if prompt.is_empty() {
+                            cmd.clone()
+                        } else {
+                            format!("{}\n\n{}", cmd, prompt)
+                        }
+                    } else {
+                        prompt.clone()
+                    };
+
+                    let mut cli_args = Vec::new();
+                    let resolved_model =
+                        resolve_model_override(None, model.as_deref(), default_model.as_deref());
+                    if let Some(m) = resolved_model {
+                        cli_args.push("--model".to_string());
+                        cli_args.push(m);
+                    }
+
+                    // Spawn CLI — mark_complete called by PTY exit handler
+                    bridge::spawn_cli_trigger_task(
+                        app_handle.clone(),
+                        task_id.clone(),
+                        default_agent_cli.clone(),
+                        cli_args,
+                        workspace_path.clone(),
+                        initial_prompt,
+                        Option::None,
                     );
 
-                    match step {
-                        ResolvedStep::Shell { name, is_check, command, work_dir, continue_on_error, fail_message } => {
-                            let output = tokio::process::Command::new("sh")
-                                .arg("-c")
-                                .arg(command)
-                                .current_dir(work_dir)
-                                .output()
-                                .await;
-
-                            match output {
-                                Ok(out) => {
-                                    let stdout = String::from_utf8_lossy(&out.stdout);
-                                    let stderr = String::from_utf8_lossy(&out.stderr);
-                                    log::info!(
-                                        "[script:{}] Step {}/{} '{}': exit={}, stdout={} bytes",
-                                        task_id, i + 1, total, name,
-                                        out.status.code().unwrap_or(-1),
-                                        stdout.len()
-                                    );
-                                    if !stderr.is_empty() {
-                                        log::warn!("[script:{}] stderr: {}", task_id, stderr.chars().take(500).collect::<String>());
-                                    }
-                                    if !out.status.success() {
-                                        if *is_check {
-                                            let msg = fail_message.as_deref().unwrap_or("Check failed");
-                                            log::warn!("[script:{}] Check failed: {}", task_id, msg);
-                                        }
-                                        if !continue_on_error {
-                                            success = false;
-                                            break;
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    log::error!("[script:{}] Failed to run step '{}': {}", task_id, name, e);
-                                    if !continue_on_error {
-                                        success = false;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        ResolvedStep::Agent { prompt, model, command, .. } => {
-                            let initial_prompt = if let Some(cmd) = command {
-                                if prompt.is_empty() {
-                                    cmd.clone()
-                                } else {
-                                    format!("{}\n\n{}", cmd, prompt)
-                                }
-                            } else {
-                                prompt.clone()
-                            };
-
-                            let mut cli_args = Vec::new();
-                            let resolved_model = resolve_model_override(
-                                None,
-                                model.as_deref(),
-                                default_model.as_deref(),
-                            );
-                            if let Some(m) = resolved_model {
-                                cli_args.push("--model".to_string());
-                                cli_args.push(m);
-                            }
-
-                            // Spawn CLI — mark_complete called by PTY exit handler
-                            bridge::spawn_cli_trigger_task(
-                                app_handle.clone(),
-                                task_id.clone(),
-                                default_agent_cli.clone(),
-                                cli_args,
-                                workspace_path.clone(),
-                                initial_prompt,
-                                Option::None,
-                            );
-
-                            // Agent step hands off to PTY exit handler
-                            return;
-                        }
-                    }
+                    // Agent step hands off to PTY exit handler
+                    return;
                 }
+            }
+        }
 
-                // All bash/check steps done — call mark_complete
-                let db_path = crate::db::db_path();
-                match rusqlite::Connection::open(&db_path) {
-                    Ok(conn) => {
-                        let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
-                        if let Err(e) = super::mark_complete(&conn, &app_handle, &task_id, success) {
-                            log::error!("[script:{}] mark_complete failed: {}", task_id, e);
-                        }
-                    }
-                    Err(e) => {
-                        log::error!("[script:{}] Failed to open DB for mark_complete: {} — task stuck in running state", task_id, e);
-                    }
+        // All bash/check steps done — call mark_complete
+        let db_path = crate::db::db_path();
+        match rusqlite::Connection::open(&db_path) {
+            Ok(conn) => {
+                let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
+                if let Err(e) = super::mark_complete(&conn, &app_handle, &task_id, success) {
+                    log::error!("[script:{}] mark_complete failed: {}", task_id, e);
                 }
-            });
+            }
+            Err(e) => {
+                log::error!("[script:{}] Failed to open DB for mark_complete: {} — task stuck in running state", task_id, e);
+            }
+        }
+    });
 
-            Ok(updated_task)
+    Ok(updated_task)
 }
 
 // Note: dependency task interpolation ({dep.<id>.title}) is handled at the
@@ -1113,7 +1338,11 @@ pub fn resolve_column_target(
     let current_col = db::get_column(conn, &task.column_id)?;
 
     match target {
-        "next" => Ok(db::get_next_column(conn, &task.workspace_id, current_col.position)?),
+        "next" => Ok(db::get_next_column(
+            conn,
+            &task.workspace_id,
+            current_col.position,
+        )?),
         "previous" => {
             if current_col.position > 0 {
                 let cols = db::list_columns(conn, &task.workspace_id)?;
@@ -1135,7 +1364,13 @@ mod tests {
     use super::*;
     use crate::db;
 
-    fn setup() -> (rusqlite::Connection, db::Workspace, db::Column, db::Column, db::Column) {
+    fn setup() -> (
+        rusqlite::Connection,
+        db::Workspace,
+        db::Column,
+        db::Column,
+        db::Column,
+    ) {
         let conn = db::init_test().unwrap();
         let ws = db::insert_workspace(&conn, "Test", "/tmp/test").unwrap();
         let col1 = db::insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
@@ -1226,7 +1461,8 @@ mod tests {
         conn.execute(
             "UPDATE tasks SET trigger_overrides = ?1 WHERE id = ?2",
             rusqlite::params![r#"{"skip_triggers": true}"#, task.id],
-        ).unwrap();
+        )
+        .unwrap();
         let task = db::get_task(&conn, &task.id).unwrap();
 
         let triggers = ColumnTriggersV2 {
@@ -1244,7 +1480,10 @@ mod tests {
         };
 
         let result = resolve_trigger(&triggers, &task, "on_entry");
-        assert!(result.is_none(), "skip_triggers should suppress the trigger");
+        assert!(
+            result.is_none(),
+            "skip_triggers should suppress the trigger"
+        );
     }
 
     #[test]
@@ -1256,7 +1495,8 @@ mod tests {
         conn.execute(
             "UPDATE tasks SET trigger_overrides = ?1 WHERE id = ?2",
             rusqlite::params![r#"{"on_entry": {"model": "opus"}}"#, task.id],
-        ).unwrap();
+        )
+        .unwrap();
         let task = db::get_task(&conn, &task.id).unwrap();
 
         let triggers = ColumnTriggersV2 {
@@ -1277,7 +1517,11 @@ mod tests {
         assert!(result.is_some());
         if let Some(TriggerActionV2::SpawnCli { model, command, .. }) = result {
             assert_eq!(model.as_deref(), Some("opus"), "task override should win");
-            assert_eq!(command.as_deref(), Some("/start-task"), "base command preserved");
+            assert_eq!(
+                command.as_deref(),
+                Some("/start-task"),
+                "base command preserved"
+            );
         } else {
             panic!("Expected SpawnCli");
         }
@@ -1290,8 +1534,13 @@ mod tests {
 
         let triggers = ColumnTriggersV2 {
             on_entry: Some(TriggerActionV2::SpawnCli {
-                cli: None, command: None, prompt_template: None,
-                prompt: None, flags: None, use_queue: None, model: None,
+                cli: None,
+                command: None,
+                prompt_template: None,
+                prompt: None,
+                flags: None,
+                use_queue: None,
+                model: None,
             }),
             on_exit: Some(TriggerActionV2::MoveColumn {
                 target: "next".to_string(),
@@ -1455,8 +1704,14 @@ mod tests {
         }"#;
 
         let triggers: ColumnTriggersV2 = serde_json::from_str(json).unwrap();
-        assert!(matches!(triggers.on_entry, Some(TriggerActionV2::RunScript { .. })));
-        assert!(matches!(triggers.on_exit, Some(TriggerActionV2::MoveColumn { .. })));
+        assert!(matches!(
+            triggers.on_entry,
+            Some(TriggerActionV2::RunScript { .. })
+        ));
+        assert!(matches!(
+            triggers.on_exit,
+            Some(TriggerActionV2::MoveColumn { .. })
+        ));
         assert!(triggers.exit_criteria.is_some());
         let exit = triggers.exit_criteria.unwrap();
         assert_eq!(exit.criteria_type, ExitCriteriaTypeV2::AgentComplete);
@@ -1476,7 +1731,10 @@ mod tests {
                 ..
             })
         ));
-        assert!(matches!(triggers.on_exit, Some(TriggerActionV2::SpawnCli { .. })));
+        assert!(matches!(
+            triggers.on_exit,
+            Some(TriggerActionV2::SpawnCli { .. })
+        ));
         assert_eq!(
             triggers.exit_criteria.unwrap().criteria_type,
             ExitCriteriaTypeV2::AgentComplete
@@ -1494,7 +1752,10 @@ mod tests {
         let step_type = step_json.get("type").and_then(|v| v.as_str()).unwrap();
         let step_name = step_json.get("name").and_then(|v| v.as_str()).unwrap();
         let command = step_json.get("command").and_then(|v| v.as_str()).unwrap();
-        let continue_on_error = step_json.get("continueOnError").and_then(|v| v.as_bool()).unwrap_or(false);
+        let continue_on_error = step_json
+            .get("continueOnError")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         assert_eq!(step_type, "bash");
         assert_eq!(step_name, "Build");
@@ -1535,13 +1796,20 @@ mod tests {
     #[test]
     fn test_resolved_step_defaults() {
         // Step with minimal fields — should use defaults
-        let step_json: serde_json::Value = serde_json::from_str(
-            r#"{"type": "bash"}"#
-        ).unwrap();
+        let step_json: serde_json::Value = serde_json::from_str(r#"{"type": "bash"}"#).unwrap();
 
-        let command = step_json.get("command").and_then(|v| v.as_str()).unwrap_or("");
-        let name = step_json.get("name").and_then(|v| v.as_str()).unwrap_or("Step");
-        let continue_on_error = step_json.get("continueOnError").and_then(|v| v.as_bool()).unwrap_or(false);
+        let command = step_json
+            .get("command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let name = step_json
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Step");
+        let continue_on_error = step_json
+            .get("continueOnError")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         assert_eq!(command, "");
         assert_eq!(name, "Step");
@@ -1561,14 +1829,15 @@ mod tests {
 
         for steps_json in built_in_steps {
             let parsed: Vec<serde_json::Value> = serde_json::from_str(steps_json)
-                .expect(&format!("Failed to parse: {}", steps_json));
+                .unwrap_or_else(|_| panic!("Failed to parse: {}", steps_json));
             assert!(!parsed.is_empty());
             for step in &parsed {
                 let step_type = step.get("type").and_then(|v| v.as_str());
                 assert!(step_type.is_some(), "Step missing type field");
                 assert!(
                     matches!(step_type.unwrap(), "bash" | "agent" | "check"),
-                    "Invalid step type: {:?}", step_type
+                    "Invalid step type: {:?}",
+                    step_type
                 );
             }
         }
@@ -1579,9 +1848,11 @@ mod tests {
     #[test]
     fn test_exit_criteria_type_extraction() {
         // Mimics the JSON parsing in evaluate_exit_criteria
-        let triggers_json = r#"{"exit_criteria": {"type": "agent_complete", "auto_advance": true}}"#;
+        let triggers_json =
+            r#"{"exit_criteria": {"type": "agent_complete", "auto_advance": true}}"#;
         let parsed: serde_json::Value = serde_json::from_str(triggers_json).unwrap();
-        let exit_type = parsed.get("exit_criteria")
+        let exit_type = parsed
+            .get("exit_criteria")
             .and_then(|v| v.get("type"))
             .and_then(|v| v.as_str())
             .unwrap_or("manual");
@@ -1592,7 +1863,8 @@ mod tests {
     fn test_exit_criteria_missing_defaults_to_manual() {
         let triggers_json = r#"{}"#;
         let parsed: serde_json::Value = serde_json::from_str(triggers_json).unwrap();
-        let exit_type = parsed.get("exit_criteria")
+        let exit_type = parsed
+            .get("exit_criteria")
             .and_then(|v| v.get("type"))
             .and_then(|v| v.as_str())
             .unwrap_or("manual");
@@ -1603,7 +1875,8 @@ mod tests {
     fn test_max_retries_extraction() {
         let triggers_json = r#"{"exit_criteria": {"type": "agent_complete", "max_retries": 3}}"#;
         let parsed: serde_json::Value = serde_json::from_str(triggers_json).unwrap();
-        let max_retries = parsed.get("exit_criteria")
+        let max_retries = parsed
+            .get("exit_criteria")
             .and_then(|v| v.get("max_retries"))
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
@@ -1612,9 +1885,11 @@ mod tests {
 
     #[test]
     fn test_auto_advance_extraction() {
-        let triggers_json = r#"{"exit_criteria": {"type": "script_success", "auto_advance": true}}"#;
+        let triggers_json =
+            r#"{"exit_criteria": {"type": "script_success", "auto_advance": true}}"#;
         let parsed: serde_json::Value = serde_json::from_str(triggers_json).unwrap();
-        let auto_advance = parsed.get("exit_criteria")
+        let auto_advance = parsed
+            .get("exit_criteria")
             .and_then(|v| v.get("auto_advance"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
@@ -1625,7 +1900,8 @@ mod tests {
     fn test_timeout_extraction() {
         let triggers_json = r#"{"exit_criteria": {"type": "time_elapsed", "timeout": 600}}"#;
         let parsed: serde_json::Value = serde_json::from_str(triggers_json).unwrap();
-        let timeout = parsed.get("exit_criteria")
+        let timeout = parsed
+            .get("exit_criteria")
             .and_then(|v| v.get("timeout"))
             .and_then(|v| v.as_u64())
             .unwrap_or(300);

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -4,6 +4,7 @@
 //! supporting spawn_cli, move_column, trigger_task actions.
 
 use crate::chat::bridge;
+use crate::config::{self, EffectivePipelineSettings};
 use crate::db::{self, Column, Task, Workspace};
 use crate::error::AppError;
 use crate::git::branch_manager;
@@ -326,6 +327,27 @@ fn resolve_working_dir(task: &Task, workspace_repo_path: &str) -> String {
     workspace_repo_path.to_string()
 }
 
+fn resolve_model_override(
+    task_model: Option<&str>,
+    trigger_model: Option<&str>,
+    default_model: Option<&str>,
+) -> Option<String> {
+    task_model
+        .and_then(non_empty_trimmed)
+        .or_else(|| trigger_model.and_then(non_empty_trimmed))
+        .or_else(|| default_model.and_then(non_empty_trimmed))
+        .map(ToString::to_string)
+}
+
+fn non_empty_trimmed(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
 /// Auto-create a branch + worktree for a task if missing.
 /// Returns the updated task with `branch_name` and `worktree_path` set.
 fn ensure_task_worktree(
@@ -333,20 +355,26 @@ fn ensure_task_worktree(
     app: &AppHandle,
     task: &Task,
     repo_path: &str,
+    settings: &EffectivePipelineSettings,
 ) -> Result<Task, AppError> {
     let mut task = task.clone();
 
     // Step 1: Ensure task has a branch
     if task.branch_name.as_deref().unwrap_or("").is_empty() {
         let slug = branch_manager::slugify(&task.title);
-        match branch_manager::create_task_branch(repo_path, &slug, None) {
+        match branch_manager::create_task_branch_with_prefix(
+            repo_path,
+            &slug,
+            None,
+            &settings.branch_prefix,
+        ) {
             Ok(branch_name) => {
                 task = db::update_task_branch(conn, &task.id, Some(&branch_name))?;
                 log::info!("[triggers] Auto-created branch '{}' for task {}", branch_name, task.id);
             }
             Err(e) => {
                 // Branch may already exist (e.g. from a previous attempt)
-                let branch_name = format!("bentoya/{}", slug);
+                let branch_name = format!("{}{}", settings.branch_prefix, slug);
                 log::warn!("[triggers] Branch creation failed ({}), trying existing '{}'", e, branch_name);
                 task = db::update_task_branch(conn, &task.id, Some(&branch_name))?;
             }
@@ -378,7 +406,7 @@ fn ensure_task_worktree(
 // ─── Per-Action Handlers ──────────────────────────────────────────────────
 
 /// Default max concurrent agents per workspace (when not configured in workspace settings).
-pub const DEFAULT_MAX_CONCURRENT_AGENTS: i64 = 3;
+pub const DEFAULT_MAX_CONCURRENT_AGENTS: i64 = config::DEFAULT_PIPELINE_MAX_CONCURRENT_AGENTS;
 
 fn execute_spawn_cli(
     conn: &Connection,
@@ -394,11 +422,12 @@ fn execute_spawn_cli(
     model: Option<&str>,
 ) -> Result<Task, AppError> {
     let workspace = db::get_workspace(conn, &task.workspace_id)?;
+    let pipeline_settings = config::effective_pipeline_settings(&workspace.config);
 
     // ── Concurrency guard ──────────────────────────────────────────────
     // Check how many agents are already running in this workspace.
     // If at or above the limit, mark this task as queued instead of spawning.
-    let max_concurrent = DEFAULT_MAX_CONCURRENT_AGENTS;
+    let max_concurrent = pipeline_settings.max_concurrent_agents;
     let running_count = db::get_running_agent_count(conn, &task.workspace_id).unwrap_or(0);
 
     if running_count >= max_concurrent {
@@ -425,8 +454,8 @@ fn execute_spawn_cli(
             log::warn!("[triggers] Worktree path set but directory missing for task {} — recreating", task.id);
             let _ = db::update_task_worktree_path(conn, &task.id, None);
         }
-        let mut fresh_task = db::get_task(conn, &task.id)?;
-        ensure_task_worktree(conn, app, &fresh_task, &workspace.repo_path)?
+        let fresh_task = db::get_task(conn, &task.id)?;
+        ensure_task_worktree(conn, app, &fresh_task, &workspace.repo_path, &pipeline_settings)?
     } else {
         task.clone()
     };
@@ -486,24 +515,11 @@ fn execute_spawn_cli(
         format!("{}\n\nSee .task.md for full spec.", task.title)
     };
 
-    // Resolve CLI and model from workspace config (both use the same parsed value)
-    let workspace_config: serde_json::Value = serde_json::from_str(&workspace.config).unwrap_or_default();
-
-    // Resolve CLI: trigger config > workspace default > "claude"
-    let ws_default_cli = workspace_config.get("defaultAgentCli").and_then(|v| v.as_str()).filter(|s| !s.is_empty());
-    let cli_type = cli.or(ws_default_cli).unwrap_or("claude").to_string();
-
-    // Resolve model: task override > trigger config > workspace default > none
-    let ws_default_model = workspace_config.get("defaultModel").and_then(|v| v.as_str()).filter(|s| !s.is_empty());
-    let resolved_model = task.model.as_deref().or(model).or(ws_default_model).map(|m| m.to_string());
     // Resolve CLI: trigger config > workspace config > global settings
-    let cli_type = cli.map(|c| c.to_string()).unwrap_or_else(|| {
-        let settings = crate::config::AppSettings::load();
-        settings.resolve_with_workspace(
-            Some(&workspace.config),
-            "default_agent_cli",
-        ).unwrap_or_else(|| settings.default_agent_cli.clone())
-    });
+    let cli_type = cli
+        .filter(|c| !c.trim().is_empty())
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| pipeline_settings.default_agent_cli.clone());
 
     // Prepend slash command if provided
     let initial_prompt = match command {
@@ -539,12 +555,11 @@ fn execute_spawn_cli(
     emit_pipeline(app, EVT_RUNNING, &task.id, &column.id, PipelineState::Running, Some(format!("CLI trigger: {}", cli_type)));
 
     // Resolve model: task override > trigger config > workspace config > global settings
-    let resolved_model = task.model.as_deref().or(model).map(|m| m.to_string()).or_else(|| {
-        let settings = crate::config::AppSettings::load();
-        let m = settings.resolve_with_workspace(Some(&workspace.config), "default_model")
-            .unwrap_or_else(|| settings.default_model.clone());
-        if m.is_empty() { None } else { Some(m) }
-    });
+    let resolved_model = resolve_model_override(
+        task.model.as_deref(),
+        model,
+        pipeline_settings.default_model.as_deref(),
+    );
     let mut cli_args = Vec::new();
     if let Some(ref m) = resolved_model {
         cli_args.push("--model".to_string());
@@ -873,6 +888,7 @@ fn execute_run_script(
             let script = db::get_script(conn, script_id)
                 .map_err(|_| AppError::NotFound(format!("Script '{}' not found", script_id)))?;
             let workspace = db::get_workspace(conn, &task.workspace_id)?;
+            let pipeline_settings = config::effective_pipeline_settings(&workspace.config);
             let working_dir = resolve_working_dir(task, &workspace.repo_path);
 
             // Validate working dir exists
@@ -962,6 +978,8 @@ fn execute_run_script(
             let app_handle = app.clone();
             let column_id = column.id.clone();
             let workspace_path = working_dir.clone();
+            let default_agent_cli = pipeline_settings.default_agent_cli.clone();
+            let default_model = pipeline_settings.default_model.clone();
 
             // Execute steps in a background task (all data is owned)
             tokio::spawn(async move {
@@ -1038,16 +1056,21 @@ fn execute_run_script(
                             };
 
                             let mut cli_args = Vec::new();
-                            if let Some(m) = model {
+                            let resolved_model = resolve_model_override(
+                                None,
+                                model.as_deref(),
+                                default_model.as_deref(),
+                            );
+                            if let Some(m) = resolved_model {
                                 cli_args.push("--model".to_string());
-                                cli_args.push(m.clone());
+                                cli_args.push(m);
                             }
 
                             // Spawn CLI — mark_complete called by PTY exit handler
                             bridge::spawn_cli_trigger_task(
                                 app_handle.clone(),
                                 task_id.clone(),
-                                "claude".to_string(),
+                                default_agent_cli.clone(),
                                 cli_args,
                                 workspace_path.clone(),
                                 initial_prompt,
@@ -1119,6 +1142,23 @@ mod tests {
         let col2 = db::insert_column(&conn, &ws.id, "Working", 1).unwrap();
         let col3 = db::insert_column(&conn, &ws.id, "Done", 2).unwrap();
         (conn, ws, col1, col2, col3)
+    }
+
+    #[test]
+    fn test_resolve_model_override_precedence_skips_blank_values() {
+        assert_eq!(
+            resolve_model_override(Some("  "), Some("sonnet"), Some("haiku")).as_deref(),
+            Some("sonnet")
+        );
+        assert_eq!(
+            resolve_model_override(Some("opus"), Some("sonnet"), Some("haiku")).as_deref(),
+            Some("opus")
+        );
+        assert_eq!(
+            resolve_model_override(None, Some("  "), Some("haiku")).as_deref(),
+            Some("haiku")
+        );
+        assert_eq!(resolve_model_override(None, Some(""), Some("  ")), None);
     }
 
     // ─── resolve_trigger tests ────────────────────────────────────────
@@ -1309,7 +1349,7 @@ mod tests {
 
     #[test]
     fn test_resolve_column_target_next() {
-        let (conn, ws, _, col2, col3) = setup();
+        let (conn, ws, _, col2, _) = setup();
         let task = db::insert_task(&conn, &ws.id, &col2.id, "Task", None).unwrap();
 
         let result = resolve_column_target(&conn, &task, "next").unwrap();
@@ -1319,7 +1359,7 @@ mod tests {
 
     #[test]
     fn test_resolve_column_target_previous() {
-        let (conn, ws, col1, col2, _) = setup();
+        let (conn, ws, _, col2, _) = setup();
         let task = db::insert_task(&conn, &ws.id, &col2.id, "Task", None).unwrap();
 
         let result = resolve_column_target(&conn, &task, "previous").unwrap();

--- a/src/components/kanban/task-card.test.tsx
+++ b/src/components/kanban/task-card.test.tsx
@@ -73,7 +73,7 @@ describe('TaskCard quick-action keyboard behavior', () => {
     expect(screen.queryByTitle(/Click again to confirm/)).not.toBeInTheDocument()
   })
 
-  it('keyboard Space toggles the agent only when the current column can trigger work', () => {
+  it('keyboard Space starts the agent only when the current column can trigger work', () => {
     const task = mockKanbanTask()
     resetStores(task)
     const { rerender } = render(<TaskCard task={task} />)
@@ -93,6 +93,21 @@ describe('TaskCard quick-action keyboard behavior', () => {
 
     fireEvent.keyDown(screen.getByText('Triggerless task'), { key: ' ' })
     expect(useTaskStore.getState().tasks[0]?.agentStatus).toBe('idle')
+  })
+
+  it('keyboard Space can stop a running agent even when the current column has no trigger', () => {
+    const task = mockKanbanTask({ agentStatus: 'running' })
+    useColumnStore.setState({
+      columns: [mockKanbanColumn({ triggers: { on_entry: { type: 'none' }, on_exit: { type: 'none' } } })],
+      loaded: true,
+    })
+    useTaskStore.setState({ tasks: [task], loaded: true })
+    useUIStore.setState({ viewMode: 'board', activeTaskId: null, modal: null })
+
+    render(<TaskCard task={task} />)
+
+    fireEvent.keyDown(screen.getByText('Test task'), { key: ' ' })
+    expect(useTaskStore.getState().tasks[0]?.agentStatus).toBe('stopped')
   })
 
   it('keyboard ArrowRight moves to the next visible column', async () => {

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -38,23 +38,16 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const [settingsTab, setSettingsTab] = useState<'triggers' | 'dependencies'>('triggers')
   const columns = useColumnStore((s) => s.columns)
 
-  const currentColumn = useMemo(() => {
-    return columns.find(c => c.id === task.columnId) ?? null
+  // Get exit criteria type for this task's column
+  const currentColumnTriggers = useMemo(() => {
+    const col = columns.find(c => c.id === task.columnId)
+    if (!col) return null
+    return getColumnTriggers(col)
   }, [columns, task.columnId])
 
-  // Get exit criteria type for this task's column
-  const columnTriggers = useMemo(() => {
-    if (!currentColumn) return null
-    const triggers = getColumnTriggers(currentColumn)
-    return triggers.exit_criteria ?? null
-  }, [currentColumn])
-
-  const canTriggerWork = useMemo(() => {
-    if (!currentColumn) return false
-    return getColumnTriggers(currentColumn).on_entry?.type !== 'none'
-  }, [currentColumn])
-
-  const isQualityGate = columnTriggers?.type === 'manual_approval'
+  const columnExitCriteria = currentColumnTriggers?.exit_criteria ?? null
+  const isQualityGate = columnExitCriteria?.type === 'manual_approval'
+  const canTriggerWork = !!currentColumnTriggers?.on_entry && currentColumnTriggers.on_entry.type !== 'none'
   const reviewStatus = task.reviewStatus
 
   // Check if task is in the last column (Done) for visual dimming
@@ -202,37 +195,26 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const handleRetry = useCallback(() => { void actions.handleRetryPipeline() }, [actions])
 
   const [deleteConfirmPending, setDeleteConfirmPending] = useState(false)
-  const deleteConfirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     setDeleteConfirmPending(false)
   }, [task.id])
 
-  useEffect(() => {
-    return () => {
-      if (deleteConfirmTimeoutRef.current) {
-        clearTimeout(deleteConfirmTimeoutRef.current)
-      }
-    }
-  }, [])
-
   const handleDeleteWithConfirm = useCallback(() => {
-    if (deleteConfirmTimeoutRef.current) {
-      clearTimeout(deleteConfirmTimeoutRef.current)
-      deleteConfirmTimeoutRef.current = null
-    }
-
     if (deleteConfirmPending) {
       actions.handleDeleteTask()
       setDeleteConfirmPending(false)
     } else {
       setDeleteConfirmPending(true)
-      deleteConfirmTimeoutRef.current = setTimeout(() => {
-        setDeleteConfirmPending(false)
-        deleteConfirmTimeoutRef.current = null
-      }, 2000)
+      setTimeout(() => { setDeleteConfirmPending(false) }, 2000)
     }
   }, [deleteConfirmPending, actions])
+
+  const handleToggleAgent = useCallback(() => {
+    if (task.agentStatus === 'running' || canTriggerWork) {
+      actions.handleToggleAgent()
+    }
+  }, [task.agentStatus, canTriggerWork, actions])
 
   const needsAttention = hasAttention || task.agentStatus === 'needs_attention'
   const isPipelineActive = task.pipelineState !== 'idle'
@@ -282,15 +264,8 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
       onKeyDown={(e) => {
         if (e.metaKey || e.ctrlKey || e.altKey) return
         // Don't intercept keyboard shortcuts when user is typing in an input
-        const target = e.target as HTMLElement
-        const tag = target.tagName
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return
-        if (
-          target !== e.currentTarget &&
-          target.closest('button, a, select, [role="button"], [contenteditable="true"]')
-        ) {
-          return
-        }
+        const tag = (e.target as HTMLElement).tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable) return
         switch (e.key) {
           case 'Enter':
             e.preventDefault()
@@ -298,9 +273,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
             break
           case ' ':
             e.preventDefault()
-            if (canTriggerWork) {
-              actions.handleToggleAgent()
-            }
+            handleToggleAgent()
             break
           case 'r':
           case 'R':
@@ -359,9 +332,9 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
         <TaskQuickActions
           task={task}
           hasNextColumn={!!nextColumnId}
-          deleteConfirmPending={deleteConfirmPending}
+          confirmDelete={deleteConfirmPending}
           onOpen={handleClick}
-          onToggleAgent={actions.handleToggleAgent}
+          onToggleAgent={handleToggleAgent}
           onRetry={handleRetry}
           onMoveNext={handleMoveNext}
           onDelete={handleDeleteWithConfirm}

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -195,20 +195,36 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const handleRetry = useCallback(() => { void actions.handleRetryPipeline() }, [actions])
 
   const [deleteConfirmPending, setDeleteConfirmPending] = useState(false)
+  const deleteConfirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearDeleteConfirmTimeout = useCallback(() => {
+    if (deleteConfirmTimeoutRef.current) {
+      clearTimeout(deleteConfirmTimeoutRef.current)
+      deleteConfirmTimeoutRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
+    clearDeleteConfirmTimeout()
     setDeleteConfirmPending(false)
-  }, [task.id])
+  }, [clearDeleteConfirmTimeout, task.id])
+
+  useEffect(() => clearDeleteConfirmTimeout, [clearDeleteConfirmTimeout])
 
   const handleDeleteWithConfirm = useCallback(() => {
     if (deleteConfirmPending) {
+      clearDeleteConfirmTimeout()
       actions.handleDeleteTask()
       setDeleteConfirmPending(false)
     } else {
+      clearDeleteConfirmTimeout()
       setDeleteConfirmPending(true)
-      setTimeout(() => { setDeleteConfirmPending(false) }, 2000)
+      deleteConfirmTimeoutRef.current = setTimeout(() => {
+        deleteConfirmTimeoutRef.current = null
+        setDeleteConfirmPending(false)
+      }, 2000)
     }
-  }, [deleteConfirmPending, actions])
+  }, [clearDeleteConfirmTimeout, deleteConfirmPending, actions])
 
   const handleToggleAgent = useCallback(() => {
     if (task.agentStatus === 'running' || canTriggerWork) {

--- a/src/components/kanban/task-quick-actions.tsx
+++ b/src/components/kanban/task-quick-actions.tsx
@@ -1,64 +1,70 @@
-import { memo, useState, useCallback } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import type { Task } from '@/types'
 
 const CONFIRM_TIMEOUT_MS = 2000
 
-type DeleteConfirmationProps =
-  | {
-      deleteConfirmPending: boolean
-      onDeleteConfirmPendingChange: (pending: boolean) => void
-    }
-  | {
-      deleteConfirmPending?: undefined
-      onDeleteConfirmPendingChange?: undefined
-    }
-
 type TaskQuickActionsProps = {
   task: Task
   hasNextColumn: boolean
+  confirmDelete?: boolean
   onOpen: () => void
   onToggleAgent: () => void
   onRetry: () => void
   onMoveNext: () => void
   onDelete: () => void
   onShowMenu: (e: React.MouseEvent) => void
-} & DeleteConfirmationProps
+}
 
 export const TaskQuickActions = memo(function TaskQuickActions({
   task,
   hasNextColumn,
+  confirmDelete,
   onOpen,
   onToggleAgent,
   onRetry,
   onMoveNext,
   onDelete,
   onShowMenu,
-  deleteConfirmPending,
-  onDeleteConfirmPendingChange,
 }: TaskQuickActionsProps) {
   const isRunning = task.agentStatus === 'running'
   const hasError = !!task.pipelineError
-
   const [internalConfirmDelete, setInternalConfirmDelete] = useState(false)
-  const confirmDelete = deleteConfirmPending ?? internalConfirmDelete
-  const setConfirmDelete = onDeleteConfirmPendingChange ?? setInternalConfirmDelete
+  const internalConfirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isConfirmingDelete = confirmDelete ?? internalConfirmDelete
+
+  const clearInternalConfirmTimeout = useCallback(() => {
+    if (internalConfirmTimeoutRef.current) {
+      clearTimeout(internalConfirmTimeoutRef.current)
+      internalConfirmTimeoutRef.current = null
+    }
+  }, [])
+
+  useEffect(() => clearInternalConfirmTimeout, [clearInternalConfirmTimeout])
 
   const handleDelete = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
-    if (confirmDelete) {
+    if (confirmDelete !== undefined) {
       onDelete()
-      setConfirmDelete(false)
-    } else {
-      setConfirmDelete(true)
-      // Auto-dismiss after 2s
-      setTimeout(() => { setConfirmDelete(false) }, CONFIRM_TIMEOUT_MS)
+      return
     }
-  }, [confirmDelete, onDelete, setConfirmDelete])
-
+    if (internalConfirmDelete) {
+      clearInternalConfirmTimeout()
+      onDelete()
+      setInternalConfirmDelete(false)
+      return
+    }
+    clearInternalConfirmTimeout()
+    setInternalConfirmDelete(true)
+    internalConfirmTimeoutRef.current = setTimeout(() => {
+      internalConfirmTimeoutRef.current = null
+      setInternalConfirmDelete(false)
+    }, CONFIRM_TIMEOUT_MS)
+  }, [clearInternalConfirmTimeout, confirmDelete, internalConfirmDelete, onDelete])
   return (
     <div
       className="absolute right-1 top-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10"
       onClick={(e) => { e.stopPropagation(); }}
+      onKeyDown={(e) => { e.stopPropagation(); }}
     >
       {/* Open in panel */}
       <button
@@ -123,11 +129,11 @@ export const TaskQuickActions = memo(function TaskQuickActions({
       <button
         onClick={handleDelete}
         className={`flex h-6 w-6 items-center justify-center rounded transition-colors ${
-          confirmDelete
+          isConfirmingDelete
             ? 'text-error bg-error/20'
             : 'text-text-secondary hover:bg-error/20 hover:text-error'
         }`}
-        title={confirmDelete ? 'Click again to confirm' : 'Delete task (Del)'}
+        title={isConfirmingDelete ? 'Click again to confirm' : 'Delete task (Del)'}
       >
         <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
           <path fillRule="evenodd" d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM7.5 3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25V4.1a40.3 40.3 0 0 0-5 0v-.35ZM9 7.75a.75.75 0 0 0-1.5 0v6.5a.75.75 0 0 0 1.5 0v-6.5Zm3.25-.75a.75.75 0 0 1 .75.75v6.5a.75.75 0 0 1-1.5 0v-6.5a.75.75 0 0 1 .75-.75Z" clipRule="evenodd" />

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
-import type { Column, ColumnTriggers } from '@/types'
+import type { Column } from '@/types'
+import { parseColumnTriggers } from '@/types/column'
 import * as ipc from '@/lib/ipc'
-import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useWorkspaceStore } from './workspace-store'
 
 type ColumnUpdates = {
   name?: string
@@ -30,12 +31,6 @@ type ColumnState = {
   updateColumnAsync: (id: string, updates: ColumnUpdates) => Promise<void>
 }
 
-async function refreshWorkspace(workspaceId: string | undefined) {
-  if (workspaceId) {
-    await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
-  }
-}
-
 export const useColumnStore = create<ColumnState>()(
   devtools(
     (set, get) => ({
@@ -51,17 +46,19 @@ export const useColumnStore = create<ColumnState>()(
         const position = get().columns.length
         const column = await ipc.createColumn(workspaceId, name, position)
         set((s) => ({ columns: [...s.columns, column] }))
-        await refreshWorkspace(workspaceId)
+        await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
         return column
       },
 
       remove: async (id) => {
         const prev = get().columns
+        const removedColumn = prev.find((c) => c.id === id)
         set((s) => ({ columns: s.columns.filter((c) => c.id !== id) }))
         try {
           await ipc.deleteColumn(id)
-          const workspaceId = prev.find((column) => column.id === id)?.workspaceId
-          await refreshWorkspace(workspaceId)
+          if (removedColumn) {
+            await useWorkspaceStore.getState().refreshWorkspace(removedColumn.workspaceId)
+          }
         } catch {
           set({ columns: prev })
         }
@@ -79,7 +76,7 @@ export const useColumnStore = create<ColumnState>()(
         }))
         try {
           await ipc.reorderColumns(workspaceId, ids)
-          await refreshWorkspace(workspaceId)
+          await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
         } catch {
           set({ columns: prev })
         }
@@ -93,15 +90,6 @@ export const useColumnStore = create<ColumnState>()(
 
       updateColumnAsync: async (id, updates) => {
         const prev = get().columns
-        let parsedTriggers: ColumnTriggers | undefined
-        if (updates.triggers !== undefined) {
-          try {
-            parsedTriggers = JSON.parse(updates.triggers) as ColumnTriggers
-          } catch {
-            parsedTriggers = undefined
-          }
-        }
-
         // Optimistically update
         set((s) => ({
           columns: s.columns.map((c) =>
@@ -112,7 +100,9 @@ export const useColumnStore = create<ColumnState>()(
                   ...(updates.icon !== undefined && { icon: updates.icon }),
                   ...(updates.color !== undefined && { color: updates.color ?? '' }),
                   ...(updates.visible !== undefined && { visible: updates.visible }),
-                  ...(parsedTriggers !== undefined && { triggers: parsedTriggers }),
+                  ...(updates.triggers !== undefined && {
+                    triggers: parseTriggerUpdate(updates.triggers, c.triggers),
+                  }),
                 }
               : c
           ),
@@ -130,3 +120,10 @@ export const useColumnStore = create<ColumnState>()(
     { name: 'column-store' },
   ),
 )
+
+function parseTriggerUpdate(
+  triggers: string,
+  fallback: Column['triggers'],
+): Column['triggers'] {
+  return parseColumnTriggers(triggers) ?? fallback
+}

--- a/src/types/column.ts
+++ b/src/types/column.ts
@@ -132,7 +132,7 @@ export const DEFAULT_SPAWN_CLI: SpawnCliAction = {
   use_queue: true,
 }
 
-export function parseColumnTriggers(triggers: Column['triggers']): ColumnTriggers | null {
+export function parseColumnTriggers(triggers: Column['triggers'] | string): ColumnTriggers | null {
   if (!triggers) return null
 
   if (typeof triggers === 'string') {


### PR DESCRIPTION
## Description

Wire workspace config (default model, CLI, branch prefix, max concurrent) to actually be enforced by the pipeline at runtime.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/enforce-workspace-settings-in-pipeline` → `main`

## Commits

```
4c82eff Polish pipeline settings changes
40076e1 Fix pipeline settings edge cases
714732a Enforce workspace pipeline settings
```

## Changes

```
src-tauri/src/chat/bridge.rs                 | 254 +++++---
 src-tauri/src/chat/gc.rs                     |  60 +-
 src-tauri/src/commands/agent.rs              | 138 ++--
 src-tauri/src/commands/column.rs             |  61 +-
 src-tauri/src/commands/history.rs            |  85 ++-
 src-tauri/src/commands/task.rs               | 421 ++++++++----
 src-tauri/src/config/mod.rs                  | 198 +++++-
 src-tauri/src/db/usage.rs                    |  36 +-
 src-tauri/src/git/branch_manager.rs          | 115 +++-
 src-tauri/src/models/metadata.rs             | 335 +++++-----
 src-tauri/src/pipeline/mod.rs                | 294 +++++++--
 src-tauri/src/pipeline/triggers.rs           | 930 ++++++++++++++++++---------
 src/components/kanban/task-card.test.tsx     |  17 +-
 src/components/kanban/task-card.tsx          |  46 +-
 src/components/kanban/task-quick-actions.tsx |  44 +-
 src/hooks/chat-session/use-chat-session.ts   |  21 +-
 src/stores/column-store.ts                   |  19 +-
 src/stores/task-store.ts                     |  10 +
 src/types/column.ts                          |   2 +-
 19 files changed, 2174 insertions(+), 912 deletions(-)
```