### PR TITLE
Auto-cleanup completed worktrees on Done

### DIFF
--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -1397,7 +1397,16 @@ fn handle_configure_triggers(conn: &Connection, args: &Value) -> Value {
     };
 
     // Validate trigger action types if present
-    let valid_types = ["spawn_cli", "move_column", "trigger_task", "run_script", "create_pr", "none"];
+    let valid_types = [
+        "auto_setup",
+        "spawn_cli",
+        "move_column",
+        "trigger_task",
+        "run_script",
+        "create_pr",
+        "auto_merge",
+        "none",
+    ];
     for key in &["on_entry", "on_exit"] {
         if let Some(action) = parsed.get(key) {
             if let Some(action_type) = action.get("type").and_then(|t| t.as_str()) {

--- a/src-tauri/src/commands/column.rs
+++ b/src-tauri/src/commands/column.rs
@@ -76,7 +76,7 @@ pub fn update_column(
                 Ok(_) => {} // Valid
                 Err(e) => {
                     return Err(AppError::InvalidInput(format!(
-                        "Invalid trigger configuration: {}. Check that trigger types match: auto_setup, spawn_cli, move_column, trigger_task, run_script (requires script_id), create_pr, none.",
+                        "Invalid trigger configuration: {}. Check that trigger types match: auto_setup, spawn_cli, move_column, trigger_task, run_script (requires script_id), create_pr, auto_merge, none.",
                         e
                     )));
                 }

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -296,6 +296,13 @@ pub async fn move_task(
             Some(&target_column),
         );
 
+        let task = pipeline::cleanup_task_worktree_if_terminal(
+            &conn,
+            &task,
+            &target_column,
+            "manual_move",
+        )?;
+
         // Notify frontend to refresh task store
         pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_moved");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -258,6 +258,9 @@ pub fn run() {
             // Recover stale pipeline work from the previous app instance.
             resume_stale_pipeline_tasks(app.handle().clone());
 
+            // Warn about orphaned Bento worktrees once a day.
+            start_nightly_worktree_sweep(app.handle().clone());
+
             // Recover tmux sessions from previous app instance
             recover_tmux_sessions(app.handle().clone());
 
@@ -271,6 +274,110 @@ pub fn run() {
 
     // Cleanup port file on exit
     api::cleanup();
+}
+
+fn is_terminal_column_for_sweep(column: &db::Column, max_position: i64) -> bool {
+    column.name.eq_ignore_ascii_case("done") || column.position == max_position
+}
+
+fn warn_stale_worktrees_once(app: &tauri::AppHandle) {
+    use std::collections::{HashMap, HashSet};
+
+    let state: tauri::State<db::AppState> = app.state();
+    let conn = match state.db.lock() {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("[worktree-sweep] DB lock failed: {}", e);
+            return;
+        }
+    };
+
+    let workspaces = match db::list_workspaces(&conn) {
+        Ok(workspaces) => workspaces,
+        Err(e) => {
+            log::warn!("[worktree-sweep] Failed to list workspaces: {}", e);
+            return;
+        }
+    };
+
+    for workspace in workspaces {
+        if workspace.repo_path.is_empty() {
+            continue;
+        }
+
+        let columns = match db::list_columns(&conn, &workspace.id) {
+            Ok(columns) => columns,
+            Err(e) => {
+                log::warn!(
+                    "[worktree-sweep] Failed to list columns for workspace {}: {}",
+                    workspace.id,
+                    e
+                );
+                continue;
+            }
+        };
+        let max_position = columns.iter().map(|col| col.position).max().unwrap_or(-1);
+        let columns_by_id: HashMap<_, _> = columns
+            .iter()
+            .map(|column| (column.id.as_str(), column))
+            .collect();
+
+        let tasks = match db::list_tasks(&conn, &workspace.id) {
+            Ok(tasks) => tasks,
+            Err(e) => {
+                log::warn!(
+                    "[worktree-sweep] Failed to list tasks for workspace {}: {}",
+                    workspace.id,
+                    e
+                );
+                continue;
+            }
+        };
+
+        let referenced_worktrees: HashSet<String> = tasks
+            .iter()
+            .filter(|task| !task.worktree_path.as_deref().unwrap_or("").is_empty())
+            .filter(|task| {
+                columns_by_id
+                    .get(task.column_id.as_str())
+                    .map(|column| !is_terminal_column_for_sweep(column, max_position))
+                    .unwrap_or(true)
+            })
+            .map(|task| format!("bentoya-{}", task.id))
+            .collect();
+
+        let worktrees = match git::branch_manager::list_worktrees(&workspace.repo_path) {
+            Ok(worktrees) => worktrees,
+            Err(e) => {
+                log::warn!(
+                    "[worktree-sweep] Failed to list git worktrees for '{}': {}",
+                    workspace.repo_path,
+                    e
+                );
+                continue;
+            }
+        };
+
+        for worktree in worktrees {
+            if !referenced_worktrees.contains(&worktree) {
+                log::warn!(
+                    "[worktree-sweep] Worktree '{}' in '{}' is not referenced by any non-Done task",
+                    worktree,
+                    workspace.repo_path
+                );
+            }
+        }
+    }
+}
+
+fn start_nightly_worktree_sweep(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        warn_stale_worktrees_once(&app);
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(24 * 60 * 60)).await;
+            warn_stale_worktrees_once(&app);
+        }
+    });
 }
 
 /// Recover tmux sessions from a previous app instance.

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -118,6 +118,50 @@ pub fn emit_tasks_changed(app: &AppHandle, workspace_id: &str, reason: &str) {
     );
 }
 
