### PR TITLE
Keyboard shortcuts overlay (press ? to open)

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { invoke } from '@tauri-apps/api/core'
+
+import App from './app'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import type { Workspace } from '@/types'
+
+vi.mock('@/hooks/use-agent-streaming-sync', () => ({
+  useAgentStreamingSync: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-cli-path', () => ({
+  useAutoDetectClis: vi.fn(() => ({ isDetecting: false })),
+}))
+
+vi.mock('@/hooks/use-pr-status-polling', () => ({
+  usePrStatusPolling: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-task-sync', () => ({
+  useTaskSync: vi.fn(),
+}))
+
+vi.mock('@/components/layout/board', () => ({
+  Board: () => <input aria-label="board input" />,
+}))
+
+vi.mock('@/components/layout/tab-bar', () => ({
+  TabBar: () => <div data-testid="tab-bar" />,
+}))
+
+vi.mock('@/components/layout/workspace-setup', () => ({
+  WorkspaceSetup: () => <div data-testid="workspace-setup" />,
+}))
+
+vi.mock('@/components/onboarding/onboarding-wizard', () => ({
+  OnboardingWizard: () => <div data-testid="onboarding-wizard" />,
+}))
+
+vi.mock('@/components/settings/settings-panel', () => ({
+  SettingsPanel: () => <div data-testid="settings-panel" />,
+}))
+
+vi.mock('@/components/checklist/checklist-panel', () => ({
+  ChecklistPanel: () => <div data-testid="checklist-panel" />,
+}))
+
+vi.mock('@/components/about/about-modal', () => ({
+  AboutModal: ({ onClose }: { onClose: () => void }) => (
+    <button type="button" onClick={onClose}>About</button>
+  ),
+}))
+
+vi.mock('@/components/command-palette/command-palette', () => ({
+  CommandPalette: ({ onClose }: { onClose: () => void }) => (
+    <button type="button" onClick={onClose}>Command Palette</button>
+  ),
+}))
+
+const workspace: Workspace = {
+  id: 'ws-1',
+  name: 'Workspace',
+  repoPath: '/repo',
+  tabOrder: 0,
+  isActive: true,
+  activeTaskCount: 0,
+  config: '{}',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+}
+
+describe('App keyboard shortcuts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(invoke).mockResolvedValue([workspace])
+    useWorkspaceStore.setState({
+      workspaces: [workspace],
+      activeWorkspaceId: workspace.id,
+      loaded: true,
+    })
+  })
+
+  it('opens the keyboard shortcuts modal when question mark is pressed', async () => {
+    render(<App />)
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('list_workspaces', undefined)
+    })
+
+    fireEvent.keyDown(window, { key: '?', shiftKey: true })
+
+    expect(screen.getByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument()
+  })
+
+  it('does not open the keyboard shortcuts modal while typing in an input', async () => {
+    render(<App />)
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('list_workspaces', undefined)
+    })
+
+    fireEvent.keyDown(screen.getByLabelText('board input'), { key: '?', shiftKey: true })
+
+    expect(screen.queryByRole('dialog', { name: /keyboard shortcuts/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -92,6 +92,22 @@ describe('App keyboard shortcuts', () => {
     expect(screen.getByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument()
   })
 
+  it('closes the keyboard shortcuts modal when Escape is pressed', async () => {
+    render(<App />)
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('list_workspaces', undefined)
+    })
+
+    fireEvent.keyDown(window, { key: '?', shiftKey: true })
+    expect(screen.getByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /keyboard shortcuts/i })).not.toBeInTheDocument()
+    })
+  })
+
   it('does not open the keyboard shortcuts modal while typing in an input', async () => {
     render(<App />)
     await waitFor(() => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,6 +16,7 @@ import { SettingsPanel } from '@/components/settings/settings-panel'
 import { ChecklistPanel } from '@/components/checklist/checklist-panel'
 import { AboutModal } from '@/components/about/about-modal'
 import { CommandPalette } from '@/components/command-palette/command-palette'
+import { ShortcutsModal } from '@/components/shortcuts-modal'
 import { SkeletonLoader } from '@/components/shared/skeleton-loader'
 
 function App() {
@@ -26,15 +27,19 @@ function App() {
   const [error, setError] = useState<string | null>(null)
   const [showAbout, setShowAbout] = useState(false)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
+  const [showShortcuts, setShowShortcuts] = useState(false)
 
   // Keyboard shortcuts
   const toggleAbout = useCallback(() => { setShowAbout((prev) => !prev) }, [])
   const toggleCommandPalette = useCallback(() => { setShowCommandPalette((prev) => !prev) }, [])
+  const openShortcuts = useCallback(() => { setShowShortcuts(true) }, [])
   const openSettings = useSettingsStore((s) => s.openSettings)
   useKeyboardShortcuts([
     { key: '/', meta: true, handler: toggleAbout },
     { key: 'k', meta: true, handler: toggleCommandPalette },
     { key: ',', meta: true, handler: openSettings },
+    { key: '?', shift: true, handler: openShortcuts, ignoreEditable: true },
+    { key: 'Escape', handler: () => { setShowShortcuts(false) }, preventDefault: false },
   ])
 
   // Auto-detect CLI paths on startup
@@ -98,10 +103,11 @@ function App() {
       {/* Modals */}
       <AnimatePresence>
         {showAbout && <AboutModal onClose={() => { setShowAbout(false) }} />}
+        {showShortcuts && <ShortcutsModal onClose={() => { setShowShortcuts(false) }} />}
         {showCommandPalette && (
           <CommandPalette
             onClose={() => { setShowCommandPalette(false) }}
-            onShowShortcuts={() => { setShowCommandPalette(false); setShowAbout(true) }}
+            onShowShortcuts={() => { setShowCommandPalette(false); setShowShortcuts(true) }}
           />
         )}
       </AnimatePresence>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -38,6 +38,7 @@ function App() {
     { key: '/', meta: true, handler: toggleAbout },
     { key: 'k', meta: true, handler: toggleCommandPalette },
     { key: ',', meta: true, handler: openSettings },
+    { key: '?', handler: openShortcuts, ignoreEditable: true },
     { key: '?', shift: true, handler: openShortcuts, ignoreEditable: true },
     { key: 'Escape', handler: () => { setShowShortcuts(false) }, preventDefault: false },
   ])

--- a/src/components/about/about-modal.tsx
+++ b/src/components/about/about-modal.tsx
@@ -9,7 +9,8 @@ const VERSION = '1.0.0'
 const SHORTCUTS = [
   { category: 'Global', items: [
     { keys: ['Cmd', 'K'], desc: 'Command palette' },
-    { keys: ['Cmd', '/'], desc: 'Keyboard shortcuts' },
+    { keys: ['?'], desc: 'Keyboard shortcuts' },
+    { keys: ['Cmd', '/'], desc: 'About Bento-ya' },
     { keys: ['Esc'], desc: 'Close panel / cancel' },
   ]},
   { category: 'Workspaces', items: [

--- a/src/components/about/about-modal.tsx
+++ b/src/components/about/about-modal.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'motion/react'
 import { KEYBOARD_SHORTCUT_SECTIONS } from '@/lib/keyboard-shortcuts'
+import { KeyboardShortcutSequence } from '@/components/shared/keyboard-shortcut-sequence'
 
 type Props = {
   onClose: () => void
@@ -85,21 +86,13 @@ export function AboutModal({ onClose }: Props) {
                     {section.category}
                   </h5>
                   <div className="space-y-1.5">
-                    {section.items.map((item, i) => (
-                      <div key={i} className="flex items-center justify-between text-sm">
-                        <span className="text-text-secondary">{item.desc}</span>
-                        <div className="flex items-center gap-1">
-                          {item.keys.map((key, j) => (
-                            <span key={j}>
-                              <kbd className="rounded bg-surface px-1.5 py-0.5 font-mono text-xs text-text-primary">
-                                {key}
-                              </kbd>
-                              {j < item.keys.length - 1 && (
-                                <span className="mx-0.5 text-text-secondary">+</span>
-                              )}
-                            </span>
-                          ))}
-                        </div>
+                    {section.items.map((item) => (
+                      <div key={`${section.category}-${item.keys.join('+')}-${item.description}`} className="flex items-center justify-between text-sm">
+                        <span className="text-text-secondary">{item.description}</span>
+                        <KeyboardShortcutSequence
+                          keys={item.keys}
+                          keyClassName="rounded bg-surface px-1.5 py-0.5 font-mono text-xs text-text-primary"
+                        />
                       </div>
                     ))}
                   </div>

--- a/src/components/about/about-modal.tsx
+++ b/src/components/about/about-modal.tsx
@@ -1,37 +1,11 @@
 import { motion } from 'motion/react'
+import { KEYBOARD_SHORTCUT_SECTIONS } from '@/lib/keyboard-shortcuts'
 
 type Props = {
   onClose: () => void
 }
 
 const VERSION = '1.0.0'
-
-const SHORTCUTS = [
-  { category: 'Global', items: [
-    { keys: ['Cmd', 'K'], desc: 'Command palette' },
-    { keys: ['?'], desc: 'Keyboard shortcuts' },
-    { keys: ['Cmd', '/'], desc: 'About Bento-ya' },
-    { keys: ['Esc'], desc: 'Close panel / cancel' },
-  ]},
-  { category: 'Workspaces', items: [
-    { keys: ['Cmd', '1-9'], desc: 'Switch to workspace 1-9' },
-    { keys: ['Cmd', 'T'], desc: 'New workspace' },
-    { keys: ['Cmd', 'W'], desc: 'Close workspace' },
-    { keys: ['Ctrl', 'Tab'], desc: 'Next workspace' },
-    { keys: ['Ctrl', 'Shift', 'Tab'], desc: 'Previous workspace' },
-  ]},
-  { category: 'Task Cards', items: [
-    { keys: ['Enter'], desc: 'Open task' },
-    { keys: ['Space'], desc: 'Open task (peek)' },
-    { keys: ['D'], desc: 'Duplicate task' },
-    { keys: ['L'], desc: 'Link dependencies' },
-    { keys: ['M'], desc: 'Move task menu' },
-    { keys: ['Del'], desc: 'Delete task menu' },
-  ]},
-  { category: 'Terminal', items: [
-    { keys: ['Ctrl', 'C'], desc: 'Interrupt process' },
-  ]},
-]
 
 export function AboutModal({ onClose }: Props) {
   return (
@@ -105,7 +79,7 @@ export function AboutModal({ onClose }: Props) {
           <div className="rounded-xl border border-border-default bg-bg p-4">
             <h4 className="mb-4 font-medium text-text-primary">Keyboard Shortcuts</h4>
             <div className="space-y-4">
-              {SHORTCUTS.map((section) => (
+              {KEYBOARD_SHORTCUT_SECTIONS.map((section) => (
                 <div key={section.category}>
                   <h5 className="mb-2 text-xs font-medium uppercase tracking-wide text-text-secondary">
                     {section.category}

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -5,6 +5,7 @@ import { useColumnStore } from '@/stores/column-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useUIStore } from '@/stores/ui-store'
 import { useSettingsStore } from '@/stores/settings-store'
+import { KeyboardShortcutSequence } from '@/components/shared/keyboard-shortcut-sequence'
 
 type Command = {
   id: string
@@ -84,7 +85,7 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
   const createTaskFromSearch = useCallback(() => {
     const firstColumn = [...columns].sort((a, b) => a.position - b.position)[0]
     if (firstColumn && activeWorkspaceId) {
-      void addTask(activeWorkspaceId, firstColumn.id, search || 'New Task', '')
+      void addTask(activeWorkspaceId, firstColumn.id, search.trim() || 'New Task', '')
     }
   }, [activeWorkspaceId, addTask, columns, search])
 
@@ -190,7 +191,7 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
     }
 
     return cmds
-  }, [tasks, workspaces, activeWorkspaceId, activeTaskId, search, focusTask, closeChat, duplicateTask, setActiveWorkspace, togglePanel, openSettings, setActiveTab, onShowShortcuts, createTaskFromSearch])
+  }, [tasks, workspaces, activeWorkspaceId, activeTaskId, focusTask, closeChat, duplicateTask, setActiveWorkspace, togglePanel, openSettings, setActiveTab, onShowShortcuts, createTaskFromSearch])
 
   // Filter commands
   const filtered = useMemo(() => {
@@ -236,10 +237,12 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault()
+        if (flatList.length === 0) break
         setSelectedIndex((prev) => (prev + 1) % flatList.length)
         break
       case 'ArrowUp':
         e.preventDefault()
+        if (flatList.length === 0) break
         setSelectedIndex((prev) => (prev - 1 + flatList.length) % flatList.length)
         break
       case 'Enter':
@@ -331,18 +334,12 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
                       </span>
                       <span className="flex-1 truncate">{cmd.label}</span>
                       {cmd.shortcut && (
-                        <div className="flex items-center gap-0.5">
-                          {cmd.shortcut.map((key, j) => (
-                            <span key={j}>
-                              <kbd className="rounded bg-bg px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
-                                {key}
-                              </kbd>
-                              {j < (cmd.shortcut?.length ?? 0) - 1 && (
-                                <span className="mx-0.5 text-[10px] text-text-secondary">+</span>
-                              )}
-                            </span>
-                          ))}
-                        </div>
+                        <KeyboardShortcutSequence
+                          keys={cmd.shortcut}
+                          className="flex items-center gap-0.5"
+                          keyClassName="rounded bg-bg px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
+                          separatorClassName="mx-0.5 text-[10px] text-text-secondary"
+                        />
                       )}
                     </div>
                   )

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -164,7 +164,7 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
       id: 'settings-shortcuts',
       label: 'Show keyboard shortcuts',
       category: 'Settings',
-      shortcut: ['Cmd', '/'],
+      shortcut: ['?'],
       action: () => { onShowShortcuts() },
     })
 

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -81,6 +81,13 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
   const openSettings = useSettingsStore((s) => s.openSettings)
   const setActiveTab = useSettingsStore((s) => s.setActiveTab)
 
+  const createTaskFromSearch = useCallback(() => {
+    const firstColumn = [...columns].sort((a, b) => a.position - b.position)[0]
+    if (firstColumn && activeWorkspaceId) {
+      void addTask(activeWorkspaceId, firstColumn.id, search || 'New Task', '')
+    }
+  }, [activeWorkspaceId, addTask, columns, search])
+
   // Build command list
   const commands = useMemo<Command[]>(() => {
     const cmds: Command[] = []
@@ -110,12 +117,7 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
       label: 'Create new task',
       category: 'Tasks',
       shortcut: ['Cmd', 'Enter'],
-      action: () => {
-        const firstColumn = columns.sort((a, b) => a.position - b.position)[0]
-        if (firstColumn && activeWorkspaceId) {
-          void addTask(activeWorkspaceId, firstColumn.id, search || 'New Task', '')
-        }
-      },
+      action: createTaskFromSearch,
     })
 
     // Tasks: duplicate active task
@@ -188,7 +190,7 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
     }
 
     return cmds
-  }, [tasks, columns, workspaces, activeWorkspaceId, activeTaskId, search, focusTask, closeChat, addTask, duplicateTask, setActiveWorkspace, togglePanel, openSettings, setActiveTab, onShowShortcuts])
+  }, [tasks, workspaces, activeWorkspaceId, activeTaskId, search, focusTask, closeChat, duplicateTask, setActiveWorkspace, togglePanel, openSettings, setActiveTab, onShowShortcuts, createTaskFromSearch])
 
   // Filter commands
   const filtered = useMemo(() => {
@@ -242,6 +244,11 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
         break
       case 'Enter':
         e.preventDefault()
+        if (e.metaKey || e.ctrlKey) {
+          createTaskFromSearch()
+          onClose()
+          break
+        }
         if (flatList[selectedIndex]) {
           executeCommand(flatList[selectedIndex])
         }
@@ -251,7 +258,7 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
         onClose()
         break
     }
-  }, [flatList, selectedIndex, executeCommand, onClose])
+  }, [flatList, selectedIndex, executeCommand, onClose, createTaskFromSearch])
 
   // Track flat index for rendering
   let flatIndex = -1

--- a/src/components/shared/keyboard-shortcut-sequence.tsx
+++ b/src/components/shared/keyboard-shortcut-sequence.tsx
@@ -1,0 +1,26 @@
+type KeyboardShortcutSequenceProps = {
+  keys: readonly string[]
+  className?: string
+  keyClassName?: string
+  separatorClassName?: string
+}
+
+export function KeyboardShortcutSequence({
+  keys,
+  className = 'flex items-center gap-1',
+  keyClassName = 'rounded bg-bg px-1.5 py-0.5 font-mono text-xs text-text-primary',
+  separatorClassName = 'mx-0.5 text-text-secondary',
+}: KeyboardShortcutSequenceProps) {
+  return (
+    <div className={className}>
+      {keys.map((key, index) => (
+        <span key={`${key}-${String(index)}`} className="inline-flex items-center gap-1">
+          <kbd className={keyClassName}>{key}</kbd>
+          {index < keys.length - 1 && (
+            <span className={separatorClassName}>+</span>
+          )}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/shortcuts-modal.test.tsx
+++ b/src/components/shortcuts-modal.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ShortcutsModal } from './shortcuts-modal'
+
+describe('ShortcutsModal', () => {
+  it('lists the current task, search, and workspace shortcuts', () => {
+    render(<ShortcutsModal onClose={vi.fn()} />)
+
+    expect(screen.getByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument()
+    expect(screen.getByText('Search and command palette')).toBeInTheDocument()
+    expect(screen.getByText('Switch workspace')).toBeInTheDocument()
+    expect(screen.getByText('Move task to next column')).toBeInTheDocument()
+    expect(screen.getByText('Run or stop agent')).toBeInTheDocument()
+    expect(screen.getByText('Retry failed pipeline')).toBeInTheDocument()
+    expect(screen.getAllByText('Confirm/delete task')).toHaveLength(2)
+  })
+
+  it('closes when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(<ShortcutsModal onClose={onClose} />)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -1,26 +1,10 @@
 import { motion } from 'motion/react'
 import { KEYBOARD_SHORTCUT_SECTIONS } from '@/lib/keyboard-shortcuts'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
+import { KeyboardShortcutSequence } from '@/components/shared/keyboard-shortcut-sequence'
 
 type Props = {
   onClose: () => void
-}
-
-function KbdSequence({ keys }: { keys: string[] }) {
-  return (
-    <div className="flex min-w-[116px] flex-wrap justify-end gap-1">
-      {keys.map((key, index) => (
-        <span key={`${key}-${String(index)}`} className="inline-flex items-center gap-1">
-          <kbd className="rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] leading-5 text-text-primary">
-            {key}
-          </kbd>
-          {index < keys.length - 1 && (
-            <span className="text-xs text-text-secondary">+</span>
-          )}
-        </span>
-      ))}
-    </div>
-  )
 }
 
 export function ShortcutsModal({ onClose }: Props) {
@@ -67,9 +51,14 @@ export function ShortcutsModal({ onClose }: Props) {
                 </h3>
                 <div className="space-y-2">
                   {section.items.map((item) => (
-                    <div key={`${section.category}-${item.keys.join('+')}-${item.desc}`} className="flex items-start justify-between gap-3 text-sm">
-                      <span className="min-w-0 text-text-secondary">{item.desc}</span>
-                      <KbdSequence keys={item.keys} />
+                    <div key={`${section.category}-${item.keys.join('+')}-${item.description}`} className="flex items-start justify-between gap-3 text-sm">
+                      <span className="min-w-0 text-text-secondary">{item.description}</span>
+                      <KeyboardShortcutSequence
+                        keys={item.keys}
+                        className="flex min-w-[116px] flex-wrap justify-end gap-1"
+                        keyClassName="rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] leading-5 text-text-primary"
+                        separatorClassName="text-xs text-text-secondary"
+                      />
                     </div>
                   ))}
                 </div>

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -1,0 +1,151 @@
+import { motion } from 'motion/react'
+
+type ShortcutItem = {
+  keys: string[]
+  desc: string
+}
+
+type ShortcutSection = {
+  category: string
+  items: ShortcutItem[]
+}
+
+type Props = {
+  onClose: () => void
+}
+
+const SHORTCUT_SECTIONS: ShortcutSection[] = [
+  {
+    category: 'Global',
+    items: [
+      { keys: ['?'], desc: 'Show keyboard shortcuts' },
+      { keys: ['Cmd', 'K'], desc: 'Search and command palette' },
+      { keys: ['Cmd', ','], desc: 'Open settings' },
+      { keys: ['Cmd', '/'], desc: 'About Bento-ya' },
+      { keys: ['Esc'], desc: 'Close panel or cancel' },
+    ],
+  },
+  {
+    category: 'Workspaces',
+    items: [
+      { keys: ['Cmd', '1-9'], desc: 'Switch workspace' },
+      { keys: ['Cmd', 'T'], desc: 'New workspace' },
+      { keys: ['Cmd', 'W'], desc: 'Close workspace' },
+      { keys: ['Ctrl', 'Tab'], desc: 'Next workspace' },
+      { keys: ['Ctrl', 'Shift', 'Tab'], desc: 'Previous workspace' },
+    ],
+  },
+  {
+    category: 'Board',
+    items: [
+      { keys: ['Cmd', 'J'], desc: 'Toggle chef panel' },
+      { keys: ['Cmd', 'L'], desc: 'Close task chat panel' },
+      { keys: ['Cmd', 'Drag'], desc: 'Link task dependencies' },
+    ],
+  },
+  {
+    category: 'Task Cards',
+    items: [
+      { keys: ['Enter'], desc: 'Open task' },
+      { keys: ['Space'], desc: 'Run or stop agent' },
+      { keys: ['R'], desc: 'Retry failed pipeline' },
+      { keys: ['ArrowRight'], desc: 'Move task to next column' },
+      { keys: ['M'], desc: 'Open move task menu' },
+      { keys: ['D'], desc: 'Duplicate task' },
+      { keys: ['L'], desc: 'Edit dependencies' },
+      { keys: ['Del'], desc: 'Delete task' },
+      { keys: ['Backspace'], desc: 'Delete task' },
+    ],
+  },
+  {
+    category: 'Command Palette',
+    items: [
+      { keys: ['ArrowDown'], desc: 'Select next command' },
+      { keys: ['ArrowUp'], desc: 'Select previous command' },
+      { keys: ['Enter'], desc: 'Run selected command' },
+      { keys: ['Cmd', 'Enter'], desc: 'Create task from search text' },
+      { keys: ['Esc'], desc: 'Close command palette' },
+    ],
+  },
+  {
+    category: 'Editing',
+    items: [
+      { keys: ['Enter'], desc: 'Submit inline task or checklist item' },
+      { keys: ['Esc'], desc: 'Cancel inline edit' },
+    ],
+  },
+]
+
+function KbdSequence({ keys }: { keys: string[] }) {
+  return (
+    <div className="flex min-w-[116px] flex-wrap justify-end gap-1">
+      {keys.map((key, index) => (
+        <span key={`${key}-${index}`} className="inline-flex items-center gap-1">
+          <kbd className="rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] leading-5 text-text-primary">
+            {key}
+          </kbd>
+          {index < keys.length - 1 && (
+            <span className="text-xs text-text-secondary">+</span>
+          )}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function ShortcutsModal({ onClose }: Props) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <motion.div
+        initial={{ scale: 0.96, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.96, opacity: 0 }}
+        className="flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-border-default bg-surface shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcuts-title"
+      >
+        <div className="flex items-center justify-between border-b border-border-default px-5 py-4">
+          <h2 id="shortcuts-title" className="text-base font-semibold text-text-primary">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 text-text-secondary transition-colors hover:bg-bg hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-accent/50"
+            aria-label="Close keyboard shortcuts"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+              <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="overflow-y-auto p-5">
+          <div className="grid gap-4 md:grid-cols-2">
+            {SHORTCUT_SECTIONS.map((section) => (
+              <section key={section.category} className="rounded-lg border border-border-default bg-bg/60 p-3">
+                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+                  {section.category}
+                </h3>
+                <div className="space-y-2">
+                  {section.items.map((item) => (
+                    <div key={`${section.category}-${item.desc}`} className="flex items-start justify-between gap-3 text-sm">
+                      <span className="min-w-0 text-text-secondary">{item.desc}</span>
+                      <KbdSequence keys={item.keys} />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </motion.div>
+    </motion.div>
+  )
+}

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { motion } from 'motion/react'
 
 type ShortcutItem = {
@@ -102,6 +103,19 @@ function KbdSequence({ keys }: { keys: string[] }) {
 }
 
 export function ShortcutsModal({ onClose }: Props) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onClose])
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -143,7 +157,7 @@ export function ShortcutsModal({ onClose }: Props) {
                 </h3>
                 <div className="space-y-2">
                   {section.items.map((item) => (
-                    <div key={`${section.category}-${item.desc}`} className="flex items-start justify-between gap-3 text-sm">
+                    <div key={`${section.category}-${item.keys.join('+')}-${item.desc}`} className="flex items-start justify-between gap-3 text-sm">
                       <span className="min-w-0 text-text-secondary">{item.desc}</span>
                       <KbdSequence keys={item.keys} />
                     </div>

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -41,6 +41,7 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
       { keys: ['Cmd', 'J'], desc: 'Toggle chef panel' },
       { keys: ['Cmd', 'L'], desc: 'Close task chat panel' },
       { keys: ['Cmd', 'Drag'], desc: 'Link task dependencies' },
+      { keys: ['Esc'], desc: 'Cancel dependency link' },
     ],
   },
   {
@@ -53,8 +54,8 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
       { keys: ['M'], desc: 'Open move task menu' },
       { keys: ['D'], desc: 'Duplicate task' },
       { keys: ['L'], desc: 'Edit dependencies' },
-      { keys: ['Del'], desc: 'Delete task' },
-      { keys: ['Backspace'], desc: 'Delete task' },
+      { keys: ['Del'], desc: 'Confirm/delete task' },
+      { keys: ['Backspace'], desc: 'Confirm/delete task' },
     ],
   },
   {
@@ -70,8 +71,15 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
   {
     category: 'Editing',
     items: [
-      { keys: ['Enter'], desc: 'Submit inline task or checklist item' },
+      { keys: ['Enter'], desc: 'Submit message, task, or checklist item' },
+      { keys: ['Shift', 'Enter'], desc: 'Insert newline in message' },
       { keys: ['Esc'], desc: 'Cancel inline edit' },
+    ],
+  },
+  {
+    category: 'Terminal',
+    items: [
+      { keys: ['Ctrl', 'C'], desc: 'Interrupt process' },
     ],
   },
 ]

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from 'react'
 import { motion } from 'motion/react'
 import { KEYBOARD_SHORTCUT_SECTIONS } from '@/lib/keyboard-shortcuts'
+import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 
 type Props = {
   onClose: () => void
@@ -24,18 +24,7 @@ function KbdSequence({ keys }: { keys: string[] }) {
 }
 
 export function ShortcutsModal({ onClose }: Props) {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose()
-      }
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [onClose])
+  useKeyboardShortcuts([{ key: 'Escape', handler: onClose, preventDefault: false }])
 
   return (
     <motion.div

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -1,95 +1,16 @@
 import { useEffect } from 'react'
 import { motion } from 'motion/react'
-
-type ShortcutItem = {
-  keys: string[]
-  desc: string
-}
-
-type ShortcutSection = {
-  category: string
-  items: ShortcutItem[]
-}
+import { KEYBOARD_SHORTCUT_SECTIONS } from '@/lib/keyboard-shortcuts'
 
 type Props = {
   onClose: () => void
 }
 
-const SHORTCUT_SECTIONS: ShortcutSection[] = [
-  {
-    category: 'Global',
-    items: [
-      { keys: ['?'], desc: 'Show keyboard shortcuts' },
-      { keys: ['Cmd', 'K'], desc: 'Search and command palette' },
-      { keys: ['Cmd', ','], desc: 'Open settings' },
-      { keys: ['Cmd', '/'], desc: 'About Bento-ya' },
-      { keys: ['Esc'], desc: 'Close panel or cancel' },
-    ],
-  },
-  {
-    category: 'Workspaces',
-    items: [
-      { keys: ['Cmd', '1-9'], desc: 'Switch workspace' },
-      { keys: ['Cmd', 'T'], desc: 'New workspace' },
-      { keys: ['Cmd', 'W'], desc: 'Close workspace' },
-      { keys: ['Ctrl', 'Tab'], desc: 'Next workspace' },
-      { keys: ['Ctrl', 'Shift', 'Tab'], desc: 'Previous workspace' },
-    ],
-  },
-  {
-    category: 'Board',
-    items: [
-      { keys: ['Cmd', 'J'], desc: 'Toggle chef panel' },
-      { keys: ['Cmd', 'L'], desc: 'Close task chat panel' },
-      { keys: ['Cmd', 'Drag'], desc: 'Link task dependencies' },
-      { keys: ['Esc'], desc: 'Cancel dependency link' },
-    ],
-  },
-  {
-    category: 'Task Cards',
-    items: [
-      { keys: ['Enter'], desc: 'Open task' },
-      { keys: ['Space'], desc: 'Run or stop agent' },
-      { keys: ['R'], desc: 'Retry failed pipeline' },
-      { keys: ['ArrowRight'], desc: 'Move task to next column' },
-      { keys: ['M'], desc: 'Open move task menu' },
-      { keys: ['D'], desc: 'Duplicate task' },
-      { keys: ['L'], desc: 'Edit dependencies' },
-      { keys: ['Del'], desc: 'Confirm/delete task' },
-      { keys: ['Backspace'], desc: 'Confirm/delete task' },
-    ],
-  },
-  {
-    category: 'Command Palette',
-    items: [
-      { keys: ['ArrowDown'], desc: 'Select next command' },
-      { keys: ['ArrowUp'], desc: 'Select previous command' },
-      { keys: ['Enter'], desc: 'Run selected command' },
-      { keys: ['Cmd', 'Enter'], desc: 'Create task from search text' },
-      { keys: ['Esc'], desc: 'Close command palette' },
-    ],
-  },
-  {
-    category: 'Editing',
-    items: [
-      { keys: ['Enter'], desc: 'Submit message, task, or checklist item' },
-      { keys: ['Shift', 'Enter'], desc: 'Insert newline in message' },
-      { keys: ['Esc'], desc: 'Cancel inline edit' },
-    ],
-  },
-  {
-    category: 'Terminal',
-    items: [
-      { keys: ['Ctrl', 'C'], desc: 'Interrupt process' },
-    ],
-  },
-]
-
 function KbdSequence({ keys }: { keys: string[] }) {
   return (
     <div className="flex min-w-[116px] flex-wrap justify-end gap-1">
       {keys.map((key, index) => (
-        <span key={`${key}-${index}`} className="inline-flex items-center gap-1">
+        <span key={`${key}-${String(index)}`} className="inline-flex items-center gap-1">
           <kbd className="rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] leading-5 text-text-primary">
             {key}
           </kbd>
@@ -150,7 +71,7 @@ export function ShortcutsModal({ onClose }: Props) {
 
         <div className="overflow-y-auto p-5">
           <div className="grid gap-4 md:grid-cols-2">
-            {SHORTCUT_SECTIONS.map((section) => (
+            {KEYBOARD_SHORTCUT_SECTIONS.map((section) => (
               <section key={section.category} className="rounded-lg border border-border-default bg-bg/60 p-3">
                 <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-secondary">
                   {section.category}

--- a/src/hooks/use-keyboard-shortcuts.test.tsx
+++ b/src/hooks/use-keyboard-shortcuts.test.tsx
@@ -10,6 +10,7 @@ function ShortcutHarness({
   onEscape: () => void
 }) {
   useKeyboardShortcuts([
+    { key: '?', handler: onShortcut, ignoreEditable: true },
     { key: '?', shift: true, handler: onShortcut, ignoreEditable: true },
     { key: 'Escape', handler: onEscape, preventDefault: false },
   ])
@@ -28,6 +29,15 @@ describe('useKeyboardShortcuts', () => {
     render(<ShortcutHarness onShortcut={onShortcut} onEscape={vi.fn()} />)
 
     fireEvent.keyDown(window, { key: '?', shiftKey: true })
+
+    expect(onShortcut).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs a question-mark shortcut when the event is already normalized', () => {
+    const onShortcut = vi.fn()
+    render(<ShortcutHarness onShortcut={onShortcut} onEscape={vi.fn()} />)
+
+    fireEvent.keyDown(window, { key: '?' })
 
     expect(onShortcut).toHaveBeenCalledTimes(1)
   })

--- a/src/hooks/use-keyboard-shortcuts.test.tsx
+++ b/src/hooks/use-keyboard-shortcuts.test.tsx
@@ -1,0 +1,54 @@
+import { render, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useKeyboardShortcuts } from './use-keyboard-shortcuts'
+
+function ShortcutHarness({
+  onShortcut,
+  onEscape,
+}: {
+  onShortcut: () => void
+  onEscape: () => void
+}) {
+  useKeyboardShortcuts([
+    { key: '?', shift: true, handler: onShortcut, ignoreEditable: true },
+    { key: 'Escape', handler: onEscape, preventDefault: false },
+  ])
+
+  return (
+    <div>
+      <input aria-label="editable" />
+      <button type="button">button</button>
+    </div>
+  )
+}
+
+describe('useKeyboardShortcuts', () => {
+  it('runs a shifted shortcut when focus is not in an editable element', () => {
+    const onShortcut = vi.fn()
+    render(<ShortcutHarness onShortcut={onShortcut} onEscape={vi.fn()} />)
+
+    fireEvent.keyDown(window, { key: '?', shiftKey: true })
+
+    expect(onShortcut).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores editable targets when requested', () => {
+    const onShortcut = vi.fn()
+    const { getByLabelText } = render(<ShortcutHarness onShortcut={onShortcut} onEscape={vi.fn()} />)
+
+    fireEvent.keyDown(getByLabelText('editable'), { key: '?', shiftKey: true })
+
+    expect(onShortcut).not.toHaveBeenCalled()
+  })
+
+  it('can run Escape without preventing the default event', () => {
+    const onEscape = vi.fn()
+    render(<ShortcutHarness onShortcut={vi.fn()} onEscape={onEscape} />)
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(onEscape).toHaveBeenCalledTimes(1)
+    expect(event.defaultPrevented).toBe(false)
+  })
+})

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -15,7 +15,7 @@ type ShortcutConfig = {
   ignoreEditable?: boolean
 }
 
-function isEditableTarget(target: EventTarget | null) {
+function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false
 
   const tag = target.tagName

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -12,12 +12,32 @@ type ShortcutConfig = {
   alt?: boolean
   handler: ShortcutHandler
   preventDefault?: boolean
+  ignoreEditable?: boolean
+}
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false
+
+  const tag = target.tagName
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    target.isContentEditable ||
+    !!target.closest('[contenteditable="true"]')
+  )
 }
 
 export function useKeyboardShortcuts(shortcuts: ShortcutConfig[]) {
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return
+
       for (const shortcut of shortcuts) {
+        if (shortcut.ignoreEditable && isEditableTarget(event.target)) {
+          continue
+        }
+
         const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase()
         const ctrlMatch = shortcut.ctrl ? event.ctrlKey : !event.ctrlKey || shortcut.meta
         const metaMatch = shortcut.meta ? event.metaKey : !event.metaKey || shortcut.ctrl

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -1,79 +1,79 @@
 export type ShortcutItem = {
-  keys: string[]
-  desc: string
+  keys: readonly string[]
+  description: string
 }
 
 export type ShortcutSection = {
   category: string
-  items: ShortcutItem[]
+  items: readonly ShortcutItem[]
 }
 
-export const KEYBOARD_SHORTCUT_SECTIONS: ShortcutSection[] = [
+export const KEYBOARD_SHORTCUT_SECTIONS: readonly ShortcutSection[] = [
   {
     category: 'Global',
     items: [
-      { keys: ['?'], desc: 'Show keyboard shortcuts' },
-      { keys: ['Cmd', 'K'], desc: 'Search and command palette' },
-      { keys: ['Cmd', ','], desc: 'Open settings' },
-      { keys: ['Cmd', '/'], desc: 'About Bento-ya' },
-      { keys: ['Esc'], desc: 'Close panel or cancel' },
+      { keys: ['?'], description: 'Show keyboard shortcuts' },
+      { keys: ['Cmd', 'K'], description: 'Search and command palette' },
+      { keys: ['Cmd', ','], description: 'Open settings' },
+      { keys: ['Cmd', '/'], description: 'About Bento-ya' },
+      { keys: ['Esc'], description: 'Close panel or cancel' },
     ],
   },
   {
     category: 'Workspaces',
     items: [
-      { keys: ['Cmd', '1-9'], desc: 'Switch workspace' },
-      { keys: ['Cmd', 'T'], desc: 'New workspace' },
-      { keys: ['Cmd', 'W'], desc: 'Close workspace' },
-      { keys: ['Ctrl', 'Tab'], desc: 'Next workspace' },
-      { keys: ['Ctrl', 'Shift', 'Tab'], desc: 'Previous workspace' },
+      { keys: ['Cmd', '1-9'], description: 'Switch workspace' },
+      { keys: ['Cmd', 'T'], description: 'New workspace' },
+      { keys: ['Cmd', 'W'], description: 'Close workspace' },
+      { keys: ['Ctrl', 'Tab'], description: 'Next workspace' },
+      { keys: ['Ctrl', 'Shift', 'Tab'], description: 'Previous workspace' },
     ],
   },
   {
     category: 'Board',
     items: [
-      { keys: ['Cmd', 'J'], desc: 'Toggle chef panel' },
-      { keys: ['Cmd', 'L'], desc: 'Close task chat panel' },
-      { keys: ['Cmd', 'Drag'], desc: 'Link task dependencies' },
-      { keys: ['Esc'], desc: 'Cancel dependency link' },
+      { keys: ['Cmd', 'J'], description: 'Toggle chef panel' },
+      { keys: ['Cmd', 'L'], description: 'Close task chat panel' },
+      { keys: ['Cmd', 'Drag'], description: 'Link task dependencies' },
+      { keys: ['Esc'], description: 'Cancel dependency link' },
     ],
   },
   {
     category: 'Task Cards',
     items: [
-      { keys: ['Enter'], desc: 'Open task' },
-      { keys: ['Space'], desc: 'Run or stop agent' },
-      { keys: ['R'], desc: 'Retry failed pipeline' },
-      { keys: ['ArrowRight'], desc: 'Move task to next column' },
-      { keys: ['M'], desc: 'Open move task menu' },
-      { keys: ['D'], desc: 'Duplicate task' },
-      { keys: ['L'], desc: 'Edit dependencies' },
-      { keys: ['Del'], desc: 'Confirm/delete task' },
-      { keys: ['Backspace'], desc: 'Confirm/delete task' },
+      { keys: ['Enter'], description: 'Open task' },
+      { keys: ['Space'], description: 'Run or stop agent' },
+      { keys: ['R'], description: 'Retry failed pipeline' },
+      { keys: ['ArrowRight'], description: 'Move task to next column' },
+      { keys: ['M'], description: 'Open move task menu' },
+      { keys: ['D'], description: 'Duplicate task' },
+      { keys: ['L'], description: 'Edit dependencies' },
+      { keys: ['Del'], description: 'Confirm/delete task' },
+      { keys: ['Backspace'], description: 'Confirm/delete task' },
     ],
   },
   {
     category: 'Command Palette',
     items: [
-      { keys: ['ArrowDown'], desc: 'Select next command' },
-      { keys: ['ArrowUp'], desc: 'Select previous command' },
-      { keys: ['Enter'], desc: 'Run selected command' },
-      { keys: ['Cmd', 'Enter'], desc: 'Create task from search text' },
-      { keys: ['Esc'], desc: 'Close command palette' },
+      { keys: ['ArrowDown'], description: 'Select next command' },
+      { keys: ['ArrowUp'], description: 'Select previous command' },
+      { keys: ['Enter'], description: 'Run selected command' },
+      { keys: ['Cmd', 'Enter'], description: 'Create task from search text' },
+      { keys: ['Esc'], description: 'Close command palette' },
     ],
   },
   {
     category: 'Editing',
     items: [
-      { keys: ['Enter'], desc: 'Submit message, task, or checklist item' },
-      { keys: ['Shift', 'Enter'], desc: 'Insert newline in message' },
-      { keys: ['Esc'], desc: 'Cancel inline edit' },
+      { keys: ['Enter'], description: 'Submit message, task, or checklist item' },
+      { keys: ['Shift', 'Enter'], description: 'Insert newline in message' },
+      { keys: ['Esc'], description: 'Cancel inline edit' },
     ],
   },
   {
     category: 'Terminal',
     items: [
-      { keys: ['Ctrl', 'C'], desc: 'Interrupt process' },
+      { keys: ['Ctrl', 'C'], description: 'Interrupt process' },
     ],
   },
 ]

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -1,0 +1,79 @@
+export type ShortcutItem = {
+  keys: string[]
+  desc: string
+}
+
+export type ShortcutSection = {
+  category: string
+  items: ShortcutItem[]
+}
+
+export const KEYBOARD_SHORTCUT_SECTIONS: ShortcutSection[] = [
+  {
+    category: 'Global',
+    items: [
+      { keys: ['?'], desc: 'Show keyboard shortcuts' },
+      { keys: ['Cmd', 'K'], desc: 'Search and command palette' },
+      { keys: ['Cmd', ','], desc: 'Open settings' },
+      { keys: ['Cmd', '/'], desc: 'About Bento-ya' },
+      { keys: ['Esc'], desc: 'Close panel or cancel' },
+    ],
+  },
+  {
+    category: 'Workspaces',
+    items: [
+      { keys: ['Cmd', '1-9'], desc: 'Switch workspace' },
+      { keys: ['Cmd', 'T'], desc: 'New workspace' },
+      { keys: ['Cmd', 'W'], desc: 'Close workspace' },
+      { keys: ['Ctrl', 'Tab'], desc: 'Next workspace' },
+      { keys: ['Ctrl', 'Shift', 'Tab'], desc: 'Previous workspace' },
+    ],
+  },
+  {
+    category: 'Board',
+    items: [
+      { keys: ['Cmd', 'J'], desc: 'Toggle chef panel' },
+      { keys: ['Cmd', 'L'], desc: 'Close task chat panel' },
+      { keys: ['Cmd', 'Drag'], desc: 'Link task dependencies' },
+      { keys: ['Esc'], desc: 'Cancel dependency link' },
+    ],
+  },
+  {
+    category: 'Task Cards',
+    items: [
+      { keys: ['Enter'], desc: 'Open task' },
+      { keys: ['Space'], desc: 'Run or stop agent' },
+      { keys: ['R'], desc: 'Retry failed pipeline' },
+      { keys: ['ArrowRight'], desc: 'Move task to next column' },
+      { keys: ['M'], desc: 'Open move task menu' },
+      { keys: ['D'], desc: 'Duplicate task' },
+      { keys: ['L'], desc: 'Edit dependencies' },
+      { keys: ['Del'], desc: 'Confirm/delete task' },
+      { keys: ['Backspace'], desc: 'Confirm/delete task' },
+    ],
+  },
+  {
+    category: 'Command Palette',
+    items: [
+      { keys: ['ArrowDown'], desc: 'Select next command' },
+      { keys: ['ArrowUp'], desc: 'Select previous command' },
+      { keys: ['Enter'], desc: 'Run selected command' },
+      { keys: ['Cmd', 'Enter'], desc: 'Create task from search text' },
+      { keys: ['Esc'], desc: 'Close command palette' },
+    ],
+  },
+  {
+    category: 'Editing',
+    items: [
+      { keys: ['Enter'], desc: 'Submit message, task, or checklist item' },
+      { keys: ['Shift', 'Enter'], desc: 'Insert newline in message' },
+      { keys: ['Esc'], desc: 'Cancel inline edit' },
+    ],
+  },
+  {
+    category: 'Terminal',
+    items: [
+      { keys: ['Ctrl', 'C'], desc: 'Interrupt process' },
+    ],
+  },
+]

--- a/src/scripts/rebase-pr.test.ts
+++ b/src/scripts/rebase-pr.test.ts
@@ -22,6 +22,7 @@ const env = {
 }
 
 const tempDirs: string[] = []
+const REBASE_TEST_TIMEOUT_MS = 30_000
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, env, encoding: 'utf8', stdio: 'pipe' }).trim()
@@ -114,7 +115,7 @@ describe('scripts/rebase-pr.sh', () => {
     expect(result.stdout).toContain('Clean rebase succeeded')
     expect(git(repo, ['merge-base', '--is-ancestor', 'origin/main', 'feature'])).toBe('')
     expect(git(repo, ['status', '--porcelain'])).toBe('')
-  })
+  }, REBASE_TEST_TIMEOUT_MS)
 
   it('marks manual review and does not push when the guarded fallback fails type-check', () => {
     const { root, repo, origin } = setupRepo()
@@ -143,5 +144,5 @@ describe('scripts/rebase-pr.sh', () => {
     expect(existsSync(marker)).toBe(true)
     expect(readFileSync(marker, 'utf8')).toContain('file.txt')
     expect(git(repo, ['ls-remote', origin, 'refs/heads/feature']).split(/\s+/)[0]).toBe(remoteBefore)
-  })
+  }, REBASE_TEST_TIMEOUT_MS)
 })


### PR DESCRIPTION
## Description

Add a modal that lists all keyboard shortcuts (move task, retry, run, delete, search, switch workspace, etc.). Triggered by pressing ? when no input focused. Component: src/components/shortcuts-modal.tsx. Use existing keyboard handlers. Acceptance: ? opens modal, Esc closes, all current shortcuts listed.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/keyboard-shortcuts-overlay-press-to-open` → `staging/overnight-20260430-bento-ya`