### PR TITLE
Per-workspace cost dashboard with daily/weekly trends

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -1,4 +1,4 @@
-use crate::db::{self, AppState, UsageRecord, UsageSummary};
+use crate::db::{self, AppState, ColumnCost, DailyCost, TaskCost, UsageRecord, UsageSummary};
 use crate::error::AppError;
 use tauri::State;
 
@@ -93,4 +93,42 @@ pub fn clear_workspace_usage(state: State<AppState>, workspace_id: String) -> Re
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::delete_workspace_usage(&conn, &workspace_id).map_err(AppError::from)
+}
+
+#[tauri::command]
+pub fn get_workspace_daily_costs(
+    state: State<AppState>,
+    workspace_id: String,
+    days: Option<i64>,
+) -> Result<Vec<DailyCost>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    db::get_workspace_daily_costs(&conn, &workspace_id, days.unwrap_or(30)).map_err(AppError::from)
+}
+
+#[tauri::command]
+pub fn get_workspace_column_costs(
+    state: State<AppState>,
+    workspace_id: String,
+) -> Result<Vec<ColumnCost>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    db::get_workspace_column_costs(&conn, &workspace_id).map_err(AppError::from)
+}
+
+#[tauri::command]
+pub fn get_workspace_task_costs(
+    state: State<AppState>,
+    workspace_id: String,
+    limit: Option<i64>,
+) -> Result<Vec<TaskCost>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    db::get_workspace_task_costs(&conn, &workspace_id, limit.unwrap_or(10)).map_err(AppError::from)
 }

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -304,6 +304,40 @@ pub struct UsageSummary {
     pub record_count: i64,
 }
 
+/// Daily cost aggregation for time-series charts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DailyCost {
+    pub date: String,
+    pub cost_usd: f64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub record_count: i64,
+}
+
+/// Cost aggregated by column (pipeline stage).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnCost {
+    pub column_name: String,
+    pub cost_usd: f64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub record_count: i64,
+}
+
+/// Cost aggregated by task (top spenders).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskCost {
+    pub task_id: String,
+    pub task_title: String,
+    pub cost_usd: f64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub record_count: i64,
+}
+
 // ─── Session History Entities ───────────────────────────────────────────────
 
 /// A snapshot of an agent session at a point in time.

--- a/src-tauri/src/db/usage.rs
+++ b/src-tauri/src/db/usage.rs
@@ -1,6 +1,6 @@
 use rusqlite::{params, Connection, Result as SqlResult};
 
-use super::models::{UsageRecord, UsageSummary};
+use super::models::{ColumnCost, DailyCost, TaskCost, UsageRecord, UsageSummary};
 use super::{new_id, now};
 
 pub const PROVIDER_ANTHROPIC: &str = "anthropic";
@@ -130,6 +130,97 @@ pub fn get_task_usage_summary(conn: &Connection, task_id: &str) -> SqlResult<Usa
             record_count: row.get(3)?,
         }),
     )