+fn column_is_terminal(conn: &Connection, column: &Column) -> Result<bool, AppError> {
+    if column.name.eq_ignore_ascii_case("done") {
+        return Ok(true);
+    }
+
+    Ok(db::get_next_column(conn, &column.workspace_id, column.position)?.is_none())
+}
+
+/// Clean up the per-task worktree after a task reaches the terminal Done column.
+///
+/// This intentionally leaves branch deletion to the merge flow. The worktree path
+/// is cleared only after git reports the worktree was removed.
+pub fn cleanup_task_worktree_if_terminal(
+    conn: &Connection,
+    task: &Task,
+    column: &Column,
+    reason: &str,
+) -> Result<Task, AppError> {
+    if task.worktree_path.as_deref().unwrap_or("").is_empty() || !column_is_terminal(conn, column)?
+    {
+        return Ok(task.clone());
+    }
+
+    let workspace = db::get_workspace(conn, &task.workspace_id)?;
+    match crate::git::branch_manager::remove_task_worktree(&workspace.repo_path, &task.id) {
+        Ok(()) => {
+            log::info!(
+                "[worktree-cleanup] Removed worktree for completed task {} ({})",
+                task.id,
+                reason
+            );
+            Ok(db::update_task_worktree_path(conn, &task.id, None)?)
+        }
+        Err(e) => {
+            log::warn!(
+                "[worktree-cleanup] Failed to remove worktree for completed task {}: {}",
+                task.id,
+                e
+            );
+            Ok(task.clone())
+        }
+    }
+}
+
 /// Payload sent to webhook URLs
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -536,6 +580,8 @@ pub fn try_auto_advance(
             ).map_err(AppError::from)?;
 
             let updated_task = db::get_task(conn, &task.id)?;
+            let updated_task =
+                cleanup_task_worktree_if_terminal(conn, &updated_task, &next_col, "auto_advance")?;
 
             emit_pipeline(
                 app,

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -2299,6 +2299,7 @@ mod tests {
             r#"{"type":"trigger_task","target_task":"task-123","action":"unblock"}"#,
             r#"{"type":"run_script","script_id":"test-1"}"#,
             r#"{"type":"create_pr","base_branch":"main"}"#,
+            r#"{"type":"auto_merge","base_branch":"main"}"#,
             r#"{"type":"none"}"#,
         ];
         for json in variants {

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -59,6 +59,10 @@ pub enum TriggerActionV2 {
         #[serde(default)]
         base_branch: Option<String>,
     },
+    AutoMerge {
+        #[serde(default)]
+        base_branch: Option<String>,
+    },
     None,
 }
 
@@ -369,6 +373,9 @@ fn execute_action(
         }
         TriggerActionV2::CreatePr { base_branch } => {
             execute_create_pr(conn, app, task, column, base_branch.as_deref())
+        }
+        TriggerActionV2::AutoMerge { base_branch } => {
+            execute_auto_merge(conn, app, task, column, base_branch.as_deref())
         }
         TriggerActionV2::None => Ok(task.clone()),
     }
