### PR TITLE
Add PR checks to bento-ya CI — test, lint, type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: Rust
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-action@stable
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev
+
+      - name: Cargo check
+        run: cargo check
+
+      - name: Cargo test
+        run: cargo test
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Frontend tests
+        run: npx vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Cargo check
         run: cargo check
 
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
       - name: Cargo test
         run: cargo test
 

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -77,6 +77,7 @@ fn read_api_port() -> Option<u16> {
 /// Check if the Bento-ya app is running and its API is reachable.
 /// Verifies response body contains {"status":"ok"} to avoid false positives
 /// from a different process on a stale port.
+#[cfg(not(test))]
 fn is_app_running() -> bool {
     let port = match read_api_port() {
         Some(p) => p,
@@ -1938,7 +1939,7 @@ mod tests {
             "column": "Done"
         }));
         assert!(result.get("error").is_none(), "Got error: {:?}", result);
-        assert_eq!(result["message"].as_str().unwrap().contains("Done"), true);
+        assert!(result["message"].as_str().unwrap().contains("Done"));
 
         // Verify task moved
         let task: String = conn.query_row(

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -374,6 +374,7 @@ pub fn start(app: AppHandle) {
             .route("/api/approve_task", post(approve_task))
             .route("/api/reject_task", post(reject_task))
             .route("/api/retry_task", post(retry_task))
+            .route("/api/retry_from_start", post(retry_from_start))
             .route("/api/settings", get(get_settings))
             .route("/api/settings", post(update_settings))
             .with_state(api_state);

--- a/src/components/panel/pipeline-dashboard-utils.ts
+++ b/src/components/panel/pipeline-dashboard-utils.ts
@@ -46,7 +46,7 @@ export function formatElapsed(startDateStr: string): string {
   const now = Date.now()
   const diffSec = Math.max(0, Math.floor((now - start) / 1000))
 
-  if (diffSec < 60) return `${diffSec}s`
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m`
-  return `${Math.floor(diffSec / 3600)}h`
+  if (diffSec < 60) return `${diffSec.toString()}s`
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60).toString()}m`
+  return `${Math.floor(diffSec / 3600).toString()}h`
 }

--- a/src/components/panel/pipeline-dashboard.tsx
+++ b/src/components/panel/pipeline-dashboard.tsx
@@ -33,7 +33,7 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
   const tasks = useTaskStore((s) => s.tasks)
   const loadTasks = useTaskStore((s) => s.load)
   const columns = useColumnStore((s) => s.columns)
-  const openTask = useUIStore((s) => s.openTask)
+  const openChat = useUIStore((s) => s.openChat)
 
   const [, setTick] = useState(0)
   const unlistenRefs = useRef<UnlistenFn[]>([])
@@ -53,19 +53,23 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
     }
 
     // tasks:changed
-    listen<TasksChangedPayload>('tasks:changed', (payload) => {
+    void listen<TasksChangedPayload>('tasks:changed', (payload) => {
       if (payload.workspaceId === workspaceId) refresh()
     }).then((unlisten) => {
       if (cancelled) unlisten()
       else unlistenRefs.current.push(unlisten)
+    }).catch((err: unknown) => {
+      console.error('Failed to subscribe to task changes:', err)
     })
 
     // Pipeline events
     const pipelineListeners = [onPipelineRunning, onPipelineComplete, onPipelineError, onPipelineAdvanced]
     for (const sub of pipelineListeners) {
-      sub(() => { refresh() }).then((unlisten) => {
+      void sub(() => { refresh() }).then((unlisten) => {
         if (cancelled) unlisten()
         else unlistenRefs.current.push(unlisten)
+      }).catch((err: unknown) => {
+        console.error('Failed to subscribe to pipeline events:', err)
       })
     }
 
@@ -129,7 +133,7 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
                   initial={{ opacity: 0, height: 0 }}
                   animate={{ opacity: 1, height: 'auto' }}
                   exit={{ opacity: 0, height: 0 }}
-                  onClick={() => { openTask(task.id) }}
+                  onClick={() => { openChat(task.id) }}
                   className="w-full rounded-md bg-surface p-2 text-left transition-colors hover:bg-surface-hover"
                   style={{ cursor: 'pointer' }}
                 >
@@ -145,7 +149,7 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
                   <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-surface-hover">
                     <div
                       className="h-full rounded-full bg-accent transition-all duration-500"
-                      style={{ width: `${progress}%` }}
+                      style={{ width: `${progress.toString()}%` }}
                     />
                   </div>
                 </motion.button>
@@ -164,7 +168,7 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
               <button
                 key={task.id}
                 type="button"
-                onClick={() => { openTask(task.id) }}
+                onClick={() => { openChat(task.id) }}
                 className="w-full rounded-md bg-surface p-2 text-left transition-colors hover:bg-surface-hover"
                 style={{ cursor: 'pointer' }}
               >
@@ -201,7 +205,7 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
                   className="mt-0.5 text-[10px] text-accent hover:underline"
                   style={{ cursor: 'pointer' }}
                 >
-                  {task.prNumber ? `PR #${task.prNumber}` : 'View PR'}
+                  {task.prNumber ? `PR #${task.prNumber.toString()}` : 'View PR'}
                 </button>
               )}
             </div>

--- a/src/components/settings/tabs/agent-tab.tsx
+++ b/src/components/settings/tabs/agent-tab.tsx
@@ -75,7 +75,7 @@ export function AgentTab() {
 
   // Get all available models from enabled providers, excluding disabled ones
   const enabledProviderIds = new Set(model.providers.filter((p) => p.enabled).map((p) => p.id))
-  const disabledModelIds = new Set(model.disabledModels ?? [])
+  const disabledModelIds = new Set(model.disabledModels)
   const availableModels = allModels
     .filter((m) => enabledProviderIds.has(m.provider) && !disabledModelIds.has(m.id))
     .map((m) => m.id)
@@ -149,7 +149,7 @@ export function AgentTab() {
             <span className="text-xs text-text-secondary">
               {allModels.length} models ·{' '}
               {modelSource === 'api'
-                ? `From API · ${new Date(lastFetched!).toLocaleDateString()}`
+                ? `From API · ${lastFetched ? new Date(lastFetched).toLocaleDateString() : 'not refreshed yet'}`
                 : modelSource === 'cli'
                   ? 'From CLI'
                   : 'Built-in list'}
@@ -161,8 +161,8 @@ export function AgentTab() {
                 void refreshModels().then((result) => {
                   if (result.success) {
                     const msg = result.newModels.length > 0
-                      ? `Found ${result.newModels.length} new: ${result.newModels.join(', ')}`
-                      : `${result.modelCount} models up to date`
+                      ? `Found ${result.newModels.length.toString()} new: ${result.newModels.join(', ')}`
+                      : `${result.modelCount.toString()} models up to date`
                     setRefreshStatus({ message: msg, type: 'success' })
                   } else {
                     setRefreshStatus({
@@ -349,6 +349,7 @@ export function AgentTab() {
                         {provider.cliPath && (() => {
                           const update = cliUpdates[provider.id]
                           const isChecking = checkingUpdate[provider.id]
+                          const updateCommand = update?.updateCommand
                           return (
                             <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
                               {isChecking ? (
@@ -366,15 +367,15 @@ export function AgentTab() {
                                     <>
                                       <span className="text-text-secondary">→</span>
                                       <span className="font-mono text-yellow-400">{update.latestVersion}</span>
-                                      {update.updateCommand && (
+                                      {updateCommand && (
                                         <button
                                           onClick={() => {
-                                            void navigator.clipboard.writeText(update.updateCommand!)
+                                            void navigator.clipboard.writeText(updateCommand)
                                             setCopiedCmd(provider.id)
                                             setTimeout(() => { setCopiedCmd(null) }, 2000)
                                           }}
                                           className="ml-0.5 rounded border border-yellow-500/30 px-1 py-0.5 text-[10px] text-yellow-400 transition-colors hover:bg-yellow-500/10"
-                                          title={update.updateCommand}
+                                          title={updateCommand}
                                         >
                                           {copiedCmd === provider.id ? '✓ copied' : (
                                             <span className="flex items-center gap-1">
@@ -420,13 +421,13 @@ export function AgentTab() {
 
                     {/* Available Models with toggles */}
                     {providerModels.length > 0 && (() => {
-                      const disabledSet = new Set(model.disabledModels ?? [])
+                      const disabledSet = new Set(model.disabledModels)
                       const enabledCount = providerModels.filter((m) => !disabledSet.has(m.id)).length
                       const allEnabled = enabledCount === providerModels.length
                       const noneEnabled = enabledCount === 0
 
                       const toggleModel = (modelId: string) => {
-                        const current = new Set(model.disabledModels ?? [])
+                        const current = new Set(model.disabledModels)
                         if (current.has(modelId)) {
                           current.delete(modelId)
                         } else {
@@ -438,12 +439,12 @@ export function AgentTab() {
                       const toggleAll = (enable: boolean) => {
                         if (enable) {
                           // Remove all this provider's models from disabled
-                          const current = new Set(model.disabledModels ?? [])
+                          const current = new Set(model.disabledModels)
                           for (const m of providerModels) current.delete(m.id)
                           updateGlobal('model', { ...model, disabledModels: [...current] })
                         } else {
                           // Add all this provider's models to disabled
-                          const current = new Set(model.disabledModels ?? [])
+                          const current = new Set(model.disabledModels)
                           for (const m of providerModels) current.add(m.id)
                           updateGlobal('model', { ...model, disabledModels: [...current] })
                         }

--- a/src/components/settings/tabs/workspace-tab.tsx
+++ b/src/components/settings/tabs/workspace-tab.tsx
@@ -50,7 +50,7 @@ export function WorkspaceTab() {
     if (!merged.defaultAgentCli) delete merged.defaultAgentCli
     try {
       const updated = await ipc.updateWorkspaceConfig(workspace.id, JSON.stringify(merged))
-      updateWorkspace(workspace.id, { config: updated.config })
+      await updateWorkspace(workspace.id, { config: updated.config })
       setMessage({ type: 'success', text: 'Workspace settings updated' })
     } catch {
       setMessage({ type: 'error', text: 'Failed to update workspace settings' })

--- a/src/hooks/use-model-capabilities.ts
+++ b/src/hooks/use-model-capabilities.ts
@@ -44,7 +44,7 @@ function toCapability(entry: ModelEntry): ModelCapability {
     name: entry.displayName,
     description,
     supportsExtendedContext: entry.supportsExtendedContext,
-    contextWindow: `${Math.round(entry.contextWindow / 1000)}k`,
+    contextWindow: `${Math.round(entry.contextWindow / 1000).toString()}k`,
     maxEffort: effort,
     available: true,
   }

--- a/src/hooks/use-models.ts
+++ b/src/hooks/use-models.ts
@@ -53,7 +53,7 @@ export function useModels(provider?: string): UseModelsResult {
       }
       setModels(filtered)
       setLastFetched(cache.lastFetched || null)
-      setSource(cache.source ?? 'built-in')
+      setSource(cache.source)
     },
     [provider],
   )


### PR DESCRIPTION
## Description

bento-ya CI only has release.yml for builds. Add ci.yml that runs on PRs: cargo check, cargo test, npm run type-check, npm run lint, npx vitest run. Should block merge if any fail.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/add-pr-checks-to-bento-ya-ci-test-lint-type-check` → `main`

## Commits

```
b600791 Fix CI quality checks
aac4c7a Add PR CI checks
```

## Changes

```
.github/workflows/ci.yml                         | 57 ++++++++++++++++++++++++
 mcp-server/src/main.rs                           |  3 +-
 src-tauri/src/api.rs                             |  1 +
 src/components/panel/pipeline-dashboard-utils.ts |  6 +--
 src/components/panel/pipeline-dashboard.tsx      | 18 +++++---
 src/components/settings/tabs/agent-tab.tsx       | 23 +++++-----
 src/components/settings/tabs/workspace-tab.tsx   |  2 +-
 src/hooks/use-model-capabilities.ts              |  2 +-
 src/hooks/use-models.ts                          |  2 +-
 9 files changed, 89 insertions(+), 25 deletions(-)
```