### PR TITLE
Better error messages on pipeline failures

### DIFF
--- a/src/components/kanban/task-card-status.tsx
+++ b/src/components/kanban/task-card-status.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react'
 import type { Task } from '@/types'
 import type { ReviewStatus } from '@/types'
 import type { AttentionItem } from '@/stores/attention-store'
 import { ATTENTION_LABELS } from '@/stores/attention-store'
 import { REVIEW_STATUS_LABELS } from '@/constants/status'
+import { Tooltip } from '@/components/shared/tooltip'
+import { parsePipelineError } from '@/lib/pipeline-error-utils'
 
 /** Attention/needs-attention banner */
 export function AttentionBanner({ attention }: { attention: AttentionItem }) {
@@ -65,7 +68,7 @@ export function QualityGateBanner({ reviewStatus }: { reviewStatus: ReviewStatus
   )
 }
 
-/** Pipeline error banner with retry button */
+/** Pipeline error banner with retry button and expandable "Why did this fail?" panel */
 export function PipelineErrorBanner({
   task,
   onRetry,
@@ -73,21 +76,67 @@ export function PipelineErrorBanner({
   task: Task
   onRetry: () => void
 }) {
+  const [expanded, setExpanded] = useState(false)
+  const rawError = task.pipelineError ?? ''
+  const parsed = parsePipelineError(rawError)
+
   return (
-    <div className="flex items-center gap-1.5 rounded bg-error/10 px-2 py-1 text-xs text-error">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 shrink-0">
-        <path fillRule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14Zm.75-8.25a.75.75 0 0 0-1.5 0v3.5a.75.75 0 0 0 1.5 0v-3.5ZM8 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
-      </svg>
-      <span className="truncate flex-1">{task.pipelineError}{task.retryCount > 0 && ` (${String(task.retryCount)} retries)`}</span>
-      <button
-        onClick={(e) => {
-          e.stopPropagation()
-          onRetry()
-        }}
-        className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium bg-error/20 hover:bg-error/30 transition-colors"
-      >
-        Retry
-      </button>
+    <div className="rounded bg-error/10 text-xs text-error">
+      <div className="flex items-center gap-1.5 px-2 py-1">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 shrink-0">
+          <path fillRule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14Zm.75-8.25a.75.75 0 0 0-1.5 0v3.5a.75.75 0 0 0 1.5 0v-3.5ZM8 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+        </svg>
+        <Tooltip content={rawError} side="top" wrap delay={400}>
+          <span className="truncate flex-1 cursor-default">
+            {parsed.friendlyMessage}
+            {task.retryCount > 0 && ` (${String(task.retryCount)} retries)`}
+          </span>
+        </Tooltip>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            setExpanded((v) => !v)
+          }}
+          className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium text-error/70 hover:text-error hover:bg-error/20 transition-colors"
+        >
+          Why?
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onRetry()
+          }}
+          className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium bg-error/20 hover:bg-error/30 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+      {expanded && (
+        <div
+          className="px-2 pb-2 space-y-1.5"
+          onClick={(e) => { e.stopPropagation() }}
+        >
+          <p className="text-error/80 leading-snug">{parsed.friendlyMessage}</p>
+          <ul className="space-y-0.5">
+            {parsed.suggestedFixes.map((fix) => (
+              <li key={fix} className="flex items-start gap-1 text-error/70">
+                <span className="mt-0.5 shrink-0">→</span>
+                <span>{fix}</span>
+              </li>
+            ))}
+          </ul>
+          {rawError && (
+            <details className="mt-1">
+              <summary className="cursor-pointer text-error/50 hover:text-error/70 transition-colors">
+                Raw error
+              </summary>
+              <p className="mt-1 break-all text-error/50 font-mono text-[10px] leading-relaxed">
+                {rawError}
+              </p>
+            </details>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/kanban/task-card-status.tsx
+++ b/src/components/kanban/task-card-status.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import type { Task } from '@/types'
-import type { ReviewStatus } from '@/types'
+import type { Task, ReviewStatus } from '@/types'
 import type { AttentionItem } from '@/stores/attention-store'
 import { ATTENTION_LABELS } from '@/stores/attention-store'
 import { REVIEW_STATUS_LABELS } from '@/constants/status'
@@ -86,7 +85,7 @@ export function PipelineErrorBanner({
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 shrink-0">
           <path fillRule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14Zm.75-8.25a.75.75 0 0 0-1.5 0v3.5a.75.75 0 0 0 1.5 0v-3.5ZM8 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
         </svg>
-        <Tooltip content={rawError} side="top" wrap delay={400}>
+        <Tooltip content={rawError || parsed.friendlyMessage} side="top" wrap delay={400}>
           <span className="truncate flex-1 cursor-default">
             {parsed.friendlyMessage}
             {task.retryCount > 0 && ` (${String(task.retryCount)} retries)`}
@@ -116,7 +115,6 @@ export function PipelineErrorBanner({
           className="px-2 pb-2 space-y-1.5"
           onClick={(e) => { e.stopPropagation() }}
         >
-          <p className="text-error/80 leading-snug">{parsed.friendlyMessage}</p>
           <ul className="space-y-0.5">
             {parsed.suggestedFixes.map((fix) => (
               <li key={fix} className="flex items-start gap-1 text-error/70">

--- a/src/components/shared/tooltip.tsx
+++ b/src/components/shared/tooltip.tsx
@@ -7,6 +7,7 @@ type TooltipProps = {
   children: ReactNode
   side?: 'top' | 'bottom' | 'left' | 'right'
   delay?: number
+  wrap?: boolean
 }
 
 type Position = {
@@ -14,7 +15,7 @@ type Position = {
   left: number
 }
 
-export function Tooltip({ content, children, side = 'top', delay = 100 }: TooltipProps) {
+export function Tooltip({ content, children, side = 'top', delay = 100, wrap = false }: TooltipProps) {
   const [isVisible, setIsVisible] = useState(false)
   const [position, setPosition] = useState<Position>({ top: 0, left: 0 })
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -124,7 +125,7 @@ export function Tooltip({ content, children, side = 'top', delay = 100 }: Toolti
                 top: position.top,
                 left: position.left,
               }}
-              className="z-[9999] whitespace-nowrap rounded-md bg-text-primary px-2 py-1 text-xs font-medium text-bg shadow-lg"
+              className={`z-[9999] rounded-md bg-text-primary px-2 py-1 text-xs font-medium text-bg shadow-lg ${wrap ? 'whitespace-pre-wrap max-w-xs' : 'whitespace-nowrap'}`}
             >
               {content}
             </motion.div>

--- a/src/lib/pipeline-error-utils.test.ts
+++ b/src/lib/pipeline-error-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { parsePipelineError } from './pipeline-error-utils'
+
+describe('parsePipelineError', () => {
+  describe('rate_limit', () => {
+    it('matches "rate limit" phrasing', () => {
+      expect(parsePipelineError('Error: rate limit exceeded').category).toBe('rate_limit')
+    })
+    it('matches 429 status code', () => {
+      expect(parsePipelineError('HTTP 429 Too Many Requests').category).toBe('rate_limit')
+    })
+    it('matches rate_limit_exceeded', () => {
+      expect(parsePipelineError('rate_limit_exceeded on API call').category).toBe('rate_limit')
+    })
+  })
+
+  describe('auth', () => {
+    it('matches authentication error', () => {
+      expect(parsePipelineError('authentication failed for request').category).toBe('auth')
+    })
+    it('matches invalid api key', () => {
+      expect(parsePipelineError('Invalid API key provided').category).toBe('auth')
+    })
+    it('matches 401 status code', () => {
+      expect(parsePipelineError('HTTP 401 Unauthorized').category).toBe('auth')
+    })
+    it('matches forbidden', () => {
+      expect(parsePipelineError('403 Forbidden').category).toBe('auth')
+    })
+  })
+
+  describe('syntax', () => {
+    it('matches SyntaxError', () => {
+      expect(parsePipelineError('SyntaxError: Unexpected token }').category).toBe('syntax')
+    })
+    it('matches parse error', () => {
+      expect(parsePipelineError('JSON parse error at line 12').category).toBe('syntax')
+    })
+    it('matches invalid json', () => {
+      expect(parsePipelineError('invalid JSON in response').category).toBe('syntax')
+    })
+  })
+
+  describe('context_limit', () => {
+    it('matches too many tokens', () => {
+      expect(parsePipelineError('too many tokens in prompt').category).toBe('context_limit')
+    })
+    it('matches context length', () => {
+      expect(parsePipelineError('context length exceeded').category).toBe('context_limit')
+    })
+    it('matches token limit', () => {
+      expect(parsePipelineError('token limit reached').category).toBe('context_limit')
+    })
+    it('matches max token', () => {
+      expect(parsePipelineError('max token count exceeded').category).toBe('context_limit')
+    })
+  })
+
+  describe('timeout', () => {
+    it('matches timeout', () => {
+      expect(parsePipelineError('Process timeout after 7200s').category).toBe('timeout')
+    })
+    it('matches timed out', () => {
+      expect(parsePipelineError('agent timed out waiting for response').category).toBe('timeout')
+    })
+    it('matches ETIMEDOUT', () => {
+      expect(parsePipelineError('ETIMEDOUT connecting to API').category).toBe('timeout')
+    })
+  })
+
+  describe('exit_code', () => {
+    it('matches exit code N', () => {
+      expect(parsePipelineError('exit code 1').category).toBe('exit_code')
+    })
+    it('matches exited with code', () => {
+      expect(parsePipelineError('Process exited with code 2').category).toBe('exit_code')
+    })
+    it('matches non-zero exit', () => {
+      expect(parsePipelineError('non-zero exit status').category).toBe('exit_code')
+    })
+    it('does not match exit code 0', () => {
+      // exit code 0 is success — should fall through to unknown
+      expect(parsePipelineError('exit code 0').category).toBe('unknown')
+    })
+  })
+
+  describe('unknown fallback', () => {
+    it('returns unknown for unrecognized errors', () => {
+      const result = parsePipelineError('something went wrong')
+      expect(result.category).toBe('unknown')
+      expect(result.friendlyMessage).toBe('Pipeline failed')
+      expect(result.suggestedFixes.length).toBeGreaterThan(0)
+    })
+
+    it('returns unknown for empty string', () => {
+      expect(parsePipelineError('').category).toBe('unknown')
+    })
+  })
+
+  describe('friendly messages', () => {
+    it('returns correct friendly message for each category', () => {
+      expect(parsePipelineError('rate limit').friendlyMessage).toBe('API rate limit reached')
+      expect(parsePipelineError('401 unauthorized').friendlyMessage).toBe('Authentication failed')
+      expect(parsePipelineError('SyntaxError').friendlyMessage).toBe('Syntax or parse error in agent output')
+      expect(parsePipelineError('too many tokens').friendlyMessage).toBe('Context or token limit exceeded')
+      expect(parsePipelineError('timed out').friendlyMessage).toBe('Agent timed out')
+      expect(parsePipelineError('exit code 1').friendlyMessage).toBe('Agent exited with an error')
+    })
+  })
+})

--- a/src/lib/pipeline-error-utils.ts
+++ b/src/lib/pipeline-error-utils.ts
@@ -1,0 +1,98 @@
+export type ErrorCategory = 'rate_limit' | 'auth' | 'syntax' | 'context_limit' | 'timeout' | 'exit_code' | 'unknown'
+
+export interface ParsedPipelineError {
+  friendlyMessage: string
+  suggestedFixes: string[]
+  category: ErrorCategory
+}
+
+interface ErrorPattern {
+  pattern: RegExp
+  category: ErrorCategory
+  friendlyMessage: string
+  suggestedFixes: string[]
+}
+
+const ERROR_PATTERNS: ErrorPattern[] = [
+  {
+    pattern: /rate.?limit|429|too many requests|rate_limit_exceeded/i,
+    category: 'rate_limit',
+    friendlyMessage: 'API rate limit reached',
+    suggestedFixes: [
+      'Wait a few minutes before retrying',
+      'Check your API plan and usage limits',
+      'Consider adding a retry delay in the trigger config',
+    ],
+  },
+  {
+    pattern: /authentication|invalid.{0,10}api.{0,10}key|unauthorized|401|403|forbidden|auth.{0,10}fail/i,
+    category: 'auth',
+    friendlyMessage: 'Authentication failed',
+    suggestedFixes: [
+      'Check your API key in Settings → Providers',
+      'Verify the API key has not expired or been revoked',
+      'Ensure the key has the required permissions',
+    ],
+  },
+  {
+    pattern: /syntax.?error|SyntaxError|unexpected.{0,20}token|parse.{0,10}error|invalid.{0,10}json/i,
+    category: 'syntax',
+    friendlyMessage: 'Syntax or parse error in agent output',
+    suggestedFixes: [
+      'Check the agent command for syntax errors',
+      'Verify CLI arguments are correctly formatted',
+      'Review the agent log for the specific failing line',
+    ],
+  },
+  {
+    pattern: /context.{0,10}length|too many tokens|context.{0,10}window|max.{0,10}token|token.{0,10}limit|context.{0,10}exceeded/i,
+    category: 'context_limit',
+    friendlyMessage: 'Context or token limit exceeded',
+    suggestedFixes: [
+      'Break the task into smaller subtasks',
+      'Reduce the task description or prompt size',
+      'Use a model with a larger context window',
+    ],
+  },
+  {
+    pattern: /timeout|timed.?out|ETIMEDOUT|connection.{0,10}timeout/i,
+    category: 'timeout',
+    friendlyMessage: 'Agent timed out',
+    suggestedFixes: [
+      'The agent exceeded the 2-hour time limit',
+      'Break the task into smaller, faster subtasks',
+      'Check if the agent process hung or stalled',
+    ],
+  },
+  {
+    pattern: /exit.{0,10}code [1-9]|non.?zero exit|exited with code [1-9]|process.{0,10}exit/i,
+    category: 'exit_code',
+    friendlyMessage: 'Agent exited with an error',
+    suggestedFixes: [
+      'Check the agent log file for error details',
+      'Verify the working directory and file permissions',
+      'Ensure the CLI command and arguments are correct',
+    ],
+  },
+]
+
+export function parsePipelineError(rawError: string): ParsedPipelineError {
+  for (const entry of ERROR_PATTERNS) {
+    if (entry.pattern.test(rawError)) {
+      return {
+        category: entry.category,
+        friendlyMessage: entry.friendlyMessage,
+        suggestedFixes: entry.suggestedFixes,
+      }
+    }
+  }
+  return {
+    category: 'unknown',
+    friendlyMessage: 'Pipeline failed',
+    suggestedFixes: [
+      'Check the agent log file for details',
+      'Retry the task to see if the error persists',
+      'Review the trigger configuration in column settings',
+    ],
+  }
+}


### PR DESCRIPTION
## Description

Improve pipeline_error display: parse common codex errors (rate limit, auth, syntax error from agent) into user-friendly messages. Show error in tooltip on task card. Add "Why did this fail?" link → expanded panel with suggested fixes. Acceptance: 5 common errors mapped to friendly messages, tooltip on failed cards, cargo check && npx tsc --noEmit passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/better-error-messages-on-pipeline-failures` → `staging/overnight-20260430-bento-ya`

## Commits

```
198f0d2 Clean up task-card-status: merge duplicate imports, fix empty tooltip, remove redundant header in error panel
8699e07 Add tests for parsePipelineError utility
0736143 Better error messages on pipeline failures
```

## Changes

```
src/components/kanban/task-card-status.tsx |  81 ++++++++++++++++-----
 src/components/shared/tooltip.tsx          |   5 +-
 src/lib/pipeline-error-utils.test.ts       | 110 +++++++++++++++++++++++++++++
 src/lib/pipeline-error-utils.ts            |  98 +++++++++++++++++++++++++
 4 files changed, 275 insertions(+), 19 deletions(-)
```