@@ -887,6 +894,8 @@ fn execute_move_column(
         );
 
         let moved_task = db::get_task(conn, &task.id)?;
+        let moved_task =
+            super::cleanup_task_worktree_if_terminal(conn, &moved_task, &col, "move_column")?;
         super::emit_tasks_changed(app, &task.workspace_id, "trigger_move_column");
         let _ = super::fire_trigger(conn, app, &moved_task, &col);
         return Ok(db::get_task(conn, &task.id)?);
@@ -1318,6 +1327,118 @@ fn maybe_create_ready_batch_pr(
             e
         ),
     }
+}
+
+fn done_column(conn: &Connection, workspace_id: &str) -> Result<Option<Column>, AppError> {
+    let columns = db::list_columns(conn, workspace_id)?;
+    Ok(columns
+        .iter()
+        .find(|col| col.name.eq_ignore_ascii_case("done"))
+        .cloned()
+        .or_else(|| columns.last().cloned()))
+}
+
+fn execute_auto_merge(
+    conn: &Connection,
+    app: &AppHandle,
+    task: &Task,
+    column: &Column,
+    base_branch: Option<&str>,
+) -> Result<Task, AppError> {
+    let workspace = db::get_workspace(conn, &task.workspace_id)?;
+    let base_branch = base_branch.unwrap_or("main");
+    let batch_id = task.batch_id.as_deref().and_then(normalize_batch_id);
+    let selector = if let Some(batch_id) = batch_id.as_deref() {
+        staging_branch_for_batch(batch_id)
+    } else if let Some(pr_url) = task.pr_url.as_deref() {
+        pr_url.to_string()
+    } else if let Some(pr_number) = task.pr_number {
+        pr_number.to_string()
+    } else if let Some(branch_name) = task.branch_name.as_deref() {
+        branch_name.to_string()
+    } else {
+        return super::handle_trigger_failure(
+            conn,
+            app,
+            task,
+            column,
+            "Cannot auto-merge: task has no batch, PR, or branch reference",
+        );
+    };
+
+    let updated_task = db::update_task_pipeline_state(
+        conn,
+        &task.id,
+        PipelineState::Running.as_str(),
+        Some(&db::now()),
+        None,
+    )?;
+    emit_pipeline(
+        app,
+        EVT_RUNNING,
+        &task.id,
+        &column.id,
+        PipelineState::Running,
+        Some(format!("Merging PR for {}", selector)),
+    );
+
+    let output = run_command(
+        &workspace.repo_path,
+        "gh",
+        &["pr", "merge", &selector, "--squash", "--delete-branch"],
+    )
+    .map_err(AppError::CommandError)?;
+    if !output.status.success() {
+        return super::handle_trigger_failure(
+            conn,
+            app,
+            &updated_task,
+            column,
+            &format!(
+                "auto_merge failed for {} into {}: {}",
+                selector,
+                base_branch,
+                command_stderr(&output)
+            ),
+        );
+    }
+
+    let Some(done_col) = done_column(conn, &task.workspace_id)? else {
+        return super::handle_trigger_failure(
+            conn,
+            app,
+            &updated_task,
+            column,
+            "Cannot auto-merge: workspace has no columns",
+        );
+    };
+
+    let tasks = if let Some(batch_id) = batch_id.as_deref() {
+        db::list_tasks_by_batch_id(conn, &task.workspace_id, batch_id)?
+    } else {
+        vec![updated_task]
+    };
+
+    let mut last_updated = None;
+    for batch_task in tasks {
+        let moved = db::append_task_to_column(conn, &batch_task.id, &done_col.id)?;
+        let cleaned =
+            super::cleanup_task_worktree_if_terminal(conn, &moved, &done_col, "auto_merge")?;
+        let _ = super::dependencies::check_dependents(conn, app, &cleaned);
+        last_updated = Some(cleaned);
+    }
+
+    emit_pipeline(
+        app,
+        EVT_ADVANCED,
+        &task.id,
+        &done_col.id,
+        PipelineState::Idle,
+        Some(format!("Merged {} and moved task(s) to Done", selector)),
+    );
+    super::emit_tasks_changed(app, &task.workspace_id, "auto_merge_done");
+
+    Ok(last_updated.unwrap_or_else(|| task.clone()))
 }
 
 fn execute_create_pr(

--- a/src/components/kanban/base-branch-action-editor.tsx
+++ b/src/components/kanban/base-branch-action-editor.tsx
@@ -1,14 +1,14 @@
-import type { AutoMergeAction, CreatePrAction } from '@/types'
+import type { BaseBranchAction } from '@/types'
 
-type CreatePrActionEditorProps = {
-  action: CreatePrAction | AutoMergeAction
-  setAction: (value: CreatePrAction | AutoMergeAction) => void
+type BaseBranchActionEditorProps = {
+  action: BaseBranchAction
+  setAction: (value: BaseBranchAction) => void
 }
 
-export function CreatePrActionEditor({
+export function BaseBranchActionEditor({
   action,
   setAction,
-}: CreatePrActionEditorProps) {
+}: BaseBranchActionEditorProps) {
   return (
     <div className="rounded-lg border border-border-default bg-bg/50 p-3">
       <label className="mb-1 block text-xs font-medium text-text-secondary">

--- a/src/components/kanban/column-config-constants.ts
+++ b/src/components/kanban/column-config-constants.ts
@@ -36,6 +36,7 @@ export const ACTION_TYPES: { value: ActionType; label: string; description: stri
   { value: 'spawn_cli', label: 'Spawn CLI', description: 'Run AI agent with command' },
   { value: 'move_column', label: 'Move Column', description: 'Move task to another column' },
   { value: 'create_pr', label: 'Create PR', description: 'Open a GitHub pull request' },
+  { value: 'auto_merge', label: 'Auto Merge', description: 'Merge PR and finish task' },
 ]
 
 export const CLI_TYPES: { value: CliType; label: string }[] = [

--- a/src/components/kanban/column-trigger-action-editors.tsx
+++ b/src/components/kanban/column-trigger-action-editors.tsx
@@ -3,8 +3,8 @@ import type {
   TriggerAction,
 } from '@/types'
 import { DEFAULT_SPAWN_CLI } from '@/types/column'
+import { BaseBranchActionEditor } from './base-branch-action-editor'
 import { ACTION_TYPES } from './column-config-constants'
-import { CreatePrActionEditor } from './create-pr-action-editor'
 import { MoveColumnActionEditor } from './move-column-action-editor'
 import { RunScriptActionEditor } from './run-script-action-editor'
 import { SpawnCliActionEditor } from './spawn-cli-action-editor'
@@ -81,15 +81,8 @@ export function ActionEditor({
         />
       )}
 
-      {action.type === 'create_pr' && (
-        <CreatePrActionEditor
-          action={action}
-          setAction={(nextAction) => { setAction(nextAction) }}
-        />
-      )}
-
-      {action.type === 'auto_merge' && (
-        <CreatePrActionEditor
+      {(action.type === 'create_pr' || action.type === 'auto_merge') && (
+        <BaseBranchActionEditor
           action={action}
           setAction={(nextAction) => { setAction(nextAction) }}
         />

--- a/src/components/kanban/column-trigger-action-editors.tsx
+++ b/src/components/kanban/column-trigger-action-editors.tsx
@@ -35,6 +35,8 @@ export function ActionEditor({
       setAction({ type: 'move_column', target: 'next' })
     } else if (type === 'create_pr') {
       setAction({ type: 'create_pr', base_branch: 'main' })
+    } else if (type === 'auto_merge') {
+      setAction({ type: 'auto_merge', base_branch: 'main' })
     }
   }
 
@@ -80,6 +82,13 @@ export function ActionEditor({
       )}
 
       {action.type === 'create_pr' && (
+        <CreatePrActionEditor
+          action={action}
+          setAction={(nextAction) => { setAction(nextAction) }}
+        />
+      )}
+
+      {action.type === 'auto_merge' && (
         <CreatePrActionEditor
           action={action}
           setAction={(nextAction) => { setAction(nextAction) }}

--- a/src/components/kanban/create-pr-action-editor.tsx
+++ b/src/components/kanban/create-pr-action-editor.tsx
@@ -1,8 +1,8 @@
-import type { CreatePrAction } from '@/types'
+import type { AutoMergeAction, CreatePrAction } from '@/types'
 
 type CreatePrActionEditorProps = {
-  action: CreatePrAction
-  setAction: (value: CreatePrAction) => void
+  action: CreatePrAction | AutoMergeAction
+  setAction: (value: CreatePrAction | AutoMergeAction) => void
 }
 
 export function CreatePrActionEditor({

--- a/src/types/column.test.ts
+++ b/src/types/column.test.ts
@@ -48,6 +48,18 @@ describe('getColumnTriggers', () => {
     expect(result).toEqual(triggers)
   })
 
+  it('should parse auto_merge trigger actions', () => {
+    const triggers = {
+      on_entry: { type: 'auto_merge' as const, base_branch: 'main' },
+      on_exit: { type: 'none' as const },
+      exit_criteria: { type: 'manual' as const, auto_advance: false },
+    }
+    const column = createMockColumn(JSON.stringify(triggers) as unknown as Column['triggers'])
+
+    const result = getColumnTriggers(column)
+    expect(result).toEqual(triggers)
+  })
+
   it('should return DEFAULT_TRIGGERS when triggers is undefined', () => {
     const column = createMockColumn(undefined)
 

--- a/src/types/column.ts
+++ b/src/types/column.ts
@@ -1,6 +1,6 @@
 // ─── Action Types ───────────────────────────────────────────────────────────
 
-export type ActionType = 'auto_setup' | 'spawn_cli' | 'move_column' | 'trigger_task' | 'run_script' | 'create_pr' | 'none'
+export type ActionType = 'auto_setup' | 'spawn_cli' | 'move_column' | 'trigger_task' | 'run_script' | 'create_pr' | 'auto_merge' | 'none'
 
 export type CliType = 'claude' | 'codex' | 'aider'
 export type TriggerTaskActionType = 'move_column' | 'start' | 'unblock'
@@ -59,11 +59,16 @@ export interface CreatePrAction {
   base_branch?: string
 }
 
+export interface AutoMergeAction {
+  type: 'auto_merge'
+  base_branch?: string
+}
+
 export interface NoneAction {
   type: 'none'
 }
 
-export type TriggerAction = AutoSetupAction | SpawnCliAction | MoveColumnAction | TriggerTaskAction | RunScriptAction | CreatePrAction | NoneAction
+export type TriggerAction = AutoSetupAction | SpawnCliAction | MoveColumnAction | TriggerTaskAction | RunScriptAction | CreatePrAction | AutoMergeAction | NoneAction
 
 // ─── Exit Criteria ──────────────────────────────────────────────────────────
 

--- a/src/types/column.ts
+++ b/src/types/column.ts
@@ -64,6 +64,8 @@ export interface AutoMergeAction {
   base_branch?: string
 }
 
+export type BaseBranchAction = CreatePrAction | AutoMergeAction
+
 export interface NoneAction {
   type: 'none'
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export type {
   RunScriptAction,
   CreatePrAction,
   AutoMergeAction,
+  BaseBranchAction,
   NoneAction,
   ExitCriteria,
   ExitCriteriaType,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export type {
   TriggerTaskActionType,
   RunScriptAction,
   CreatePrAction,
+  AutoMergeAction,
   NoneAction,
   ExitCriteria,
   ExitCriteriaType,


### PR DESCRIPTION
## Description

When auto_merge moves a task to Done, automatically run git worktree remove for that task's worktree (already in spec but verify). Also add nightly sweep: find worktrees not referenced by any non-Done task, log warning. Acceptance: completed task triggers worktree cleanup, sweep runs nightly, cargo check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/auto-cleanup-completed-worktrees-on-done` → `staging/overnight-20260430-bento-ya`

## Commits

```
64d6d88 Polish auto-merge trigger wiring
c404072 Wire auto merge trigger into column config
c477554 Clean up completed task worktrees
```

## Changes

```
mcp-server/src/main.rs                             |  11 +-
 src-tauri/src/commands/column.rs                   |   2 +-
 src-tauri/src/commands/task.rs                     |   7 ++
 src-tauri/src/lib.rs                               | 107 ++++++++++++++++++
 src-tauri/src/pipeline/mod.rs                      |  46 ++++++++
 src-tauri/src/pipeline/triggers.rs                 | 122 +++++++++++++++++++++
 ...on-editor.tsx => base-branch-action-editor.tsx} |  12 +-
 src/components/kanban/column-config-constants.ts   |   1 +
 .../kanban/column-trigger-action-editors.tsx       |   8 +-
 src/types/column.test.ts                           |  12 ++
 src/types/column.ts                                |  11 +-
 src/types/index.ts                                 |   2 +
 12 files changed, 328 insertions(+), 13 deletions(-)
```