### PR TITLE
Fix .app bundle crash on macOS Finder launch

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,18 +272,13 @@ pub fn run() {
 }
 
 fn start_background_startup_recovery(app: tauri::AppHandle) {
-    if let Err(e) = std::thread::Builder::new()
-        .name("bentoya-startup-recovery".into())
-        .spawn(move || {
-            // Recover stale pipeline work from the previous app instance.
-            resume_stale_pipeline_tasks(app.clone());
+    tauri::async_runtime::spawn(async move {
+        // Recover stale pipeline work from the previous app instance.
+        resume_stale_pipeline_tasks(app.clone());
 
-            // Recover tmux sessions from previous app instance.
-            recover_tmux_sessions(app);
-        })
-    {
-        eprintln!("[startup] Failed to start background recovery: {}", e);
-    }
+        // Recover tmux sessions from previous app instance.
+        recover_tmux_sessions(app);
+    });
 }
 
 /// Recover tmux sessions from a previous app instance.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,7 +272,7 @@ pub fn run() {
 }
 
 fn start_background_startup_recovery(app: tauri::AppHandle) {
-    tauri::async_runtime::spawn(async move {
+    tauri::async_runtime::spawn_blocking(move || {
         // Recover stale pipeline work from the previous app instance.
         resume_stale_pipeline_tasks(app.clone());
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -255,11 +255,9 @@ pub fn run() {
             // Start periodic idle session sweep (every 60s)
             start_idle_sweep(session_registry_for_sweep, app.handle().clone());
 
-            // Recover stale pipeline work from the previous app instance.
-            resume_stale_pipeline_tasks(app.handle().clone());
-
-            // Recover tmux sessions from previous app instance
-            recover_tmux_sessions(app.handle().clone());
+            // Keep macOS didFinishLaunching light. Finder/Spotlight launches can
+            // abort if setup blocks on DB queries, tmux checks, or pipeline resume.
+            start_background_startup_recovery(app.handle().clone());
 
             // Start garbage collector for tmux sessions + agent resources
             chat::gc::start_gc();
@@ -271,6 +269,21 @@ pub fn run() {
 
     // Cleanup port file on exit
     api::cleanup();
+}
+
+fn start_background_startup_recovery(app: tauri::AppHandle) {
+    if let Err(e) = std::thread::Builder::new()
+        .name("bentoya-startup-recovery".into())
+        .spawn(move || {
+            // Recover stale pipeline work from the previous app instance.
+            resume_stale_pipeline_tasks(app.clone());
+
+            // Recover tmux sessions from previous app instance.
+            recover_tmux_sessions(app);
+        })
+    {
+        eprintln!("[startup] Failed to start background recovery: {}", e);
+    }
 }
 
 /// Recover tmux sessions from a previous app instance.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -257,7 +257,7 @@ pub fn run() {
 
             // Keep macOS didFinishLaunching light. Finder/Spotlight launches can
             // abort if setup blocks on DB queries, tmux checks, or pipeline resume.
-            start_background_startup_recovery(app.handle().clone());
+            spawn_startup_recovery(app.handle().clone());
 
             // Start garbage collector for tmux sessions + agent resources
             chat::gc::start_gc();
@@ -271,14 +271,17 @@ pub fn run() {
     api::cleanup();
 }
 
-fn start_background_startup_recovery(app: tauri::AppHandle) {
-    tauri::async_runtime::spawn_blocking(move || {
+fn spawn_startup_recovery(app: tauri::AppHandle) {
+    let recovery_task = tauri::async_runtime::spawn_blocking(move || {
         // Recover stale pipeline work from the previous app instance.
         resume_stale_pipeline_tasks(app.clone());
 
         // Recover tmux sessions from previous app instance.
         recover_tmux_sessions(app);
     });
+
+    // Startup recovery is best-effort and must not hold up Tauri startup.
+    std::mem::drop(recovery_task);
 }
 
 /// Recover tmux sessions from a previous app instance.


### PR DESCRIPTION
## Description

Release binary works from terminal but crashes with SIGABRT when launched via open/Finder/Spotlight. Panic in tao did_finish_launching. setup() closure too heavy for macOS watchdog. Fix: defer DB queries, tmux recovery, pipeline resume to background thread. Workaround: run target/release/bento-ya from terminal.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/fix-app-bundle-crash-on-macos-finder-launch` → `staging/overnight-20260430-bento-ya`