+}
+
+/// Daily cost aggregation for the past N days (for time-series charts).
+pub fn get_workspace_daily_costs(
+    conn: &Connection,
+    workspace_id: &str,
+    days: i64,
+) -> SqlResult<Vec<DailyCost>> {
+    let mut stmt = conn.prepare(
+        "SELECT DATE(created_at) as date,
+                COALESCE(SUM(cost_usd), 0.0) as cost_usd,
+                COALESCE(SUM(input_tokens), 0) as input_tokens,
+                COALESCE(SUM(output_tokens), 0) as output_tokens,
+                COUNT(*) as record_count
+         FROM usage_records
+         WHERE workspace_id = ?1
+           AND created_at >= DATE('now', '-' || ?2 || ' days')
+         GROUP BY DATE(created_at)
+         ORDER BY date ASC",
+    )?;
+    let rows = stmt.query_map(params![workspace_id, days], |row| {
+        Ok(DailyCost {
+            date: row.get(0)?,
+            cost_usd: row.get(1)?,
+            input_tokens: row.get(2)?,
+            output_tokens: row.get(3)?,
+            record_count: row.get(4)?,
+        })
+    })?;
+    rows.collect()
+}
+
+/// Cost aggregated by column name.
+pub fn get_workspace_column_costs(
+    conn: &Connection,
+    workspace_id: &str,
+) -> SqlResult<Vec<ColumnCost>> {
+    let mut stmt = conn.prepare(
+        "SELECT COALESCE(column_name, 'Untracked') as column_name,
+                COALESCE(SUM(cost_usd), 0.0) as cost_usd,
+                COALESCE(SUM(input_tokens), 0) as input_tokens,
+                COALESCE(SUM(output_tokens), 0) as output_tokens,
+                COUNT(*) as record_count
+         FROM usage_records
+         WHERE workspace_id = ?1
+         GROUP BY column_name
+         ORDER BY cost_usd DESC",
+    )?;
+    let rows = stmt.query_map(params![workspace_id], |row| {
+        Ok(ColumnCost {
+            column_name: row.get(0)?,
+            cost_usd: row.get(1)?,
+            input_tokens: row.get(2)?,
+            output_tokens: row.get(3)?,
+            record_count: row.get(4)?,
+        })
+    })?;
+    rows.collect()
+}
+
+/// Cost aggregated by task (top N tasks by cost), with task title from JOIN.
+pub fn get_workspace_task_costs(
+    conn: &Connection,
+    workspace_id: &str,
+    limit: i64,
+) -> SqlResult<Vec<TaskCost>> {
+    let mut stmt = conn.prepare(
+        "SELECT u.task_id,
+                COALESCE(t.title, 'Unknown Task') as task_title,
+                COALESCE(SUM(u.cost_usd), 0.0) as cost_usd,
+                COALESCE(SUM(u.input_tokens), 0) as input_tokens,
+                COALESCE(SUM(u.output_tokens), 0) as output_tokens,
+                COUNT(*) as record_count
+         FROM usage_records u
+         LEFT JOIN tasks t ON t.id = u.task_id
+         WHERE u.workspace_id = ?1 AND u.task_id IS NOT NULL
+         GROUP BY u.task_id
+         ORDER BY cost_usd DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![workspace_id, limit], |row| {
+        Ok(TaskCost {
+            task_id: row.get(0)?,
+            task_title: row.get(1)?,
+            cost_usd: row.get(2)?,
+            input_tokens: row.get(3)?,
+            output_tokens: row.get(4)?,
+            record_count: row.get(5)?,
+        })
+    })?;
+    rows.collect()
 }
 
 pub fn delete_workspace_usage(conn: &Connection, workspace_id: &str) -> SqlResult<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -208,6 +208,9 @@ pub fn run() {
             commands::usage::get_workspace_usage_summary,
             commands::usage::get_task_usage_summary,
             commands::usage::clear_workspace_usage,
+            commands::usage::get_workspace_daily_costs,
+            commands::usage::get_workspace_column_costs,
+            commands::usage::get_workspace_task_costs,
             // History commands
             commands::history::create_snapshot,
             commands::history::get_snapshot,

--- a/src/components/usage/metrics-dashboard.tsx
+++ b/src/components/usage/metrics-dashboard.tsx
@@ -1,7 +1,15 @@
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { motion } from 'motion/react'
 import { useWorkspaceUsage } from '@/hooks/use-workspace-usage'
 import { formatUsageCost, formatUsageDate, formatUsageTokens } from '@/lib/usage'
+import {
+  type ColumnCost,
+  type DailyCost,
+  type TaskCost,
+  getWorkspaceColumnCosts,
+  getWorkspaceDailyCosts,
+  getWorkspaceTaskCosts,
+} from '@/lib/ipc/usage'
 
 type Props = {
   workspaceId: string
@@ -16,16 +24,26 @@ type ModelStats = {
   count: number
 }
 
-type DailyStats = {
-  date: string
-  cost: number
-  tokens: number
-}
+type ActiveTab = 'overview' | 'model' | 'column' | 'task'
+
+const DAYS = 30
 
 export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const { summary, records, isLoading, error } = useWorkspaceUsage(workspaceId, {
-    limit: 500,
+    limit: 1000,
   })
+
+  const [dailyCosts, setDailyCosts] = useState<DailyCost[]>([])
+  const [columnCosts, setColumnCosts] = useState<ColumnCost[]>([])
+  const [taskCosts, setTaskCosts] = useState<TaskCost[]>([])
+  const [activeTab, setActiveTab] = useState<ActiveTab>('overview')
+  const [isExporting, setIsExporting] = useState(false)
+
+  useEffect(() => {
+    void getWorkspaceDailyCosts(workspaceId, DAYS).then(setDailyCosts)
+    void getWorkspaceColumnCosts(workspaceId).then(setColumnCosts)
+    void getWorkspaceTaskCosts(workspaceId, 10).then(setTaskCosts)
+  }, [workspaceId])
 
   const modelStats = useMemo((): ModelStats[] => {
     const map = new Map<string, ModelStats>()
@@ -46,22 +64,41 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
     return Array.from(map.values()).sort((a, b) => b.cost - a.cost)
   }, [records])
 
-  const dailyStats = useMemo((): DailyStats[] => {
-    const map = new Map<string, DailyStats>()
-    for (const r of records) {
-      const date = r.createdAt.split('T')[0] ?? r.createdAt
-      const existing = map.get(date) ?? { date, cost: 0, tokens: 0 }
-      existing.cost += r.costUsd
-      existing.tokens += r.inputTokens + r.outputTokens
-      map.set(date, existing)
-    }
-    return Array.from(map.values())
-      .sort((a, b) => a.date.localeCompare(b.date))
-      .slice(-14)
-  }, [records])
-
-  const maxDailyCost = Math.max(...dailyStats.map((d) => d.cost), 0.01)
+  const maxDailyCost = Math.max(...dailyCosts.map((d) => d.costUsd), 0.01)
+  const maxColumnCost = Math.max(...columnCosts.map((c) => c.costUsd), 0.01)
+  const maxTaskCost = Math.max(...taskCosts.map((t) => t.costUsd), 0.01)
   const maxModelCost = Math.max(...modelStats.map((m) => m.cost), 0.01)
+
+  const exportCsv = useCallback(() => {
+    setIsExporting(true)
+    try {
+      const header = 'Date,Model,Column,Task,Input Tokens,Output Tokens,Cost USD\n'
+      const rows = records.map((r) => {
+        const date = r.createdAt.split('T')[0] ?? r.createdAt
+        const model = r.model.split('/').pop() ?? r.model
+        const column = r.columnName ?? ''
+        const task = ''
+        return `${date},${model},${column},${task},${r.inputTokens},${r.outputTokens},${r.costUsd.toFixed(6)}`
+      })
+      const csv = header + rows.join('\n')
+      const blob = new Blob([csv], { type: 'text/csv' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `usage-${workspaceId}-${new Date().toISOString().split('T')[0]}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+    } finally {
+      setIsExporting(false)
+    }
+  }, [records, workspaceId])
+
+  const TABS: { id: ActiveTab; label: string }[] = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'model', label: 'By Model' },
+    { id: 'column', label: 'By Column' },
+    { id: 'task', label: 'By Task' },
+  ]
 
   return (
     <motion.div
@@ -78,24 +115,40 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
         className="max-h-[85vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-border-default bg-surface shadow-2xl"
       >
         <div className="flex items-center justify-between border-b border-border-default px-6 py-4">
-          <h2 className="text-xl font-semibold text-text-primary">Usage Metrics</h2>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-2 text-text-secondary transition-colors hover:bg-bg hover:text-text-primary"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
-              <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
-            </svg>
-          </button>
+          <h2 className="text-xl font-semibold text-text-primary">Usage Dashboard</h2>
+          <div className="flex items-center gap-2">
+            {records.length > 0 && (
+              <button
+                onClick={exportCsv}
+                disabled={isExporting}
+                className="flex items-center gap-1.5 rounded-lg border border-border-default px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-bg hover:text-text-primary disabled:opacity-50"
+                title="Export CSV"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                  <path d="M10.75 2.75a.75.75 0 0 0-1.5 0v8.614L6.295 8.235a.75.75 0 1 0-1.09 1.03l4.25 4.5a.75.75 0 0 0 1.09 0l4.25-4.5a.75.75 0 0 0-1.09-1.03l-2.955 3.129V2.75Z" />
+                  <path d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z" />
+                </svg>
+                Export CSV
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded-lg p-2 text-text-secondary transition-colors hover:bg-bg hover:text-text-primary"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+                <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+              </svg>
+            </button>
+          </div>
         </div>
 
-        <div className="max-h-[calc(85vh-72px)] overflow-y-auto p-6">
+        <div className="max-h-[calc(85vh-72px)] overflow-y-auto">
           {isLoading ? (
             <div className="flex items-center justify-center py-20">
               <span className="text-text-secondary">Loading metrics...</span>
             </div>
           ) : error ? (
-            <div className="rounded-xl bg-red-500/10 px-4 py-6 text-sm text-red-400">
+            <div className="rounded-xl bg-red-500/10 px-4 py-6 text-sm text-red-400 m-6">
               {error}
             </div>
           ) : !summary || summary.recordCount === 0 ? (
@@ -107,7 +160,7 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
               </p>
             </div>
           ) : (
-            <div className="space-y-8">
+            <div className="p-6 space-y-6">
               {/* Summary Cards */}
               <div className="grid grid-cols-4 gap-4">
                 <div className="rounded-xl bg-bg p-4">
@@ -128,92 +181,190 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
                 </div>
               </div>
 
-              {/* Daily Cost Chart */}
-              {dailyStats.length > 0 && (
+              {/* 30-Day Time Series Chart */}
+              {dailyCosts.length > 0 && (
                 <div className="rounded-xl border border-border-default bg-bg p-4">
-                  <h3 className="mb-4 font-semibold text-text-primary">Daily Costs (Last 14 Days)</h3>
-                  <div className="flex h-32 items-end gap-1">
-                    {dailyStats.map((day) => (
+                  <h3 className="mb-4 font-semibold text-text-primary">Daily Costs — Last {DAYS} Days</h3>
+                  <div className="flex h-32 items-end gap-0.5">
+                    {dailyCosts.map((day) => (
                       <div
                         key={day.date}
                         className="group relative flex flex-1 flex-col items-center"
                       >
-                        <div className="absolute -top-8 hidden rounded bg-surface px-2 py-1 text-xs shadow-lg group-hover:block">
-                          {formatUsageCost(day.cost)}
+                        <div className="absolute -top-8 hidden rounded bg-surface px-2 py-1 text-xs shadow-lg group-hover:block whitespace-nowrap z-10">
+                          {formatUsageDate(day.date)}: {formatUsageCost(day.costUsd)}
                         </div>
                         <div
                           className="w-full rounded-t bg-accent transition-all hover:bg-accent/80"
-                          style={{ height: `${String((day.cost / maxDailyCost) * 100)}%`, minHeight: day.cost > 0 ? '4px' : '0' }}
+                          style={{ height: `${String((day.costUsd / maxDailyCost) * 100)}%`, minHeight: day.costUsd > 0 ? '4px' : '0' }}
                         />
-                        <div className="mt-1 text-[10px] text-text-secondary">{formatUsageDate(day.date)}</div>
+                        {dailyCosts.length <= 14 && (
+                          <div className="mt-1 text-[10px] text-text-secondary">{formatUsageDate(day.date)}</div>
+                        )}
                       </div>
                     ))}
+                  </div>
+                  {dailyCosts.length > 14 && (
+                    <div className="mt-2 flex justify-between text-[10px] text-text-secondary">
+                      <span>{formatUsageDate(dailyCosts[0]?.date ?? '')}</span>
+                      <span>{formatUsageDate(dailyCosts[dailyCosts.length - 1]?.date ?? '')}</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Tab Navigation */}
+              <div className="flex gap-1 rounded-lg bg-bg p-1">
+                {TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => { setActiveTab(tab.id) }}
+                    className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                      activeTab === tab.id
+                        ? 'bg-surface text-text-primary shadow-sm'
+                        : 'text-text-secondary hover:text-text-primary'
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Tab Content */}
+              {activeTab === 'overview' && (
+                <div className="rounded-xl border border-border-default bg-bg p-4">
+                  <h3 className="mb-4 font-semibold text-text-primary">Recent API Calls</h3>
+                  <div className="max-h-64 overflow-y-auto">
+                    <table className="w-full text-sm">
+                      <thead className="border-b border-border-default text-left text-text-secondary">
+                        <tr>
+                          <th className="pb-2 font-medium">Model</th>
+                          <th className="pb-2 font-medium">Column</th>
+                          <th className="pb-2 font-medium">Input</th>
+                          <th className="pb-2 font-medium">Output</th>
+                          <th className="pb-2 text-right font-medium">Cost</th>
+                          <th className="pb-2 text-right font-medium">Time</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-border-default">
+                        {records.slice(0, 50).map((record) => (
+                          <tr key={record.id} className="text-text-primary">
+                            <td className="py-2 font-mono text-xs">{record.model.split('/').pop()}</td>
+                            <td className="py-2 text-xs text-text-secondary">{record.columnName ?? '—'}</td>
+                            <td className="py-2">{formatUsageTokens(record.inputTokens)}</td>
+                            <td className="py-2">{formatUsageTokens(record.outputTokens)}</td>
+                            <td className="py-2 text-right text-accent">{formatUsageCost(record.costUsd)}</td>
+                            <td className="py-2 text-right text-text-secondary">
+                              {new Date(record.createdAt).toLocaleTimeString('en-US', {
+                                hour: '2-digit',
+                                minute: '2-digit',
+                              })}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
                   </div>
                 </div>
               )}
 
-              {/* Model Breakdown */}
-              {modelStats.length > 0 && (
+              {activeTab === 'model' && (
                 <div className="rounded-xl border border-border-default bg-bg p-4">
                   <h3 className="mb-4 font-semibold text-text-primary">Cost by Model</h3>
-                  <div className="space-y-3">
-                    {modelStats.map((model) => (
-                      <div key={model.model} className="space-y-1">
-                        <div className="flex items-center justify-between text-sm">
-                          <span className="font-mono text-text-primary">{model.model.split('/').pop()}</span>
-                          <span className="text-text-secondary">
-                            {formatUsageCost(model.cost)} ({model.count} calls)
-                          </span>
+                  {modelStats.length === 0 ? (
+                    <p className="text-sm text-text-secondary">No model data available</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {modelStats.map((model) => (
+                        <div key={model.model} className="space-y-1">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className="font-mono text-text-primary">{model.model.split('/').pop()}</span>
+                            <span className="text-text-secondary">
+                              {formatUsageCost(model.cost)} ({model.count} calls)
+                            </span>
+                          </div>
+                          <div className="h-2 rounded-full bg-surface">
+                            <div
+                              className="h-full rounded-full bg-accent"
+                              style={{ width: `${String((model.cost / maxModelCost) * 100)}%` }}
+                            />
+                          </div>
+                          <div className="flex gap-4 text-xs text-text-secondary">
+                            <span>In: {formatUsageTokens(model.inputTokens)}</span>
+                            <span>Out: {formatUsageTokens(model.outputTokens)}</span>
+                          </div>
                         </div>
-                        <div className="h-2 rounded-full bg-surface">
-                          <div
-                            className="h-full rounded-full bg-accent"
-                            style={{ width: `${String((model.cost / maxModelCost) * 100)}%` }}
-                          />
-                        </div>
-                        <div className="flex gap-4 text-xs text-text-secondary">
-                          <span>In: {formatUsageTokens(model.inputTokens)}</span>
-                          <span>Out: {formatUsageTokens(model.outputTokens)}</span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
 
-              {/* Recent Records Table */}
-              <div className="rounded-xl border border-border-default bg-bg p-4">
-                <h3 className="mb-4 font-semibold text-text-primary">Recent API Calls</h3>
-                <div className="max-h-64 overflow-y-auto">
-                  <table className="w-full text-sm">
-                    <thead className="border-b border-border-default text-left text-text-secondary">
-                      <tr>
-                        <th className="pb-2 font-medium">Model</th>
-                        <th className="pb-2 font-medium">Input</th>
-                        <th className="pb-2 font-medium">Output</th>
-                        <th className="pb-2 text-right font-medium">Cost</th>
-                        <th className="pb-2 text-right font-medium">Time</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-border-default">
-                      {records.slice(0, 50).map((record) => (
-                        <tr key={record.id} className="text-text-primary">
-                          <td className="py-2 font-mono text-xs">{record.model.split('/').pop()}</td>
-                          <td className="py-2">{formatUsageTokens(record.inputTokens)}</td>
-                          <td className="py-2">{formatUsageTokens(record.outputTokens)}</td>
-                          <td className="py-2 text-right text-accent">{formatUsageCost(record.costUsd)}</td>
-                          <td className="py-2 text-right text-text-secondary">
-                            {new Date(record.createdAt).toLocaleTimeString('en-US', {
-                              hour: '2-digit',
-                              minute: '2-digit',
-                            })}
-                          </td>
-                        </tr>
+              {activeTab === 'column' && (
+                <div className="rounded-xl border border-border-default bg-bg p-4">
+                  <h3 className="mb-4 font-semibold text-text-primary">Cost by Column</h3>
+                  {columnCosts.length === 0 ? (
+                    <p className="text-sm text-text-secondary">No column data available</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {columnCosts.map((col) => (
+                        <div key={col.columnName} className="space-y-1">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className="text-text-primary">{col.columnName}</span>
+                            <span className="text-text-secondary">
+                              {formatUsageCost(col.costUsd)} ({col.recordCount} calls)
+                            </span>
+                          </div>
+                          <div className="h-2 rounded-full bg-surface">
+                            <div
+                              className="h-full rounded-full bg-blue-500"
+                              style={{ width: `${String((col.costUsd / maxColumnCost) * 100)}%` }}
+                            />
+                          </div>
+                          <div className="flex gap-4 text-xs text-text-secondary">
+                            <span>In: {formatUsageTokens(col.inputTokens)}</span>
+                            <span>Out: {formatUsageTokens(col.outputTokens)}</span>
+                          </div>
+                        </div>
                       ))}
-                    </tbody>
-                  </table>
+                    </div>
+                  )}
                 </div>
-              </div>
+              )}
+
+              {activeTab === 'task' && (
+                <div className="rounded-xl border border-border-default bg-bg p-4">
+                  <h3 className="mb-4 font-semibold text-text-primary">Top Tasks by Cost</h3>
+                  {taskCosts.length === 0 ? (
+                    <p className="text-sm text-text-secondary">No task data available</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {taskCosts.map((task) => (
+                        <div key={task.taskId} className="space-y-1">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className="text-text-primary truncate max-w-[60%]" title={task.taskTitle}>
+                              {task.taskTitle}
+                            </span>
+                            <span className="text-text-secondary shrink-0 ml-2">
+                              {formatUsageCost(task.costUsd)} ({task.recordCount} calls)
+                            </span>
+                          </div>
+                          <div className="h-2 rounded-full bg-surface">
+                            <div
+                              className="h-full rounded-full bg-purple-500"
+                              style={{ width: `${String((task.costUsd / maxTaskCost) * 100)}%` }}
+                            />
+                          </div>
+                          <div className="flex gap-4 text-xs text-text-secondary">
+                            <span>In: {formatUsageTokens(task.inputTokens)}</span>
+                            <span>Out: {formatUsageTokens(task.outputTokens)}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/usage/metrics-dashboard.tsx
+++ b/src/components/usage/metrics-dashboard.tsx
@@ -27,6 +27,19 @@ type ModelStats = {
 type ActiveTab = 'overview' | 'model' | 'column' | 'task'
 
 const DAYS = 30
+const TOP_TASKS_LIMIT = 10
+const RECENT_RECORDS_LIMIT = 50
+
+const TABS: { id: ActiveTab; label: string }[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'model', label: 'By Model' },
+  { id: 'column', label: 'By Column' },
+  { id: 'task', label: 'By Task' },
+]
+
+function shortModelName(model: string): string {
+  return model.split('/').pop() ?? model
+}
 
 export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const { summary, records, isLoading, error } = useWorkspaceUsage(workspaceId, {
@@ -37,12 +50,11 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const [columnCosts, setColumnCosts] = useState<ColumnCost[]>([])
   const [taskCosts, setTaskCosts] = useState<TaskCost[]>([])
   const [activeTab, setActiveTab] = useState<ActiveTab>('overview')
-  const [isExporting, setIsExporting] = useState(false)
 
   useEffect(() => {
     void getWorkspaceDailyCosts(workspaceId, DAYS).then(setDailyCosts)
     void getWorkspaceColumnCosts(workspaceId).then(setColumnCosts)
-    void getWorkspaceTaskCosts(workspaceId, 10).then(setTaskCosts)
+    void getWorkspaceTaskCosts(workspaceId, TOP_TASKS_LIMIT).then(setTaskCosts)
   }, [workspaceId])
 
   const modelStats = useMemo((): ModelStats[] => {
@@ -70,36 +82,24 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const maxModelCost = Math.max(...modelStats.map((m) => m.cost), 0.01)
 
   const exportCsv = useCallback(() => {
-    setIsExporting(true)
-    try {
-      const csvField = (v: string) => (v.includes(',') || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v)
-      const header = 'Date,Model,Column,Task ID,Input Tokens,Output Tokens,Cost USD\n'
-      const rows = records.map((r) => {
-        const date = r.createdAt.slice(0, 10)
-        const model = csvField(r.model.split('/').pop() ?? r.model)
-        const column = csvField(r.columnName ?? '')
-        const taskId = csvField(r.taskId ?? '')
-        return `${date},${model},${column},${taskId},${String(r.inputTokens)},${String(r.outputTokens)},${r.costUsd.toFixed(6)}`
-      })
-      const csv = header + rows.join('\n')
-      const blob = new Blob([csv], { type: 'text/csv' })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `usage-${workspaceId}-${new Date().toISOString().slice(0, 10)}.csv`
-      a.click()
-      URL.revokeObjectURL(url)
-    } finally {
-      setIsExporting(false)
-    }
+    const csvField = (v: string) => (v.includes(',') || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v)
+    const header = 'Date,Model,Column,Task ID,Input Tokens,Output Tokens,Cost USD\n'
+    const rows = records.map((r) => {
+      const date = r.createdAt.slice(0, 10)
+      const model = csvField(shortModelName(r.model))
+      const column = csvField(r.columnName ?? '')
+      const taskId = csvField(r.taskId ?? '')
+      return `${date},${model},${column},${taskId},${String(r.inputTokens)},${String(r.outputTokens)},${r.costUsd.toFixed(6)}`
+    })
+    const csv = header + rows.join('\n')
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `usage-${workspaceId}-${new Date().toISOString().slice(0, 10)}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
   }, [records, workspaceId])
-
-  const TABS: { id: ActiveTab; label: string }[] = [
-    { id: 'overview', label: 'Overview' },
-    { id: 'model', label: 'By Model' },
-    { id: 'column', label: 'By Column' },
-    { id: 'task', label: 'By Task' },
-  ]
 
   return (
     <motion.div
@@ -121,8 +121,7 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
             {records.length > 0 && (
               <button
                 onClick={exportCsv}
-                disabled={isExporting}
-                className="flex items-center gap-1.5 rounded-lg border border-border-default px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-bg hover:text-text-primary disabled:opacity-50"
+                className="flex items-center gap-1.5 rounded-lg border border-border-default px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-bg hover:text-text-primary"
                 title="Export CSV"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
@@ -248,9 +247,9 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-border-default">
-                        {records.slice(0, 50).map((record) => (
+                        {records.slice(0, RECENT_RECORDS_LIMIT).map((record) => (
                           <tr key={record.id} className="text-text-primary">
-                            <td className="py-2 font-mono text-xs">{record.model.split('/').pop()}</td>
+                            <td className="py-2 font-mono text-xs">{shortModelName(record.model)}</td>
                             <td className="py-2 text-xs text-text-secondary">{record.columnName ?? '—'}</td>
                             <td className="py-2">{formatUsageTokens(record.inputTokens)}</td>
                             <td className="py-2">{formatUsageTokens(record.outputTokens)}</td>
@@ -279,7 +278,7 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
                       {modelStats.map((model) => (
                         <div key={model.model} className="space-y-1">
                           <div className="flex items-center justify-between text-sm">
-                            <span className="font-mono text-text-primary">{model.model.split('/').pop()}</span>
+                            <span className="font-mono text-text-primary">{shortModelName(model.model)}</span>
                             <span className="text-text-secondary">
                               {formatUsageCost(model.cost)} ({model.count} calls)
                             </span>

--- a/src/components/usage/metrics-dashboard.tsx
+++ b/src/components/usage/metrics-dashboard.tsx
@@ -72,20 +72,21 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const exportCsv = useCallback(() => {
     setIsExporting(true)
     try {
-      const header = 'Date,Model,Column,Task,Input Tokens,Output Tokens,Cost USD\n'
+      const csvField = (v: string) => (v.includes(',') || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v)
+      const header = 'Date,Model,Column,Task ID,Input Tokens,Output Tokens,Cost USD\n'
       const rows = records.map((r) => {
-        const date = r.createdAt.split('T')[0] ?? r.createdAt
-        const model = r.model.split('/').pop() ?? r.model
-        const column = r.columnName ?? ''
-        const task = ''
-        return `${date},${model},${column},${task},${r.inputTokens},${r.outputTokens},${r.costUsd.toFixed(6)}`
+        const date = r.createdAt.slice(0, 10)
+        const model = csvField(r.model.split('/').pop() ?? r.model)
+        const column = csvField(r.columnName ?? '')
+        const taskId = csvField(r.taskId ?? '')
+        return `${date},${model},${column},${taskId},${String(r.inputTokens)},${String(r.outputTokens)},${r.costUsd.toFixed(6)}`
       })
       const csv = header + rows.join('\n')
       const blob = new Blob([csv], { type: 'text/csv' })
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `usage-${workspaceId}-${new Date().toISOString().split('T')[0]}.csv`
+      a.download = `usage-${workspaceId}-${new Date().toISOString().slice(0, 10)}.csv`
       a.click()
       URL.revokeObjectURL(url)
     } finally {

--- a/src/lib/ipc/usage.ts
+++ b/src/lib/ipc/usage.ts
@@ -74,3 +74,46 @@ export async function getTaskUsageSummary(taskId: string): Promise<UsageSummary>
 export async function clearWorkspaceUsage(workspaceId: string): Promise<void> {
   return invoke('clear_workspace_usage', { workspaceId })
 }
+
+export type DailyCost = {
+  date: string
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+  recordCount: number
+}
+
+export type ColumnCost = {
+  columnName: string
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+  recordCount: number
+}
+
+export type TaskCost = {
+  taskId: string
+  taskTitle: string
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+  recordCount: number
+}
+
+export async function getWorkspaceDailyCosts(
+  workspaceId: string,
+  days?: number,
+): Promise<DailyCost[]> {
+  return invoke<DailyCost[]>('get_workspace_daily_costs', { workspaceId, days })
+}
+
+export async function getWorkspaceColumnCosts(workspaceId: string): Promise<ColumnCost[]> {
+  return invoke<ColumnCost[]>('get_workspace_column_costs', { workspaceId })
+}
+
+export async function getWorkspaceTaskCosts(
+  workspaceId: string,
+  limit?: number,
+): Promise<TaskCost[]> {
+  return invoke<TaskCost[]>('get_workspace_task_costs', { workspaceId, limit })
+}


### PR DESCRIPTION
## Description

Extend cost tracking. Show cost per workspace, broken down by: model (gpt-5.5/spark/sonnet/opus), column (Plan/Working/Review etc), task. Time series chart (daily for past 30 days). Export CSV. Acceptance: dashboard renders accurate numbers, charts work, CSV export works, cargo check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/per-workspace-cost-dashboard-with-daily-weekly-tre` → `staging/overnight-20260430-bento-ya`

## Commits

```
487b183 Clean up metrics-dashboard: hoist constants, deduplicate model name helper
3754e39 Fix CSV export lint errors and field escaping
eebd723 Add per-workspace cost dashboard with daily/weekly trends
```

## Changes

```
src-tauri/src/commands/usage.rs            |  40 +++-
 src-tauri/src/db/models.rs                 |  34 +++
 src-tauri/src/db/usage.rs                  |  93 +++++++-
 src-tauri/src/lib.rs                       |   3 +
 src/components/usage/metrics-dashboard.tsx | 341 +++++++++++++++++++++--------
 src/lib/ipc/usage.ts                       |  43 ++++
 6 files changed, 457 insertions(+), 97 deletions(-)
```