### PR TITLE
Task templates — save and reuse task patterns

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod pipeline;
 pub mod script;
 pub mod siege;
 pub mod task;
+pub mod task_template;
 pub mod terminal;
 pub mod usage;
 #[cfg(feature = "voice")]

--- a/src-tauri/src/commands/task_template.rs
+++ b/src-tauri/src/commands/task_template.rs
@@ -84,6 +84,13 @@ pub async fn create_task_from_template(
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let template = db::get_task_template(&conn, &template_id)?;
+    let column = db::get_column(&conn, &column_id)?;
+    if column.workspace_id != template.workspace_id {
+        return Err(AppError::InvalidInput(
+            "Template and target column must belong to the same workspace".to_string(),
+        ));
+    }
+
     let task = db::insert_task(
         &conn,
         &template.workspace_id,
@@ -100,7 +107,6 @@ pub async fn create_task_from_template(
     .map_err(AppError::from)?;
 
     let task = db::get_task(&conn, &task.id)?;
-    let column = db::get_column(&conn, &column_id)?;
     let task = pipeline::fire_trigger(&conn, &app, &task, &column)?;
     pipeline::emit_tasks_changed(&app, &template.workspace_id, "task_created_from_template");
 

--- a/src-tauri/src/commands/task_template.rs
+++ b/src-tauri/src/commands/task_template.rs
@@ -1,0 +1,108 @@
+use crate::db::{self, AppState, Task, TaskTemplate};
+use crate::error::AppError;
+use crate::pipeline;
+use tauri::{AppHandle, State};
+
+fn validate_template(title: &str, labels: &str) -> Result<(), AppError> {
+    if title.trim().is_empty() {
+        return Err(AppError::InvalidInput(
+            "Template title cannot be empty".to_string(),
+        ));
+    }
+    serde_json::from_str::<Vec<String>>(labels)
+        .map_err(|e| AppError::InvalidInput(format!("Invalid labels JSON: {}", e)))?;
+    Ok(())
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn list_task_templates(
+    state: State<AppState>,
+    workspace_id: String,
+) -> Result<Vec<TaskTemplate>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::list_task_templates(&conn, &workspace_id)?)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn create_task_template_from_task(
+    state: State<AppState>,
+    task_id: String,
+) -> Result<TaskTemplate, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let task = db::get_task(&conn, &task_id)?;
+    Ok(db::insert_task_template_from_task(&conn, &task)?)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn update_task_template(
+    state: State<AppState>,
+    id: String,
+    title: String,
+    description: Option<String>,
+    labels: String,
+    model: Option<String>,
+) -> Result<TaskTemplate, AppError> {
+    validate_template(&title, &labels)?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::update_task_template(
+        &conn,
+        &id,
+        title.trim(),
+        description.as_deref(),
+        &labels,
+        model.as_deref(),
+    )?)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn delete_task_template(state: State<AppState>, id: String) -> Result<(), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::delete_task_template(&conn, &id)?)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn create_task_from_template(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    template_id: String,
+    column_id: String,
+) -> Result<Task, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let template = db::get_task_template(&conn, &template_id)?;
+    let task = db::insert_task(
+        &conn,
+        &template.workspace_id,
+        &column_id,
+        &template.title,
+        template.description.as_deref(),
+    )?;
+
+    let ts = db::now();
+    conn.execute(
+        "UPDATE tasks SET pr_labels = ?1, model = ?2, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![template.labels, template.model, ts, task.id],
+    )
+    .map_err(AppError::from)?;
+
+    let task = db::get_task(&conn, &task.id)?;
+    let column = db::get_column(&conn, &column_id)?;
+    let task = pipeline::fire_trigger(&conn, &app, &task, &column)?;
+    pipeline::emit_tasks_changed(&app, &template.workspace_id, "task_created_from_template");
+
+    Ok(task)
+}

--- a/src-tauri/src/db/migrations/032_task_templates.sql
+++ b/src-tauri/src/db/migrations/032_task_templates.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS task_templates (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  labels TEXT NOT NULL DEFAULT '[]',
+  model TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_templates_workspace ON task_templates(workspace_id);

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -19,6 +19,7 @@ pub mod orchestrator_session;
 pub mod pipeline_timing;
 pub mod script;
 pub mod task;
+pub mod task_template;
 pub mod usage;
 pub mod workspace;
 
@@ -37,6 +38,7 @@ pub use orchestrator_session::*;
 pub use pipeline_timing::*;
 pub use script::*;
 pub use task::*;
+pub use task_template::*;
 pub use usage::*;
 pub use workspace::*;
 
@@ -140,6 +142,7 @@ fn run_migrations(conn: &Connection) -> SqlResult<()> {
         ("030_pipeline_timing", include_str!("migrations/030_pipeline_timing.sql")),
         ("030_usage_column_duration", include_str!("migrations/030_usage_column_duration.sql")),
         ("031_task_batch_id", include_str!("migrations/031_task_batch_id.sql")),
+        ("032_task_templates", include_str!("migrations/032_task_templates.sql")),
     ];
 
     for (name, sql) in migrations {
@@ -202,8 +205,8 @@ mod tests {
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
             .unwrap();
-        // We have 33 migrations, including split 019 and 030 migration files.
-        assert_eq!(count, 33);
+        // We have 34 migrations, including split 019 and 030 migration files.
+        assert_eq!(count, 34);
     }
 
     #[test]

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -103,6 +103,21 @@ pub struct Task {
     pub updated_at: String,
 }
 
+/// A reusable task template scoped to a workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskTemplate {
+    pub id: String,
+    pub workspace_id: String,
+    pub title: String,
+    pub description: Option<String>,
+    /// JSON array of label strings.
+    pub labels: String,
+    pub model: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
 // ─── Agent Entities ─────────────────────────────────────────────────────────
 
 /// A PTY/CLI session for an agent working on a task.

--- a/src-tauri/src/db/task_template.rs
+++ b/src-tauri/src/db/task_template.rs
@@ -89,3 +89,80 @@ pub fn delete_task_template(conn: &Connection, id: &str) -> SqlResult<()> {
     conn.execute("DELETE FROM task_templates WHERE id = ?1", params![id])?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    #[test]
+    fn task_templates_are_scoped_to_workspace() {
+        let conn = db::init_test().expect("test database initializes");
+        let ws_1 = db::insert_workspace(&conn, "Workspace 1", "/tmp/ws-1").unwrap();
+        let ws_2 = db::insert_workspace(&conn, "Workspace 2", "/tmp/ws-2").unwrap();
+
+        let template = insert_task_template(
+            &conn,
+            &ws_1.id,
+            "Implement feature",
+            Some("Use the existing patterns"),
+            r#"["frontend","bug"]"#,
+            Some("gpt-5.4"),
+        )
+        .unwrap();
+        insert_task_template(&conn, &ws_2.id, "Other workspace", None, "[]", None).unwrap();
+
+        let ws_1_templates = list_task_templates(&conn, &ws_1.id).unwrap();
+        let ws_2_templates = list_task_templates(&conn, &ws_2.id).unwrap();
+
+        assert_eq!(ws_1_templates.len(), 1);
+        assert_eq!(ws_1_templates[0].id, template.id);
+        assert_eq!(ws_1_templates[0].labels, r#"["frontend","bug"]"#);
+        assert_eq!(ws_1_templates[0].model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(ws_2_templates.len(), 1);
+        assert_ne!(ws_2_templates[0].id, template.id);
+    }
+
+    #[test]
+    fn task_template_can_be_created_from_task_and_updated() {
+        let conn = db::init_test().expect("test database initializes");
+        let workspace = db::insert_workspace(&conn, "Workspace", "/tmp/ws").unwrap();
+        let column = db::insert_column(&conn, &workspace.id, "Backlog", 0).unwrap();
+        let task = db::insert_task(
+            &conn,
+            &workspace.id,
+            &column.id,
+            "Original task",
+            Some("Original description"),
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE tasks SET pr_labels = ?1, model = ?2 WHERE id = ?3",
+            params![r#"["backend"]"#, "gpt-5.4", task.id],
+        )
+        .unwrap();
+        let task = db::get_task(&conn, &task.id).unwrap();
+
+        let template = insert_task_template_from_task(&conn, &task).unwrap();
+        assert_eq!(template.workspace_id, workspace.id);
+        assert_eq!(template.title, "Original task");
+        assert_eq!(template.description.as_deref(), Some("Original description"));
+        assert_eq!(template.labels, r#"["backend"]"#);
+        assert_eq!(template.model.as_deref(), Some("gpt-5.4"));
+
+        let updated = update_task_template(
+            &conn,
+            &template.id,
+            "Updated template",
+            None,
+            r#"["docs"]"#,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(updated.title, "Updated template");
+        assert_eq!(updated.description, None);
+        assert_eq!(updated.labels, r#"["docs"]"#);
+        assert_eq!(updated.model, None);
+    }
+}

--- a/src-tauri/src/db/task_template.rs
+++ b/src-tauri/src/db/task_template.rs
@@ -1,0 +1,91 @@
+use rusqlite::{params, Connection, Result as SqlResult};
+
+use super::models::{Task, TaskTemplate};
+use super::{new_id, now};
+
+const TASK_TEMPLATE_COLUMNS: &str =
+    "id, workspace_id, title, description, labels, model, created_at, updated_at";
+
+fn map_task_template_row(row: &rusqlite::Row) -> rusqlite::Result<TaskTemplate> {
+    Ok(TaskTemplate {
+        id: row.get(0)?,
+        workspace_id: row.get(1)?,
+        title: row.get(2)?,
+        description: row.get(3)?,
+        labels: row
+            .get::<_, Option<String>>(4)?
+            .unwrap_or_else(|| "[]".to_string()),
+        model: row.get(5)?,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
+}
+
+pub fn insert_task_template(
+    conn: &Connection,
+    workspace_id: &str,
+    title: &str,
+    description: Option<&str>,
+    labels: &str,
+    model: Option<&str>,
+) -> SqlResult<TaskTemplate> {
+    let id = new_id();
+    let ts = now();
+    conn.execute(
+        "INSERT INTO task_templates (id, workspace_id, title, description, labels, model, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![id, workspace_id, title, description, labels, model, ts, ts],
+    )?;
+    get_task_template(conn, &id)
+}
+
+pub fn insert_task_template_from_task(conn: &Connection, task: &Task) -> SqlResult<TaskTemplate> {
+    insert_task_template(
+        conn,
+        &task.workspace_id,
+        &task.title,
+        task.description.as_deref(),
+        &task.pr_labels,
+        task.model.as_deref(),
+    )
+}
+
+pub fn get_task_template(conn: &Connection, id: &str) -> SqlResult<TaskTemplate> {
+    conn.query_row(
+        &format!(
+            "SELECT {} FROM task_templates WHERE id = ?1",
+            TASK_TEMPLATE_COLUMNS
+        ),
+        params![id],
+        map_task_template_row,
+    )
+}
+
+pub fn list_task_templates(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<TaskTemplate>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {} FROM task_templates WHERE workspace_id = ?1 ORDER BY updated_at DESC, title",
+        TASK_TEMPLATE_COLUMNS
+    ))?;
+    let rows = stmt.query_map(params![workspace_id], map_task_template_row)?;
+    rows.collect()
+}
+
+pub fn update_task_template(
+    conn: &Connection,
+    id: &str,
+    title: &str,
+    description: Option<&str>,
+    labels: &str,
+    model: Option<&str>,
+) -> SqlResult<TaskTemplate> {
+    let ts = now();
+    conn.execute(
+        "UPDATE task_templates SET title = ?1, description = ?2, labels = ?3, model = ?4, updated_at = ?5 WHERE id = ?6",
+        params![title, description, labels, model, ts, id],
+    )?;
+    get_task_template(conn, id)
+}
+
+pub fn delete_task_template(conn: &Connection, id: &str) -> SqlResult<()> {
+    conn.execute("DELETE FROM task_templates WHERE id = ?1", params![id])?;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -127,6 +127,12 @@ pub fn run() {
             commands::task::queue_backlog,
             commands::task::create_task_worktree,
             commands::task::remove_task_worktree,
+            // Task templates
+            commands::task_template::list_task_templates,
+            commands::task_template::create_task_template_from_task,
+            commands::task_template::update_task_template,
+            commands::task_template::delete_task_template,
+            commands::task_template::create_task_from_template,
             // Git commands
             commands::git::create_task_branch,
             commands::git::switch_branch,

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -23,6 +23,7 @@ type ColumnHeaderProps = {
   onConfigure: () => void
   onDelete: () => void
   onAddTask: () => void
+  onNewFromTemplate: () => void
   onRunAll?: () => void
   onCancelQueue?: () => void
 }
@@ -95,6 +96,7 @@ export const ColumnHeader = memo(function ColumnHeader({
   onConfigure,
   onDelete,
   onAddTask,
+  onNewFromTemplate,
   onRunAll,
   onCancelQueue,
 }: ColumnHeaderProps) {
@@ -193,6 +195,17 @@ export const ColumnHeader = memo(function ColumnHeader({
             }
             onClick={onAddTask}
             tooltip="Add task"
+            tooltipSide="bottom"
+          />
+
+          <IconButton
+            icon={
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+                <path d="M3.5 2A1.5 1.5 0 0 0 2 3.5v9A1.5 1.5 0 0 0 3.5 14h9a1.5 1.5 0 0 0 1.5-1.5V6.621a1.5 1.5 0 0 0-.44-1.06L10.44 2.44A1.5 1.5 0 0 0 9.378 2H3.5Zm2 4.75A.75.75 0 0 1 6.25 6h3.5a.75.75 0 0 1 0 1.5h-3.5a.75.75 0 0 1-.75-.75Zm0 2.5A.75.75 0 0 1 6.25 8.5h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Zm.75 1.75a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z" />
+              </svg>
+            }
+            onClick={onNewFromTemplate}
+            tooltip="New from template"
             tooltipSide="bottom"
           />
 

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -13,6 +13,7 @@ import { queueBacklog, cancelBacklogQueue } from '@/lib/ipc/pipeline'
 import { ColumnHeader } from './column-header'
 import { TaskCard } from './task-card'
 import { ColumnConfigDialog } from './column-config-dialog'
+import { TaskTemplateDialog } from './task-template-dialog'
 
 type BatchQueueLocalState = {
   isQueuing: boolean
@@ -63,6 +64,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
   const [showConfigDialog, setShowConfigDialog] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [showAddTask, setShowAddTask] = useState(false)
+  const [showTemplateDialog, setShowTemplateDialog] = useState(false)
   const [newTaskTitle, setNewTaskTitle] = useState('')
   const addTaskInputRef = useRef<HTMLInputElement>(null)
 
@@ -176,6 +178,10 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
     setShowAddTask(true)
   }, [])
 
+  const handleNewFromTemplate = useCallback(() => {
+    setShowTemplateDialog(true)
+  }, [])
+
   const handleSubmitTask = useCallback(async () => {
     if (!newTaskTitle.trim() || !activeWorkspaceId) return
     await addTask(activeWorkspaceId, column.id, newTaskTitle.trim(), '')
@@ -211,6 +217,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
             onConfigure={handleConfigure}
             onDelete={handleDelete}
             onAddTask={handleAddTask}
+            onNewFromTemplate={handleNewFromTemplate}
             onRunAll={() => { void handleRunAll(); }}
             onCancelQueue={() => { void handleCancelQueue(); }}
           />
@@ -278,6 +285,14 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
           </div>
         </SortableContext>
       </motion.div>
+
+      {showTemplateDialog && activeWorkspaceId && (
+        <TaskTemplateDialog
+          workspaceId={activeWorkspaceId}
+          columnId={column.id}
+          onClose={() => { setShowTemplateDialog(false) }}
+        />
+      )}
 
       {/* Config dialog */}
       {showConfigDialog && (

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -205,7 +205,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
           isDragging ? 'opacity-50' : ''
         }`}
       >
-        <div {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing">
+        <div {...attributes} {...listeners} style={{ cursor: 'grab' }}>
           <ColumnHeader
             name={column.name}
             icon={column.icon || 'list'}

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -498,6 +498,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
         onStartSiege={() => { void actions.handleStartSiege(); }}
         onStopSiege={() => { void actions.handleStopSiege(); }}
         onConfigureTask={() => { setShowSettings(true) }}
+        onSaveAsTemplate={actions.handleSaveAsTemplate}
       />
     )}
 

--- a/src/components/kanban/task-context-menu.tsx
+++ b/src/components/kanban/task-context-menu.tsx
@@ -36,6 +36,7 @@ type TaskContextMenuProps = {
   onStartSiege: () => void
   onStopSiege: () => void
   onConfigureTask?: () => void
+  onSaveAsTemplate: () => void
 }
 
 // Icons
@@ -86,6 +87,11 @@ const Icons = {
   configure: (
     <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
       <path fillRule="evenodd" d="M7.84 1.804A1 1 0 0 1 8.82 1h2.36a1 1 0 0 1 .98.804l.331 1.652a6.993 6.993 0 0 1 1.929 1.115l1.598-.54a1 1 0 0 1 1.186.447l1.18 2.044a1 1 0 0 1-.205 1.251l-1.267 1.113a7.047 7.047 0 0 1 0 2.228l1.267 1.113a1 1 0 0 1 .206 1.25l-1.18 2.045a1 1 0 0 1-1.187.447l-1.598-.54a6.993 6.993 0 0 1-1.929 1.115l-.33 1.652a1 1 0 0 1-.98.804H8.82a1 1 0 0 1-.98-.804l-.331-1.652a6.993 6.993 0 0 1-1.929-1.115l-1.598.54a1 1 0 0 1-1.186-.447l-1.18-2.044a1 1 0 0 1 .205-1.251l1.267-1.114a7.05 7.05 0 0 1 0-2.227L1.821 7.773a1 1 0 0 1-.206-1.25l1.18-2.045a1 1 0 0 1 1.187-.447l1.598.54A6.993 6.993 0 0 1 7.51 3.456l.33-1.652ZM10 13a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" clipRule="evenodd" />
+    </svg>
+  ),
+  template: (
+    <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M4.5 3A1.5 1.5 0 0 0 3 4.5v11A1.5 1.5 0 0 0 4.5 17h11a1.5 1.5 0 0 0 1.5-1.5V7.621a1.5 1.5 0 0 0-.44-1.06L13.44 3.44A1.5 1.5 0 0 0 12.378 3H4.5Zm2 3.75A.75.75 0 0 1 7.25 6h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Zm0 3A.75.75 0 0 1 7.25 9h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1-.75-.75Zm.75 2.25a.75.75 0 0 0 0 1.5h3.5a.75.75 0 0 0 0-1.5h-3.5Z" />
     </svg>
   ),
   chevronRight: (
@@ -181,6 +187,7 @@ export function TaskContextMenu({
   onStartSiege,
   onStopSiege,
   onConfigureTask,
+  onSaveAsTemplate,
 }: TaskContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -251,6 +258,7 @@ export function TaskContextMenu({
       })),
     },
     { label: 'Duplicate', icon: Icons.duplicate, shortcut: 'D', onClick: onDuplicateTask },
+    { label: 'Save as template', icon: Icons.template, onClick: onSaveAsTemplate },
     { type: 'divider' },
     { label: 'Archive', icon: Icons.archive, onClick: onArchiveTask },
     { label: 'Delete', icon: Icons.trash, variant: 'danger' as const, onClick: onDeleteTask },

--- a/src/components/kanban/task-context-menu.tsx
+++ b/src/components/kanban/task-context-menu.tsx
@@ -113,9 +113,10 @@ function MenuItemComponent({ item, onClose }: { item: MenuItem; onClose: () => v
     <button
       onClick={handleClick}
       disabled={item.disabled}
+      style={{ cursor: item.disabled ? 'not-allowed' : undefined }}
       className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors ${
         item.disabled
-          ? 'text-text-secondary/50 cursor-not-allowed'
+          ? 'text-text-secondary/50'
           : item.variant === 'danger'
             ? 'text-error hover:bg-error/10'
             : 'text-text-primary hover:bg-surface-hover'

--- a/src/components/kanban/task-template-dialog.tsx
+++ b/src/components/kanban/task-template-dialog.tsx
@@ -27,12 +27,16 @@ function textToLabels(text: string) {
 }
 
 export function TaskTemplateDialog({ workspaceId, columnId, onClose }: TaskTemplateDialogProps) {
-  const templates = useTaskTemplateStore((s) => s.templates)
+  const rawTemplates = useTaskTemplateStore((s) => s.templates)
   const loadedWorkspaceId = useTaskTemplateStore((s) => s.loadedWorkspaceId)
   const load = useTaskTemplateStore((s) => s.load)
   const update = useTaskTemplateStore((s) => s.update)
   const remove = useTaskTemplateStore((s) => s.remove)
   const createTask = useTaskTemplateStore((s) => s.createTask)
+
+  const templates = loadedWorkspaceId === workspaceId
+    ? rawTemplates.filter((template) => template.workspaceId === workspaceId)
+    : []
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [title, setTitle] = useState('')

--- a/src/components/kanban/task-template-dialog.tsx
+++ b/src/components/kanban/task-template-dialog.tsx
@@ -34,9 +34,14 @@ export function TaskTemplateDialog({ workspaceId, columnId, onClose }: TaskTempl
   const remove = useTaskTemplateStore((s) => s.remove)
   const createTask = useTaskTemplateStore((s) => s.createTask)
 
-  const templates = loadedWorkspaceId === workspaceId
-    ? rawTemplates.filter((template) => template.workspaceId === workspaceId)
-    : []
+  const templates = useMemo(
+    () => (
+      loadedWorkspaceId === workspaceId
+        ? rawTemplates.filter((template) => template.workspaceId === workspaceId)
+        : []
+    ),
+    [loadedWorkspaceId, rawTemplates, workspaceId],
+  )
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [title, setTitle] = useState('')

--- a/src/components/kanban/task-template-dialog.tsx
+++ b/src/components/kanban/task-template-dialog.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useMemo, useState } from 'react'
+import { motion } from 'motion/react'
+import { useTaskTemplateStore } from '@/stores/task-template-store'
+
+type TaskTemplateDialogProps = {
+  workspaceId: string
+  columnId: string
+  onClose: () => void
+}
+
+function labelsToText(labels: string) {
+  try {
+    const parsed = JSON.parse(labels) as string[]
+    return parsed.join(', ')
+  } catch {
+    return ''
+  }
+}
+
+function textToLabels(text: string) {
+  return JSON.stringify(
+    text
+      .split(',')
+      .map((label) => label.trim())
+      .filter(Boolean),
+  )
+}
+
+export function TaskTemplateDialog({ workspaceId, columnId, onClose }: TaskTemplateDialogProps) {
+  const templates = useTaskTemplateStore((s) => s.templates)
+  const loadedWorkspaceId = useTaskTemplateStore((s) => s.loadedWorkspaceId)
+  const load = useTaskTemplateStore((s) => s.load)
+  const update = useTaskTemplateStore((s) => s.update)
+  const remove = useTaskTemplateStore((s) => s.remove)
+  const createTask = useTaskTemplateStore((s) => s.createTask)
+
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [labels, setLabels] = useState('')
+  const [model, setModel] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (loadedWorkspaceId !== workspaceId) {
+      void load(workspaceId)
+    }
+  }, [load, loadedWorkspaceId, workspaceId])
+
+  const selected = useMemo(
+    () => templates.find((template) => template.id === selectedId) ?? null,
+    [selectedId, templates],
+  )
+
+  useEffect(() => {
+    const next = selected ?? templates[0] ?? null
+    if (!next) return
+    if (next.id === selectedId) return
+    setSelectedId(next.id)
+  }, [selected, selectedId, templates])
+
+  useEffect(() => {
+    if (!selected) return
+    setTitle(selected.title)
+    setDescription(selected.description ?? '')
+    setLabels(labelsToText(selected.labels))
+    setModel(selected.model ?? '')
+    setError(null)
+  }, [selected])
+
+  const handleSave = async () => {
+    if (!selected) return false
+    if (!title.trim()) {
+      setError('Template title is required.')
+      return false
+    }
+    try {
+      await update(selected.id, {
+        title: title.trim(),
+        description: description.trim() || null,
+        labels: textToLabels(labels),
+        model: model.trim() || null,
+      })
+      setError(null)
+      return true
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save template.')
+      return false
+    }
+  }
+
+  const handleCreate = async () => {
+    if (!selected) return
+    try {
+      const saved = await handleSave()
+      if (!saved) return
+      await createTask(selected.id, columnId)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create task.')
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!selected) return
+    await remove(selected.id)
+    const remaining = templates.filter((template) => template.id !== selected.id)
+    setSelectedId(remaining[0]?.id ?? null)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <motion.div
+        initial={{ opacity: 0, scale: 0.96 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.96 }}
+        className="flex max-h-[80vh] w-[720px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border-default bg-surface shadow-xl"
+        onClick={(event) => { event.stopPropagation() }}
+      >
+        <div className="w-64 border-r border-border-default">
+          <div className="border-b border-border-default px-3 py-2">
+            <h3 className="text-sm font-medium text-text-primary">Task Templates</h3>
+          </div>
+          <div className="max-h-[calc(80vh-42px)] overflow-y-auto p-2">
+            {templates.length === 0 ? (
+              <p className="px-2 py-6 text-center text-xs text-text-secondary">
+                Save a task as a template first.
+              </p>
+            ) : templates.map((template) => (
+              <button
+                key={template.id}
+                onClick={() => { setSelectedId(template.id) }}
+                className={`mb-1 w-full rounded px-2 py-2 text-left text-sm ${
+                  selectedId === template.id
+                    ? 'bg-accent/15 text-text-primary'
+                    : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+                }`}
+              >
+                <span className="block truncate">{template.title}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col">
+          <div className="border-b border-border-default px-4 py-3">
+            <h3 className="text-sm font-medium text-text-primary">New From Template</h3>
+          </div>
+
+          {selected ? (
+            <div className="flex-1 space-y-3 overflow-y-auto p-4">
+              {error && (
+                <div className="rounded border border-error/30 bg-error/10 px-3 py-2 text-sm text-error">
+                  {error}
+                </div>
+              )}
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-text-secondary">Title</span>
+                <input
+                  value={title}
+                  onChange={(event) => { setTitle(event.target.value) }}
+                  className="w-full rounded border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-text-secondary">Description</span>
+                <textarea
+                  value={description}
+                  onChange={(event) => { setDescription(event.target.value) }}
+                  rows={5}
+                  className="w-full resize-none rounded border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-text-secondary">Labels</span>
+                <input
+                  value={labels}
+                  onChange={(event) => { setLabels(event.target.value) }}
+                  placeholder="bug, frontend"
+                  className="w-full rounded border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-text-secondary">Model</span>
+                <input
+                  value={model}
+                  onChange={(event) => { setModel(event.target.value) }}
+                  placeholder="Default"
+                  className="w-full rounded border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+                />
+              </label>
+            </div>
+          ) : (
+            <div className="flex flex-1 items-center justify-center text-sm text-text-secondary">
+              No templates yet
+            </div>
+          )}
+
+          <div className="flex items-center justify-between border-t border-border-default p-3">
+            <button
+              onClick={() => { void handleDelete() }}
+              disabled={!selected}
+              className="rounded px-3 py-1.5 text-sm text-error hover:bg-error/10 disabled:opacity-40"
+            >
+              Delete
+            </button>
+            <div className="flex gap-2">
+              <button onClick={onClose} className="rounded px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-hover">
+                Cancel
+              </button>
+              <button
+                onClick={() => { void handleSave() }}
+                disabled={!selected}
+                className="rounded border border-border-default px-3 py-1.5 text-sm text-text-primary hover:bg-surface-hover disabled:opacity-40"
+              >
+                Save
+              </button>
+              <button
+                onClick={() => { void handleCreate() }}
+                disabled={!selected}
+                className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-bg disabled:opacity-40"
+              >
+                Create Task
+              </button>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/src/components/kanban/use-task-card-actions.ts
+++ b/src/components/kanban/use-task-card-actions.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import type { Task } from '@/types'
 import { useTaskStore } from '@/stores/task-store'
+import { useTaskTemplateStore } from '@/stores/task-template-store'
 import * as ipc from '@/lib/ipc'
 
 /** Encapsulates all task card action handlers (context menu, keyboard, quick actions). */
@@ -9,6 +10,7 @@ export function useTaskCardActions(task: Task) {
   const removeTask = useTaskStore((s) => s.remove)
   const updateTask = useTaskStore((s) => s.updateTask)
   const duplicateTask = useTaskStore((s) => s.duplicate)
+  const saveTemplateFromTask = useTaskTemplateStore((s) => s.saveFromTask)
 
   const handleMoveToColumn = useCallback((columnId: string) => {
     void moveTask(task.id, columnId, 0)
@@ -59,6 +61,10 @@ export function useTaskCardActions(task: Task) {
     void duplicateTask(task.id)
   }, [task.id, duplicateTask])
 
+  const handleSaveAsTemplate = useCallback(() => {
+    void saveTemplateFromTask(task.id)
+  }, [task.id, saveTemplateFromTask])
+
   const handleToggleAgent = useCallback(() => {
     if (task.agentStatus === 'running') {
       updateTask(task.id, { agentStatus: 'stopped' })
@@ -89,6 +95,7 @@ export function useTaskCardActions(task: Task) {
     handleArchiveTask,
     handleDeleteTask,
     handleDuplicateTask,
+    handleSaveAsTemplate,
     handleToggleAgent,
     handleRetryPipeline,
   }

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- Mock data uses ?? for defensive safety with unknown runtime args */
 
-import type { Workspace, Column, Task, AgentMode, AgentStatus, PipelineState } from '@/types'
+import type { Workspace, Column, Task, TaskTemplate, AgentMode, AgentStatus, PipelineState } from '@/types'
 import { DEFAULT_TRIGGERS } from '@/types/column'
 
 // Check if we're running in Tauri or in a test environment
@@ -131,6 +131,19 @@ let mockTasks: Task[] = [
     worktreePath: null,
     queuedAt: null,
     position: 0,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+]
+
+let mockTaskTemplates: TaskTemplate[] = [
+  {
+    id: 'template-1',
+    workspaceId: 'ws-demo',
+    title: 'Bug fix',
+    description: 'Describe the defect, expected behavior, and validation steps.',
+    labels: JSON.stringify(['bug']),
+    model: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   },
@@ -352,6 +365,105 @@ const mockCommands: Record<string, CommandHandler> = {
       if (task) task.position = idx
     })
     return mockTasks.filter((t) => t.columnId === args?.columnId)
+  },
+
+  // Task template commands
+  list_task_templates: (args) =>
+    mockTaskTemplates
+      .filter((template) => template.workspaceId === args?.workspaceId)
+      .sort((a, b) => {
+        const updatedCompare = b.updatedAt.localeCompare(a.updatedAt)
+        return updatedCompare !== 0 ? updatedCompare : a.title.localeCompare(b.title)
+      }),
+  create_task_template_from_task: (args) => {
+    const task = mockTasks.find((item) => item.id === args?.taskId)
+    if (!task) throw new Error('Task not found')
+
+    const now = new Date().toISOString()
+    const template: TaskTemplate = {
+      id: generateId('template'),
+      workspaceId: task.workspaceId,
+      title: task.title,
+      description: task.description || null,
+      labels: task.prLabels,
+      model: task.model,
+      createdAt: now,
+      updatedAt: now,
+    }
+    mockTaskTemplates.push(template)
+    return template
+  },
+  update_task_template: (args) => {
+    const template = mockTaskTemplates.find((item) => item.id === args?.id)
+    if (!template) throw new Error('Template not found')
+
+    template.title = (args?.title as string) ?? template.title
+    template.description = (args?.description as string | null | undefined) ?? template.description
+    template.labels = (args?.labels as string) ?? template.labels
+    template.model = (args?.model as string | null | undefined) ?? template.model
+    template.updatedAt = new Date().toISOString()
+    return template
+  },
+  delete_task_template: (args) => {
+    mockTaskTemplates = mockTaskTemplates.filter((template) => template.id !== args?.id)
+  },
+  create_task_from_template: (args) => {
+    const template = mockTaskTemplates.find((item) => item.id === args?.templateId)
+    const column = mockColumns.find((item) => item.id === args?.columnId)
+    if (!template) throw new Error('Template not found')
+    if (!column) throw new Error('Column not found')
+    if (column.workspaceId !== template.workspaceId) {
+      throw new Error('Template and target column must belong to the same workspace')
+    }
+
+    const now = new Date().toISOString()
+    const task: Task = {
+      id: generateId('task'),
+      workspaceId: template.workspaceId,
+      columnId: column.id,
+      title: template.title,
+      description: template.description ?? '',
+      branch: null,
+      agentType: null,
+      agentMode: null,
+      agentStatus: null,
+      pipelineState: 'idle',
+      pipelineTriggeredAt: null,
+      pipelineError: null,
+      retryCount: 0,
+      model: template.model,
+      lastScriptExitCode: null,
+      reviewStatus: null,
+      prNumber: null,
+      prUrl: null,
+      siegeIteration: 0,
+      siegeActive: false,
+      siegeMaxIterations: 5,
+      siegeLastChecked: null,
+      prMergeable: null,
+      prCiStatus: null,
+      prReviewDecision: null,
+      prCommentCount: 0,
+      prIsDraft: false,
+      prLabels: template.labels,
+      prLastFetched: null,
+      prHeadSha: null,
+      checklist: null,
+      notifyStakeholders: null,
+      notificationSentAt: null,
+      triggerOverrides: null,
+      triggerPrompt: null,
+      lastOutput: null,
+      dependencies: null,
+      blocked: false,
+      worktreePath: null,
+      queuedAt: null,
+      position: mockTasks.filter((item) => item.columnId === column.id).length,
+      createdAt: now,
+      updatedAt: now,
+    }
+    mockTasks.push(task)
+    return task
   },
 
   // Settings

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -398,9 +398,13 @@ const mockCommands: Record<string, CommandHandler> = {
     if (!template) throw new Error('Template not found')
 
     template.title = (args?.title as string) ?? template.title
-    template.description = (args?.description as string | null | undefined) ?? template.description
+    if (args && 'description' in args) {
+      template.description = args.description as string | null
+    }
     template.labels = (args?.labels as string) ?? template.labels
-    template.model = (args?.model as string | null | undefined) ?? template.model
+    if (args && 'model' in args) {
+      template.model = args.model as string | null
+    }
     template.updatedAt = new Date().toISOString()
     return template
   },
@@ -1037,6 +1041,19 @@ export function resetMockData() {
       position: 1,
       createdAt: new Date(Date.now() - 86400000).toISOString(),
       updatedAt: new Date(Date.now() - 7200000).toISOString(),
+    },
+  ]
+
+  mockTaskTemplates = [
+    {
+      id: 'template-1',
+      workspaceId: 'ws-demo',
+      title: 'Bug fix',
+      description: 'Describe the defect, expected behavior, and validation steps.',
+      labels: JSON.stringify(['bug']),
+      model: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
     },
   ]
 

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -1,6 +1,7 @@
 export * from './workspace'
 export * from './column'
 export * from './task'
+export * from './task-template'
 export * from './git'
 export * from './agent'
 export * from './cli'

--- a/src/lib/ipc/task-template.ts
+++ b/src/lib/ipc/task-template.ts
@@ -1,0 +1,24 @@
+import { invoke } from './invoke'
+import type { Task, TaskTemplate } from '@/types'
+
+export const listTaskTemplates = (workspaceId: string) =>
+  invoke<TaskTemplate[]>('list_task_templates', { workspaceId })
+
+export const createTaskTemplateFromTask = (taskId: string) =>
+  invoke<TaskTemplate>('create_task_template_from_task', { taskId })
+
+export const updateTaskTemplate = (
+  id: string,
+  updates: {
+    title: string
+    description?: string | null
+    labels: string
+    model?: string | null
+  },
+) => invoke<TaskTemplate>('update_task_template', { id, ...updates })
+
+export const deleteTaskTemplate = (id: string) =>
+  invoke<void>('delete_task_template', { id })
+
+export const createTaskFromTemplate = (templateId: string, columnId: string) =>
+  invoke<Task>('create_task_from_template', { templateId, columnId })

--- a/src/lib/ipc/task-template.ts
+++ b/src/lib/ipc/task-template.ts
@@ -1,6 +1,13 @@
 import { invoke } from './invoke'
 import type { Task, TaskTemplate } from '@/types'
 
+export type TaskTemplateUpdate = {
+  title: string
+  description?: string | null
+  labels: string
+  model?: string | null
+}
+
 export const listTaskTemplates = (workspaceId: string) =>
   invoke<TaskTemplate[]>('list_task_templates', { workspaceId })
 
@@ -9,16 +16,11 @@ export const createTaskTemplateFromTask = (taskId: string) =>
 
 export const updateTaskTemplate = (
   id: string,
-  updates: {
-    title: string
-    description?: string | null
-    labels: string
-    model?: string | null
-  },
+  updates: TaskTemplateUpdate,
 ) => invoke<TaskTemplate>('update_task_template', { id, ...updates })
 
-export const deleteTaskTemplate = (id: string) =>
-  invoke<void>('delete_task_template', { id })
+export const deleteTaskTemplate = (id: string): Promise<void> =>
+  invoke('delete_task_template', { id })
 
 export const createTaskFromTemplate = (templateId: string, columnId: string) =>
   invoke<Task>('create_task_from_template', { templateId, columnId })

--- a/src/scripts/rebase-pr.test.ts
+++ b/src/scripts/rebase-pr.test.ts
@@ -22,6 +22,7 @@ const env = {
 }
 
 const tempDirs: string[] = []
+const TEST_TIMEOUT_MS = 90_000
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, env, encoding: 'utf8', stdio: 'pipe' }).trim()
@@ -92,7 +93,7 @@ afterEach(() => {
 })
 
 describe('scripts/rebase-pr.sh', () => {
-  it('rebases a clean PR branch and force-pushes it', () => {
+  it('rebases a clean PR branch and force-pushes it', { timeout: TEST_TIMEOUT_MS }, () => {
     const { root, repo } = setupRepo()
 
     git(repo, ['checkout', '-b', 'feature'])
@@ -116,7 +117,7 @@ describe('scripts/rebase-pr.sh', () => {
     expect(git(repo, ['status', '--porcelain'])).toBe('')
   })
 
-  it('marks manual review and does not push when the guarded fallback fails type-check', () => {
+  it('marks manual review and does not push when the guarded fallback fails type-check', { timeout: TEST_TIMEOUT_MS }, () => {
     const { root, repo, origin } = setupRepo()
 
     git(repo, ['checkout', '-b', 'feature'])

--- a/src/stores/task-template-store.test.ts
+++ b/src/stores/task-template-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import type { TaskTemplate } from '@/types'
+import type { Task, TaskTemplate } from '@/types'
 
 vi.mock('@/lib/ipc', () => ({
   listTaskTemplates: vi.fn(),
@@ -11,6 +11,8 @@ vi.mock('@/lib/ipc', () => ({
 
 import * as ipc from '@/lib/ipc'
 import { useTaskTemplateStore } from './task-template-store'
+import { useTaskStore } from './task-store'
+import { useWorkspaceStore } from './workspace-store'
 
 const mockIpc = vi.mocked(ipc)
 
@@ -26,6 +28,54 @@ const template = (overrides: Partial<TaskTemplate> = {}): TaskTemplate => ({
   ...overrides,
 })
 
+const task = (overrides: Partial<Task> = {}): Task => ({
+  id: 'task-1',
+  workspaceId: 'ws-1',
+  columnId: 'col-1',
+  title: 'Task',
+  description: '',
+  branch: null,
+  agentType: null,
+  agentMode: null,
+  agentStatus: null,
+  queuedAt: null,
+  batchId: null,
+  pipelineState: 'idle',
+  pipelineTriggeredAt: null,
+  pipelineError: null,
+  retryCount: 0,
+  model: null,
+  lastScriptExitCode: null,
+  reviewStatus: null,
+  prNumber: null,
+  prUrl: null,
+  siegeIteration: 0,
+  siegeActive: false,
+  siegeMaxIterations: 5,
+  siegeLastChecked: null,
+  prMergeable: null,
+  prCiStatus: null,
+  prReviewDecision: null,
+  prCommentCount: 0,
+  prIsDraft: false,
+  prLabels: '[]',
+  prLastFetched: null,
+  prHeadSha: null,
+  checklist: null,
+  notifyStakeholders: null,
+  notificationSentAt: null,
+  triggerOverrides: null,
+  triggerPrompt: null,
+  lastOutput: null,
+  dependencies: null,
+  blocked: false,
+  worktreePath: null,
+  position: 0,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
 describe('task-template-store', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -34,6 +84,13 @@ describe('task-template-store', () => {
       loadedWorkspaceId: null,
       loadingWorkspaceId: null,
     })
+    useTaskStore.setState({ tasks: [], loaded: false })
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      loaded: false,
+    })
+    useWorkspaceStore.setState({ refreshWorkspace: vi.fn() })
   })
 
   it('clears templates while loading a different workspace', async () => {
@@ -77,6 +134,56 @@ describe('task-template-store', () => {
     await useTaskTemplateStore.getState().saveFromTask('task-1')
 
     expect(useTaskTemplateStore.getState().templates.map((item) => item.id)).toEqual(['existing'])
+  })
+
+  it('keeps templates sorted after save and edit', async () => {
+    useTaskTemplateStore.setState({
+      templates: [
+        template({ id: 'old', title: 'Old', updatedAt: '2024-01-01T00:00:00Z' }),
+        template({ id: 'middle', title: 'Middle', updatedAt: '2024-01-02T00:00:00Z' }),
+      ],
+      loadedWorkspaceId: 'ws-1',
+      loadingWorkspaceId: null,
+    })
+    mockIpc.createTaskTemplateFromTask.mockResolvedValueOnce(
+      template({ id: 'new', title: 'New', updatedAt: '2024-01-03T00:00:00Z' }),
+    )
+    mockIpc.updateTaskTemplate.mockResolvedValueOnce(
+      template({ id: 'old', title: 'Old edited', updatedAt: '2024-01-04T00:00:00Z' }),
+    )
+
+    await useTaskTemplateStore.getState().saveFromTask('task-1')
+    expect(useTaskTemplateStore.getState().templates.map((item) => item.id)).toEqual(['new', 'middle', 'old'])
+
+    await useTaskTemplateStore.getState().update('old', {
+      title: 'Old edited',
+      description: null,
+      labels: '[]',
+      model: null,
+    })
+
+    expect(useTaskTemplateStore.getState().templates.map((item) => item.id)).toEqual(['old', 'new', 'middle'])
+  })
+
+  it('adds a task from a template and refreshes its workspace', async () => {
+    const refreshWorkspace = vi.fn().mockResolvedValue(undefined)
+    useWorkspaceStore.setState({ refreshWorkspace })
+    const createdTask = task({ id: 'created-task', workspaceId: 'ws-1', columnId: 'col-1' })
+    mockIpc.createTaskFromTemplate.mockResolvedValueOnce(createdTask)
+    mockIpc.listTaskTemplates.mockResolvedValueOnce([
+      template({ id: 'template-1', workspaceId: 'ws-1' }),
+    ])
+    useTaskTemplateStore.setState({
+      templates: [template({ id: 'template-1', workspaceId: 'ws-1' })],
+      loadedWorkspaceId: 'ws-1',
+      loadingWorkspaceId: null,
+    })
+
+    await useTaskTemplateStore.getState().createTask('template-1', 'col-1')
+
+    expect(mockIpc.createTaskFromTemplate).toHaveBeenCalledWith('template-1', 'col-1')
+    expect(useTaskStore.getState().tasks).toEqual([createdTask])
+    expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
   })
 
   it('ignores stale load responses when switching workspaces quickly', async () => {

--- a/src/stores/task-template-store.test.ts
+++ b/src/stores/task-template-store.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { TaskTemplate } from '@/types'
+
+vi.mock('@/lib/ipc', () => ({
+  listTaskTemplates: vi.fn(),
+  createTaskTemplateFromTask: vi.fn(),
+  updateTaskTemplate: vi.fn(),
+  deleteTaskTemplate: vi.fn(),
+  createTaskFromTemplate: vi.fn(),
+}))
+
+import * as ipc from '@/lib/ipc'
+import { useTaskTemplateStore } from './task-template-store'
+
+const mockIpc = vi.mocked(ipc)
+
+const template = (overrides: Partial<TaskTemplate> = {}): TaskTemplate => ({
+  id: 'template-1',
+  workspaceId: 'ws-1',
+  title: 'Template',
+  description: null,
+  labels: '[]',
+  model: null,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('task-template-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useTaskTemplateStore.setState({
+      templates: [],
+      loadedWorkspaceId: null,
+      loadingWorkspaceId: null,
+    })
+  })
+
+  it('clears templates while loading a different workspace', async () => {
+    useTaskTemplateStore.setState({
+      templates: [template({ workspaceId: 'ws-1' })],
+      loadedWorkspaceId: 'ws-1',
+      loadingWorkspaceId: null,
+    })
+
+    let resolveTemplates: (templates: TaskTemplate[]) => void = () => {}
+    mockIpc.listTaskTemplates.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveTemplates = resolve
+      }),
+    )
+
+    const loadPromise = useTaskTemplateStore.getState().load('ws-2')
+
+    expect(useTaskTemplateStore.getState().templates).toEqual([])
+    expect(useTaskTemplateStore.getState().loadedWorkspaceId).toBeNull()
+    expect(useTaskTemplateStore.getState().loadingWorkspaceId).toBe('ws-2')
+
+    const nextTemplates = [template({ id: 'template-2', workspaceId: 'ws-2' })]
+    resolveTemplates(nextTemplates)
+    await loadPromise
+
+    expect(useTaskTemplateStore.getState().templates).toEqual(nextTemplates)
+    expect(useTaskTemplateStore.getState().loadedWorkspaceId).toBe('ws-2')
+  })
+
+  it('only prepends a saved template when its workspace is loaded', async () => {
+    useTaskTemplateStore.setState({
+      templates: [template({ id: 'existing', workspaceId: 'ws-1' })],
+      loadedWorkspaceId: 'ws-1',
+      loadingWorkspaceId: null,
+    })
+    mockIpc.createTaskTemplateFromTask.mockResolvedValueOnce(
+      template({ id: 'other-workspace-template', workspaceId: 'ws-2' }),
+    )
+
+    await useTaskTemplateStore.getState().saveFromTask('task-1')
+
+    expect(useTaskTemplateStore.getState().templates.map((item) => item.id)).toEqual(['existing'])
+  })
+
+  it('ignores stale load responses when switching workspaces quickly', async () => {
+    let resolveWs1: (templates: TaskTemplate[]) => void = () => {}
+    let resolveWs2: (templates: TaskTemplate[]) => void = () => {}
+    mockIpc.listTaskTemplates
+      .mockReturnValueOnce(new Promise((resolve) => { resolveWs1 = resolve }))
+      .mockReturnValueOnce(new Promise((resolve) => { resolveWs2 = resolve }))
+
+    const ws1Load = useTaskTemplateStore.getState().load('ws-1')
+    const ws2Load = useTaskTemplateStore.getState().load('ws-2')
+
+    const ws2Templates = [template({ id: 'template-2', workspaceId: 'ws-2' })]
+    resolveWs2(ws2Templates)
+    await ws2Load
+
+    resolveWs1([template({ id: 'template-1', workspaceId: 'ws-1' })])
+    await ws1Load
+
+    expect(useTaskTemplateStore.getState().templates).toEqual(ws2Templates)
+    expect(useTaskTemplateStore.getState().loadedWorkspaceId).toBe('ws-2')
+  })
+})

--- a/src/stores/task-template-store.ts
+++ b/src/stores/task-template-store.ts
@@ -8,6 +8,7 @@ import { useWorkspaceStore } from '@/stores/workspace-store'
 type TaskTemplateState = {
   templates: TaskTemplate[]
   loadedWorkspaceId: string | null
+  loadingWorkspaceId: string | null
   load: (workspaceId: string) => Promise<void>
   saveFromTask: (taskId: string) => Promise<TaskTemplate>
   update: (id: string, updates: { title: string; description?: string | null; labels: string; model?: string | null }) => Promise<TaskTemplate>
@@ -20,15 +21,34 @@ export const useTaskTemplateStore = create<TaskTemplateState>()(
     (set, get) => ({
       templates: [],
       loadedWorkspaceId: null,
+      loadingWorkspaceId: null,
 
       load: async (workspaceId) => {
-        const templates = await ipc.listTaskTemplates(workspaceId)
-        set({ templates, loadedWorkspaceId: workspaceId })
+        set((state) => (
+          state.loadedWorkspaceId === workspaceId
+            ? state
+            : { templates: [], loadedWorkspaceId: null, loadingWorkspaceId: workspaceId }
+        ))
+        try {
+          const templates = await ipc.listTaskTemplates(workspaceId)
+          if (get().loadingWorkspaceId === workspaceId || get().loadedWorkspaceId === workspaceId) {
+            set({ templates, loadedWorkspaceId: workspaceId, loadingWorkspaceId: null })
+          }
+        } catch (err) {
+          if (get().loadingWorkspaceId === workspaceId) {
+            set({ loadingWorkspaceId: null })
+          }
+          throw err
+        }
       },
 
       saveFromTask: async (taskId) => {
         const template = await ipc.createTaskTemplateFromTask(taskId)
-        set((state) => ({ templates: [template, ...state.templates] }))
+        set((state) => (
+          state.loadedWorkspaceId === template.workspaceId
+            ? { templates: [template, ...state.templates] }
+            : state
+        ))
         return template
       },
 

--- a/src/stores/task-template-store.ts
+++ b/src/stores/task-template-store.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import type { TaskTemplate } from '@/types'
+import * as ipc from '@/lib/ipc'
+import { useTaskStore } from '@/stores/task-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+
+type TaskTemplateState = {
+  templates: TaskTemplate[]
+  loadedWorkspaceId: string | null
+  load: (workspaceId: string) => Promise<void>
+  saveFromTask: (taskId: string) => Promise<TaskTemplate>
+  update: (id: string, updates: { title: string; description?: string | null; labels: string; model?: string | null }) => Promise<TaskTemplate>
+  remove: (id: string) => Promise<void>
+  createTask: (templateId: string, columnId: string) => Promise<void>
+}
+
+export const useTaskTemplateStore = create<TaskTemplateState>()(
+  devtools(
+    (set, get) => ({
+      templates: [],
+      loadedWorkspaceId: null,
+
+      load: async (workspaceId) => {
+        const templates = await ipc.listTaskTemplates(workspaceId)
+        set({ templates, loadedWorkspaceId: workspaceId })
+      },
+
+      saveFromTask: async (taskId) => {
+        const template = await ipc.createTaskTemplateFromTask(taskId)
+        set((state) => ({ templates: [template, ...state.templates] }))
+        return template
+      },
+
+      update: async (id, updates) => {
+        const template = await ipc.updateTaskTemplate(id, updates)
+        set((state) => ({
+          templates: state.templates.map((item) => item.id === id ? template : item),
+        }))
+        return template
+      },
+
+      remove: async (id) => {
+        await ipc.deleteTaskTemplate(id)
+        set((state) => ({
+          templates: state.templates.filter((item) => item.id !== id),
+        }))
+      },
+
+      createTask: async (templateId, columnId) => {
+        const task = await ipc.createTaskFromTemplate(templateId, columnId)
+        useTaskStore.setState((state) => ({ tasks: [...state.tasks, task] }))
+        await useWorkspaceStore.getState().refreshWorkspace(task.workspaceId)
+        const workspaceId = get().loadedWorkspaceId
+        if (workspaceId) {
+          await get().load(workspaceId)
+        }
+      },
+    }),
+    { name: 'task-template-store' },
+  ),
+)

--- a/src/stores/task-template-store.ts
+++ b/src/stores/task-template-store.ts
@@ -4,6 +4,7 @@ import type { TaskTemplate } from '@/types'
 import * as ipc from '@/lib/ipc'
 import { useTaskStore } from '@/stores/task-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import type { TaskTemplateUpdate } from '@/lib/ipc/task-template'
 
 type TaskTemplateState = {
   templates: TaskTemplate[]
@@ -11,7 +12,7 @@ type TaskTemplateState = {
   loadingWorkspaceId: string | null
   load: (workspaceId: string) => Promise<void>
   saveFromTask: (taskId: string) => Promise<TaskTemplate>
-  update: (id: string, updates: { title: string; description?: string | null; labels: string; model?: string | null }) => Promise<TaskTemplate>
+  update: (id: string, updates: TaskTemplateUpdate) => Promise<TaskTemplate>
   remove: (id: string) => Promise<void>
   createTask: (templateId: string, columnId: string) => Promise<void>
 }

--- a/src/stores/task-template-store.ts
+++ b/src/stores/task-template-store.ts
@@ -16,6 +16,13 @@ type TaskTemplateState = {
   createTask: (templateId: string, columnId: string) => Promise<void>
 }
 
+function sortTemplates(templates: TaskTemplate[]) {
+  return [...templates].sort((a, b) => {
+    const updatedCompare = b.updatedAt.localeCompare(a.updatedAt)
+    return updatedCompare !== 0 ? updatedCompare : a.title.localeCompare(b.title)
+  })
+}
+
 export const useTaskTemplateStore = create<TaskTemplateState>()(
   devtools(
     (set, get) => ({
@@ -46,7 +53,7 @@ export const useTaskTemplateStore = create<TaskTemplateState>()(
         const template = await ipc.createTaskTemplateFromTask(taskId)
         set((state) => (
           state.loadedWorkspaceId === template.workspaceId
-            ? { templates: [template, ...state.templates] }
+            ? { templates: sortTemplates([template, ...state.templates.filter((item) => item.id !== template.id)]) }
             : state
         ))
         return template
@@ -55,7 +62,7 @@ export const useTaskTemplateStore = create<TaskTemplateState>()(
       update: async (id, updates) => {
         const template = await ipc.updateTaskTemplate(id, updates)
         set((state) => ({
-          templates: state.templates.map((item) => item.id === id ? template : item),
+          templates: sortTemplates(state.templates.map((item) => item.id === id ? template : item)),
         }))
         return template
       },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export type {
   CliType,
 } from './column'
 export type { Task, TaskChecklistItem, PipelineState, ReviewStatus, PrCiStatus, PrReviewDecision, PrMergeable } from './task'
+export type { TaskTemplate } from './task-template'
 export type { AgentSession, AgentStatus, AgentMode, AgentMessage } from './agent'
 export type { Script, ScriptStep, BashStep, AgentStep, CheckStep, StepType } from './script'
 export { parseSteps } from './script'

--- a/src/types/task-template.ts
+++ b/src/types/task-template.ts
@@ -1,0 +1,10 @@
+export type TaskTemplate = {
+  id: string
+  workspaceId: string
+  title: string
+  description: string | null
+  labels: string
+  model: string | null
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
## Description

Add a templates table in SQLite with title/description/labels/model. Add UI: "Save as template" on task context menu, "New from template" button in column headers. Templates stored per-workspace. Acceptance: save template, create task from template, edit template, cargo check && npx tsc --noEmit passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/task-templates-save-and-reuse-task-patterns` → `staging/overnight-20260430-bento-ya`

## Commits

```
48585d6 Polish task template quality issues
7147ac8 Fix task template browser mocks
ab1b733 Add task template store coverage
17406ca test: increase rebase-pr test timeout
bab53cc Fix task template workspace handling
266c347 Add workspace task templates
```

## Changes

```
src-tauri/src/commands/mod.rs                      |   1 +
 src-tauri/src/commands/task_template.rs            | 114 ++++++++++
 src-tauri/src/db/migrations/032_task_templates.sql |  13 ++
 src-tauri/src/db/mod.rs                            |   7 +-
 src-tauri/src/db/models.rs                         |  15 ++
 src-tauri/src/db/task_template.rs                  | 168 +++++++++++++++
 src-tauri/src/lib.rs                               |   6 +
 src/components/kanban/column-header.tsx            |  13 ++
 src/components/kanban/column.tsx                   |  17 +-
 src/components/kanban/task-card.tsx                |   1 +
 src/components/kanban/task-context-menu.tsx        |  11 +-
 src/components/kanban/task-template-dialog.tsx     | 240 +++++++++++++++++++++
 src/components/kanban/use-task-card-actions.ts     |   7 +
 src/lib/browser-mock.ts                            | 131 ++++++++++-
 src/lib/ipc/index.ts                               |   1 +
 src/lib/ipc/task-template.ts                       |  26 +++
 src/scripts/rebase-pr.test.ts                      |   5 +-
 src/stores/task-template-store.test.ts             | 209 ++++++++++++++++++
 src/stores/task-template-store.ts                  |  90 ++++++++
 src/types/index.ts                                 |   1 +
 src/types/task-template.ts                         |  10 +
 21 files changed, 1079 insertions(+), 7 deletions(-)
```