### PR TITLE
Window state persistence — remember size, position, zoom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-shell",
  "tauri-plugin-webdriver-automation",
+ "tauri-plugin-window-state",
  "thiserror 1.0.69",
  "tokio",
  "uuid",
@@ -4907,6 +4908,21 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-window-state = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:webview:allow-set-webview-zoom",
     "shell:allow-open",
     "dialog:allow-open",
     "fs:allow-read"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod usage;
 pub mod voice;
 #[cfg(not(feature = "voice"))]
 pub mod voice_stubs;
+pub mod window_state;
 #[cfg(not(feature = "voice"))]
 pub use voice_stubs as voice;
 pub mod workspace;

--- a/src-tauri/src/commands/window_state.rs
+++ b/src-tauri/src/commands/window_state.rs
@@ -1,0 +1,133 @@
+use crate::error::AppError;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::Manager;
+
+const WINDOW_ZOOM_FILENAME: &str = ".window-zoom.json";
+const MIN_ZOOM: f64 = 0.5;
+const MAX_ZOOM: f64 = 2.0;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WindowZoomState {
+    zoom: f64,
+}
+
+fn normalize_zoom(zoom: f64) -> Result<f64, AppError> {
+    if !zoom.is_finite() {
+        return Err(AppError::InvalidInput(
+            "Window zoom must be a finite number".to_string(),
+        ));
+    }
+
+    let clamped = zoom.clamp(MIN_ZOOM, MAX_ZOOM);
+    Ok((clamped * 100.0).round() / 100.0)
+}
+
+fn zoom_state_path(app: &tauri::AppHandle) -> Result<PathBuf, AppError> {
+    app.path()
+        .app_config_dir()
+        .map(|dir| dir.join(WINDOW_ZOOM_FILENAME))
+        .map_err(|err| AppError::CommandError(format!("Failed to resolve app config dir: {err}")))
+}
+
+fn read_window_zoom_from_path(path: PathBuf) -> Result<Option<f64>, AppError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = std::fs::read_to_string(&path).map_err(|err| {
+        AppError::CommandError(format!("Failed to read window zoom state: {err}"))
+    })?;
+    let state: WindowZoomState = serde_json::from_str(&raw).map_err(|err| {
+        AppError::CommandError(format!("Failed to parse window zoom state: {err}"))
+    })?;
+
+    normalize_zoom(state.zoom).map(Some)
+}
+
+fn write_window_zoom_to_path(path: PathBuf, zoom: f64) -> Result<f64, AppError> {
+    let normalized = normalize_zoom(zoom)?;
+    let parent = path.parent().ok_or_else(|| {
+        AppError::CommandError("Window zoom state path has no parent directory".to_string())
+    })?;
+
+    std::fs::create_dir_all(parent)
+        .map_err(|err| AppError::CommandError(format!("Failed to create app config dir: {err}")))?;
+
+    let state = WindowZoomState { zoom: normalized };
+    let raw = serde_json::to_vec_pretty(&state).map_err(|err| {
+        AppError::CommandError(format!("Failed to serialize window zoom state: {err}"))
+    })?;
+
+    std::fs::write(path, raw).map_err(|err| {
+        AppError::CommandError(format!("Failed to write window zoom state: {err}"))
+    })?;
+
+    Ok(normalized)
+}
+
+#[tauri::command]
+pub fn get_window_zoom(app: tauri::AppHandle) -> Result<Option<f64>, AppError> {
+    read_window_zoom_from_path(zoom_state_path(&app)?)
+}
+
+#[tauri::command]
+pub fn set_window_zoom(app: tauri::AppHandle, zoom: f64) -> Result<f64, AppError> {
+    write_window_zoom_to_path(zoom_state_path(&app)?, zoom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_zoom_path(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "bento-ya-window-zoom-{name}-{}-{}.json",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    #[test]
+    fn writes_and_reads_normalized_zoom() {
+        let path = temp_zoom_path("roundtrip");
+
+        let written = write_window_zoom_to_path(path.clone(), 1.234).unwrap();
+        let read = read_window_zoom_from_path(path.clone()).unwrap();
+
+        assert_eq!(written, 1.23);
+        assert_eq!(read, Some(1.23));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn clamps_zoom_to_supported_bounds() {
+        let path = temp_zoom_path("clamp");
+
+        assert_eq!(write_window_zoom_to_path(path.clone(), 10.0).unwrap(), 2.0);
+        assert_eq!(read_window_zoom_from_path(path.clone()).unwrap(), Some(2.0));
+
+        assert_eq!(write_window_zoom_to_path(path.clone(), 0.1).unwrap(), 0.5);
+        assert_eq!(read_window_zoom_from_path(path.clone()).unwrap(), Some(0.5));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn returns_none_when_zoom_state_does_not_exist() {
+        let path = temp_zoom_path("missing");
+
+        assert_eq!(read_window_zoom_from_path(path).unwrap(), None);
+    }
+
+    #[test]
+    fn rejects_non_finite_zoom() {
+        let path = temp_zoom_path("non-finite");
+
+        assert!(write_window_zoom_to_path(path, f64::NAN).is_err());
+    }
+}

--- a/src-tauri/src/commands/window_state.rs
+++ b/src-tauri/src/commands/window_state.rs
@@ -1,6 +1,6 @@
 use crate::error::AppError;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::Manager;
 
 const WINDOW_ZOOM_FILENAME: &str = ".window-zoom.json";
@@ -30,12 +30,12 @@ fn zoom_state_path(app: &tauri::AppHandle) -> Result<PathBuf, AppError> {
         .map_err(|err| AppError::CommandError(format!("Failed to resolve app config dir: {err}")))
 }
 
-fn read_window_zoom_from_path(path: PathBuf) -> Result<Option<f64>, AppError> {
+fn read_window_zoom_from_path(path: &Path) -> Result<Option<f64>, AppError> {
     if !path.exists() {
         return Ok(None);
     }
 
-    let raw = std::fs::read_to_string(&path).map_err(|err| {
+    let raw = std::fs::read_to_string(path).map_err(|err| {
         AppError::CommandError(format!("Failed to read window zoom state: {err}"))
     })?;
     let state: WindowZoomState = serde_json::from_str(&raw).map_err(|err| {
@@ -45,7 +45,7 @@ fn read_window_zoom_from_path(path: PathBuf) -> Result<Option<f64>, AppError> {
     normalize_zoom(state.zoom).map(Some)
 }
 
-fn write_window_zoom_to_path(path: PathBuf, zoom: f64) -> Result<f64, AppError> {
+fn write_window_zoom_to_path(path: &Path, zoom: f64) -> Result<f64, AppError> {
     let normalized = normalize_zoom(zoom)?;
     let parent = path.parent().ok_or_else(|| {
         AppError::CommandError("Window zoom state path has no parent directory".to_string())
@@ -68,12 +68,12 @@ fn write_window_zoom_to_path(path: PathBuf, zoom: f64) -> Result<f64, AppError> 
 
 #[tauri::command]
 pub fn get_window_zoom(app: tauri::AppHandle) -> Result<Option<f64>, AppError> {
-    read_window_zoom_from_path(zoom_state_path(&app)?)
+    read_window_zoom_from_path(&zoom_state_path(&app)?)
 }
 
 #[tauri::command]
 pub fn set_window_zoom(app: tauri::AppHandle, zoom: f64) -> Result<f64, AppError> {
-    write_window_zoom_to_path(zoom_state_path(&app)?, zoom)
+    write_window_zoom_to_path(&zoom_state_path(&app)?, zoom)
 }
 
 #[cfg(test)]
@@ -95,8 +95,8 @@ mod tests {
     fn writes_and_reads_normalized_zoom() {
         let path = temp_zoom_path("roundtrip");
 
-        let written = write_window_zoom_to_path(path.clone(), 1.234).unwrap();
-        let read = read_window_zoom_from_path(path.clone()).unwrap();
+        let written = write_window_zoom_to_path(&path, 1.234).unwrap();
+        let read = read_window_zoom_from_path(&path).unwrap();
 
         assert_eq!(written, 1.23);
         assert_eq!(read, Some(1.23));
@@ -108,11 +108,11 @@ mod tests {
     fn clamps_zoom_to_supported_bounds() {
         let path = temp_zoom_path("clamp");
 
-        assert_eq!(write_window_zoom_to_path(path.clone(), 10.0).unwrap(), 2.0);
-        assert_eq!(read_window_zoom_from_path(path.clone()).unwrap(), Some(2.0));
+        assert_eq!(write_window_zoom_to_path(&path, 10.0).unwrap(), 2.0);
+        assert_eq!(read_window_zoom_from_path(&path).unwrap(), Some(2.0));
 
-        assert_eq!(write_window_zoom_to_path(path.clone(), 0.1).unwrap(), 0.5);
-        assert_eq!(read_window_zoom_from_path(path.clone()).unwrap(), Some(0.5));
+        assert_eq!(write_window_zoom_to_path(&path, 0.1).unwrap(), 0.5);
+        assert_eq!(read_window_zoom_from_path(&path).unwrap(), Some(0.5));
 
         let _ = std::fs::remove_file(path);
     }
@@ -121,13 +121,13 @@ mod tests {
     fn returns_none_when_zoom_state_does_not_exist() {
         let path = temp_zoom_path("missing");
 
-        assert_eq!(read_window_zoom_from_path(path).unwrap(), None);
+        assert_eq!(read_window_zoom_from_path(&path).unwrap(), None);
     }
 
     #[test]
     fn rejects_non_finite_zoom() {
         let path = temp_zoom_path("non-finite");
 
-        assert!(write_window_zoom_to_path(path, f64::NAN).is_err());
+        assert!(write_window_zoom_to_path(&path, f64::NAN).is_err());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ use chat::registry::{new_shared_session_registry, start_idle_sweep};
 use commands::voice::RecorderState;
 use db::AppState;
 use tauri::Manager;
+use tauri_plugin_window_state::StateFlags;
 #[cfg(feature = "voice")]
 use whisper::AudioRecorder;
 
@@ -64,7 +65,11 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED)
+                .build(),
+        )
         .manage(state)
         .manage(session_registry);
 
@@ -209,6 +214,9 @@ pub fn run() {
             commands::usage::get_workspace_usage_summary,
             commands::usage::get_task_usage_summary,
             commands::usage::clear_workspace_usage,
+            // Window state commands
+            commands::window_state::get_window_zoom,
+            commands::window_state::set_window_zoom,
             // History commands
             commands::history::create_snapshot,
             commands::history::get_snapshot,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .manage(state)
         .manage(session_registry);
 

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -360,7 +360,7 @@ const mockCommands: Record<string, CommandHandler> = {
   update_settings: () => undefined,
   get_window_zoom: () => mockWindowZoom,
   set_window_zoom: (args) => {
-    const zoom = args?.zoom as number
+    const zoom = typeof args?.zoom === 'number' ? args.zoom : null
     mockWindowZoom = Number.isFinite(zoom) ? zoom : 1
     return mockWindowZoom
   },

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -137,6 +137,7 @@ let mockTasks: Task[] = [
 ]
 
 let idCounter = 100
+let mockWindowZoom: number | null = null
 
 const generateId = (prefix: string) => `${prefix}-${String(++idCounter)}`
 
@@ -357,6 +358,12 @@ const mockCommands: Record<string, CommandHandler> = {
   // Settings
   get_settings: () => ({ theme: 'dark', defaultTemplate: 'standard' }),
   update_settings: () => undefined,
+  get_window_zoom: () => mockWindowZoom,
+  set_window_zoom: (args) => {
+    const zoom = args?.zoom as number
+    mockWindowZoom = Number.isFinite(zoom) ? zoom : 1
+    return mockWindowZoom
+  },
 
   // PR creation (stub)
   create_pr: (args) => {
@@ -929,4 +936,5 @@ export function resetMockData() {
   ]
 
   idCounter = 100
+  mockWindowZoom = null
 }

--- a/src/lib/window-zoom.test.ts
+++ b/src/lib/window-zoom.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { getCurrentWebviewMock, setZoomMock } = vi.hoisted(() => ({
+const { getCurrentWebviewMock, setZoomMock, invokeMock } = vi.hoisted(() => ({
   getCurrentWebviewMock: vi.fn(),
   setZoomMock: vi.fn(),
+  invokeMock: vi.fn(),
 }))
 
 vi.mock('@tauri-apps/api/webview', () => ({
   getCurrentWebview: getCurrentWebviewMock,
+}))
+
+vi.mock('./ipc/invoke', () => ({
+  invoke: invokeMock,
 }))
 
 const STORAGE_KEY = 'bento-window-zoom'
@@ -17,6 +22,8 @@ async function importWindowZoom() {
 
 async function waitForAsyncZoom() {
   await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
 }
 
 describe('window zoom persistence', () => {
@@ -25,9 +32,14 @@ describe('window zoom persistence', () => {
     vi.clearAllMocks()
     localStorage.clear()
     getCurrentWebviewMock.mockReturnValue({ setZoom: setZoomMock })
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_window_zoom') return Promise.resolve(null)
+      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
+      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
+    })
   })
 
-  it('applies a stored zoom level on initialization', async () => {
+  it('applies a legacy local zoom level on initialization', async () => {
     localStorage.setItem(STORAGE_KEY, '1.25')
     const { initializeWindowZoom } = await importWindowZoom()
 
@@ -36,6 +48,23 @@ describe('window zoom persistence', () => {
 
     expect(setZoomMock).toHaveBeenCalledWith(1.25)
     expect(localStorage.getItem(STORAGE_KEY)).toBe('1.25')
+    expect(invokeMock).toHaveBeenCalledWith('set_window_zoom', { zoom: 1.25 })
+  })
+
+  it('prefers the persisted app zoom over legacy localStorage', async () => {
+    localStorage.setItem(STORAGE_KEY, '1.25')
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_window_zoom') return Promise.resolve(1.5)
+      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
+      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
+    })
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).toHaveBeenCalledWith(1.5)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('1.5')
   })
 
   it('updates and persists zoom from keyboard shortcuts', async () => {
@@ -90,6 +119,28 @@ describe('window zoom persistence', () => {
     expect(setZoomMock).toHaveBeenCalledWith(1)
     expect(consoleError).toHaveBeenCalledWith(
       '[window-zoom] Failed to read stored zoom:',
+      expect.any(Error),
+    )
+
+    consoleError.mockRestore()
+  })
+
+  it('falls back to local zoom when persisted zoom cannot be read', async () => {
+    localStorage.setItem(STORAGE_KEY, '1.2')
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_window_zoom') return Promise.reject(new Error('backend unavailable'))
+      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
+      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).toHaveBeenCalledWith(1.2)
+    expect(consoleError).toHaveBeenCalledWith(
+      '[window-zoom] Failed to read persisted zoom:',
       expect.any(Error),
     )
 

--- a/src/lib/window-zoom.test.ts
+++ b/src/lib/window-zoom.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getCurrentWebviewMock, setZoomMock } = vi.hoisted(() => ({
+  getCurrentWebviewMock: vi.fn(),
+  setZoomMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: getCurrentWebviewMock,
+}))
+
+const STORAGE_KEY = 'bento-window-zoom'
+
+async function importWindowZoom() {
+  return import('./window-zoom')
+}
+
+async function waitForAsyncZoom() {
+  await Promise.resolve()
+}
+
+describe('window zoom persistence', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+    getCurrentWebviewMock.mockReturnValue({ setZoom: setZoomMock })
+  })
+
+  it('applies a stored zoom level on initialization', async () => {
+    localStorage.setItem(STORAGE_KEY, '1.25')
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).toHaveBeenCalledWith(1.25)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('1.25')
+  })
+
+  it('updates and persists zoom from keyboard shortcuts', async () => {
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '=', ctrlKey: true }))
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).toHaveBeenLastCalledWith(1.1)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('1.1')
+  })
+
+  it('clamps invalid stored and shortcut zoom values to supported bounds', async () => {
+    localStorage.setItem(STORAGE_KEY, '4')
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '+', metaKey: true }))
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).toHaveBeenLastCalledWith(2)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('2')
+  })
+
+  it('does not attach duplicate shortcut handlers when initialized twice', async () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    initializeWindowZoom()
+    await waitForAsyncZoom()
+
+    const keydownRegistrations = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === 'keydown',
+    )
+    expect(keydownRegistrations).toHaveLength(1)
+
+    addEventListenerSpy.mockRestore()
+  })
+
+  it('falls back to default zoom when stored data cannot be read', async () => {
+    vi.spyOn(localStorage, 'getItem').mockImplementationOnce(() => {
+      throw new Error('storage unavailable')
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).toHaveBeenCalledWith(1)
+    expect(consoleError).toHaveBeenCalledWith(
+      '[window-zoom] Failed to read stored zoom:',
+      expect.any(Error),
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/lib/window-zoom.test.ts
+++ b/src/lib/window-zoom.test.ts
@@ -21,9 +21,9 @@ async function importWindowZoom() {
 }
 
 async function waitForAsyncZoom() {
-  await Promise.resolve()
-  await Promise.resolve()
-  await Promise.resolve()
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve()
+  }
 }
 
 describe('window zoom persistence', () => {
@@ -145,5 +145,45 @@ describe('window zoom persistence', () => {
     )
 
     consoleError.mockRestore()
+  })
+
+  it('ignores a delayed persisted zoom after the user changes zoom', async () => {
+    let resolvePersistedZoom: (zoom: number | null) => void = () => {}
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_window_zoom') {
+        return new Promise<number | null>((resolve) => {
+          resolvePersistedZoom = resolve
+        })
+      }
+      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
+      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
+    })
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '=', ctrlKey: true }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '-', ctrlKey: true }))
+    resolvePersistedZoom(1.5)
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).not.toHaveBeenCalledWith(1.5)
+    expect(setZoomMock).toHaveBeenLastCalledWith(1)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+
+  it('treats malformed persisted zoom as missing', async () => {
+    localStorage.setItem(STORAGE_KEY, '1.2')
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'get_window_zoom') return Promise.resolve(Number.NaN)
+      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
+      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
+    })
+    const { initializeWindowZoom } = await importWindowZoom()
+
+    initializeWindowZoom()
+    await waitForAsyncZoom()
+
+    expect(setZoomMock).toHaveBeenCalledWith(1.2)
+    expect(invokeMock).toHaveBeenCalledWith('set_window_zoom', { zoom: 1.2 })
   })
 })

--- a/src/lib/window-zoom.test.ts
+++ b/src/lib/window-zoom.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { getCurrentWebviewMock, setZoomMock, invokeMock } = vi.hoisted(() => ({
   getCurrentWebviewMock: vi.fn(),
@@ -20,10 +20,18 @@ async function importWindowZoom() {
   return import('./window-zoom')
 }
 
-async function waitForAsyncZoom() {
+async function flushWindowZoomTasks() {
   for (let i = 0; i < 10; i += 1) {
     await Promise.resolve()
   }
+}
+
+function mockWindowZoomCommands(persistedZoom: number | null | Promise<number | null> = null) {
+  invokeMock.mockImplementation((cmd: string) => {
+    if (cmd === 'get_window_zoom') return Promise.resolve(persistedZoom)
+    if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
+    return Promise.reject(new Error(`Unexpected command: ${cmd}`))
+  })
 }
 
 describe('window zoom persistence', () => {
@@ -32,11 +40,11 @@ describe('window zoom persistence', () => {
     vi.clearAllMocks()
     localStorage.clear()
     getCurrentWebviewMock.mockReturnValue({ setZoom: setZoomMock })
-    invokeMock.mockImplementation((cmd: string) => {
-      if (cmd === 'get_window_zoom') return Promise.resolve(null)
-      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
-      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
-    })
+    mockWindowZoomCommands()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('applies a legacy local zoom level on initialization', async () => {
@@ -44,7 +52,7 @@ describe('window zoom persistence', () => {
     const { initializeWindowZoom } = await importWindowZoom()
 
     initializeWindowZoom()
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).toHaveBeenCalledWith(1.25)
     expect(localStorage.getItem(STORAGE_KEY)).toBe('1.25')
@@ -53,15 +61,11 @@ describe('window zoom persistence', () => {
 
   it('prefers the persisted app zoom over legacy localStorage', async () => {
     localStorage.setItem(STORAGE_KEY, '1.25')
-    invokeMock.mockImplementation((cmd: string) => {
-      if (cmd === 'get_window_zoom') return Promise.resolve(1.5)
-      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
-      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
-    })
+    mockWindowZoomCommands(1.5)
     const { initializeWindowZoom } = await importWindowZoom()
 
     initializeWindowZoom()
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).toHaveBeenCalledWith(1.5)
     expect(localStorage.getItem(STORAGE_KEY)).toBe('1.5')
@@ -72,7 +76,7 @@ describe('window zoom persistence', () => {
 
     initializeWindowZoom()
     window.dispatchEvent(new KeyboardEvent('keydown', { key: '=', ctrlKey: true }))
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).toHaveBeenLastCalledWith(1.1)
     expect(localStorage.getItem(STORAGE_KEY)).toBe('1.1')
@@ -84,7 +88,7 @@ describe('window zoom persistence', () => {
 
     initializeWindowZoom()
     window.dispatchEvent(new KeyboardEvent('keydown', { key: '+', metaKey: true }))
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).toHaveBeenLastCalledWith(2)
     expect(localStorage.getItem(STORAGE_KEY)).toBe('2')
@@ -96,7 +100,7 @@ describe('window zoom persistence', () => {
 
     initializeWindowZoom()
     initializeWindowZoom()
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     const keydownRegistrations = addEventListenerSpy.mock.calls.filter(
       ([eventName]) => eventName === 'keydown',
@@ -114,15 +118,13 @@ describe('window zoom persistence', () => {
     const { initializeWindowZoom } = await importWindowZoom()
 
     initializeWindowZoom()
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).toHaveBeenCalledWith(1)
     expect(consoleError).toHaveBeenCalledWith(
       '[window-zoom] Failed to read stored zoom:',
       expect.any(Error),
     )
-
-    consoleError.mockRestore()
   })
 
   it('falls back to local zoom when persisted zoom cannot be read', async () => {
@@ -136,15 +138,13 @@ describe('window zoom persistence', () => {
     const { initializeWindowZoom } = await importWindowZoom()
 
     initializeWindowZoom()
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).toHaveBeenCalledWith(1.2)
     expect(consoleError).toHaveBeenCalledWith(
       '[window-zoom] Failed to read persisted zoom:',
       expect.any(Error),
     )
-
-    consoleError.mockRestore()
   })
 
   it('ignores a delayed persisted zoom after the user changes zoom', async () => {
@@ -164,7 +164,7 @@ describe('window zoom persistence', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: '=', ctrlKey: true }))
     window.dispatchEvent(new KeyboardEvent('keydown', { key: '-', ctrlKey: true }))
     resolvePersistedZoom(1.5)
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).not.toHaveBeenCalledWith(1.5)
     expect(setZoomMock).toHaveBeenLastCalledWith(1)
@@ -173,15 +173,11 @@ describe('window zoom persistence', () => {
 
   it('treats malformed persisted zoom as missing', async () => {
     localStorage.setItem(STORAGE_KEY, '1.2')
-    invokeMock.mockImplementation((cmd: string) => {
-      if (cmd === 'get_window_zoom') return Promise.resolve(Number.NaN)
-      if (cmd === 'set_window_zoom') return Promise.resolve(undefined)
-      return Promise.reject(new Error(`Unexpected command: ${cmd}`))
-    })
+    mockWindowZoomCommands(Number.NaN)
     const { initializeWindowZoom } = await importWindowZoom()
 
     initializeWindowZoom()
-    await waitForAsyncZoom()
+    await flushWindowZoomTasks()
 
     expect(setZoomMock).toHaveBeenCalledWith(1.2)
     expect(invokeMock).toHaveBeenCalledWith('set_window_zoom', { zoom: 1.2 })

--- a/src/lib/window-zoom.ts
+++ b/src/lib/window-zoom.ts
@@ -1,0 +1,70 @@
+import { getCurrentWebview } from '@tauri-apps/api/webview'
+
+const STORAGE_KEY = 'bento-window-zoom'
+const DEFAULT_ZOOM = 1
+const MIN_ZOOM = 0.5
+const MAX_ZOOM = 2
+const ZOOM_STEP = 0.1
+
+let currentZoom = DEFAULT_ZOOM
+
+function clampZoom(value: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
+}
+
+function normalizeZoom(value: number): number {
+  return Number(clampZoom(value).toFixed(2))
+}
+
+function readStoredZoom(): number {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (!stored) return DEFAULT_ZOOM
+
+  const parsed = Number(stored)
+  if (!Number.isFinite(parsed)) return DEFAULT_ZOOM
+
+  return normalizeZoom(parsed)
+}
+
+async function applyWindowZoom(zoom: number): Promise<void> {
+  const normalized = normalizeZoom(zoom)
+  currentZoom = normalized
+  localStorage.setItem(STORAGE_KEY, String(normalized))
+
+  try {
+    await getCurrentWebview().setZoom(normalized)
+  } catch (error) {
+    console.error('[window-zoom] Failed to apply zoom:', error)
+  }
+}
+
+function isZoomShortcut(event: KeyboardEvent): boolean {
+  return (event.metaKey || event.ctrlKey) && !event.altKey
+}
+
+function handleZoomShortcut(event: KeyboardEvent): void {
+  if (!isZoomShortcut(event)) return
+
+  if (event.key === '+' || (event.key === '=' && !event.shiftKey)) {
+    event.preventDefault()
+    void applyWindowZoom(currentZoom + ZOOM_STEP)
+    return
+  }
+
+  if (event.key === '-' && !event.shiftKey) {
+    event.preventDefault()
+    void applyWindowZoom(currentZoom - ZOOM_STEP)
+    return
+  }
+
+  if (event.key === '0' && !event.shiftKey) {
+    event.preventDefault()
+    void applyWindowZoom(DEFAULT_ZOOM)
+  }
+}
+
+export function initializeWindowZoom(): void {
+  currentZoom = readStoredZoom()
+  void applyWindowZoom(currentZoom)
+  window.addEventListener('keydown', handleZoomShortcut)
+}

--- a/src/lib/window-zoom.ts
+++ b/src/lib/window-zoom.ts
@@ -1,4 +1,5 @@
 import { getCurrentWebview } from '@tauri-apps/api/webview'
+import { invoke } from './ipc/invoke'
 
 const STORAGE_KEY = 'bento-window-zoom'
 const DEFAULT_ZOOM = 1
@@ -35,7 +36,25 @@ function readStoredZoom(): number {
   return normalizeZoom(parsed)
 }
 
-async function applyWindowZoom(zoom: number): Promise<void> {
+async function readPersistedZoom(): Promise<number | null> {
+  try {
+    const zoom = await invoke<number | null>('get_window_zoom')
+    return zoom === null ? null : normalizeZoom(zoom)
+  } catch (error) {
+    console.error('[window-zoom] Failed to read persisted zoom:', error)
+    return null
+  }
+}
+
+async function persistZoom(zoom: number): Promise<void> {
+  try {
+    await invoke<number>('set_window_zoom', { zoom })
+  } catch (error) {
+    console.error('[window-zoom] Failed to persist zoom:', error)
+  }
+}
+
+async function applyWindowZoom(zoom: number, persist = true): Promise<void> {
   const normalized = normalizeZoom(zoom)
   currentZoom = normalized
 
@@ -49,6 +68,10 @@ async function applyWindowZoom(zoom: number): Promise<void> {
     await getCurrentWebview().setZoom(normalized)
   } catch (error) {
     console.error('[window-zoom] Failed to apply zoom:', error)
+  }
+
+  if (persist) {
+    await persistZoom(normalized)
   }
 }
 
@@ -81,7 +104,18 @@ export function initializeWindowZoom(): void {
   if (initialized) return
 
   initialized = true
-  currentZoom = readStoredZoom()
-  void applyWindowZoom(currentZoom)
+  const localZoom = readStoredZoom()
+  currentZoom = localZoom
+  void applyWindowZoom(localZoom, false)
+  void readPersistedZoom().then((persistedZoom) => {
+    if (currentZoom !== localZoom) return
+
+    if (persistedZoom === null) {
+      void persistZoom(localZoom)
+      return
+    }
+
+    void applyWindowZoom(persistedZoom)
+  })
   window.addEventListener('keydown', handleZoomShortcut)
 }

--- a/src/lib/window-zoom.ts
+++ b/src/lib/window-zoom.ts
@@ -7,6 +7,7 @@ const MAX_ZOOM = 2
 const ZOOM_STEP = 0.1
 
 let currentZoom = DEFAULT_ZOOM
+let initialized = false
 
 function clampZoom(value: number): number {
   return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
@@ -17,7 +18,15 @@ function normalizeZoom(value: number): number {
 }
 
 function readStoredZoom(): number {
-  const stored = localStorage.getItem(STORAGE_KEY)
+  let stored: string | null
+
+  try {
+    stored = localStorage.getItem(STORAGE_KEY)
+  } catch (error) {
+    console.error('[window-zoom] Failed to read stored zoom:', error)
+    return DEFAULT_ZOOM
+  }
+
   if (!stored) return DEFAULT_ZOOM
 
   const parsed = Number(stored)
@@ -29,7 +38,12 @@ function readStoredZoom(): number {
 async function applyWindowZoom(zoom: number): Promise<void> {
   const normalized = normalizeZoom(zoom)
   currentZoom = normalized
-  localStorage.setItem(STORAGE_KEY, String(normalized))
+
+  try {
+    localStorage.setItem(STORAGE_KEY, String(normalized))
+  } catch (error) {
+    console.error('[window-zoom] Failed to store zoom:', error)
+  }
 
   try {
     await getCurrentWebview().setZoom(normalized)
@@ -64,6 +78,9 @@ function handleZoomShortcut(event: KeyboardEvent): void {
 }
 
 export function initializeWindowZoom(): void {
+  if (initialized) return
+
+  initialized = true
   currentZoom = readStoredZoom()
   void applyWindowZoom(currentZoom)
   window.addEventListener('keydown', handleZoomShortcut)

--- a/src/lib/window-zoom.ts
+++ b/src/lib/window-zoom.ts
@@ -9,12 +9,16 @@ const ZOOM_STEP = 0.1
 
 let currentZoom = DEFAULT_ZOOM
 let initialized = false
+let zoomRevision = 0
+let applyQueue: Promise<void> = Promise.resolve()
+let persistQueue: Promise<void> = Promise.resolve()
 
 function clampZoom(value: number): number {
   return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
 }
 
 function normalizeZoom(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_ZOOM
   return Number(clampZoom(value).toFixed(2))
 }
 
@@ -39,7 +43,8 @@ function readStoredZoom(): number {
 async function readPersistedZoom(): Promise<number | null> {
   try {
     const zoom = await invoke<number | null>('get_window_zoom')
-    return zoom === null ? null : normalizeZoom(zoom)
+    if (typeof zoom !== 'number' || !Number.isFinite(zoom)) return null
+    return normalizeZoom(zoom)
   } catch (error) {
     console.error('[window-zoom] Failed to read persisted zoom:', error)
     return null
@@ -54,8 +59,28 @@ async function persistZoom(zoom: number): Promise<void> {
   }
 }
 
+function queuePersistZoom(zoom: number): void {
+  const normalized = normalizeZoom(zoom)
+  persistQueue = persistQueue
+    .catch(() => undefined)
+    .then(() => persistZoom(normalized))
+}
+
+function queueWebviewZoom(zoom: number): Promise<void> {
+  const normalized = normalizeZoom(zoom)
+  applyQueue = applyQueue.catch(() => undefined).then(async () => {
+    try {
+      await getCurrentWebview().setZoom(normalized)
+    } catch (error) {
+      console.error('[window-zoom] Failed to apply zoom:', error)
+    }
+  })
+  return applyQueue
+}
+
 async function applyWindowZoom(zoom: number, persist = true): Promise<void> {
   const normalized = normalizeZoom(zoom)
+  zoomRevision += 1
   currentZoom = normalized
 
   try {
@@ -64,14 +89,10 @@ async function applyWindowZoom(zoom: number, persist = true): Promise<void> {
     console.error('[window-zoom] Failed to store zoom:', error)
   }
 
-  try {
-    await getCurrentWebview().setZoom(normalized)
-  } catch (error) {
-    console.error('[window-zoom] Failed to apply zoom:', error)
-  }
+  await queueWebviewZoom(normalized)
 
   if (persist) {
-    await persistZoom(normalized)
+    queuePersistZoom(normalized)
   }
 }
 
@@ -107,11 +128,12 @@ export function initializeWindowZoom(): void {
   const localZoom = readStoredZoom()
   currentZoom = localZoom
   void applyWindowZoom(localZoom, false)
+  const initialZoomRevision = zoomRevision
   void readPersistedZoom().then((persistedZoom) => {
-    if (currentZoom !== localZoom) return
+    if (zoomRevision !== initialZoomRevision) return
 
     if (persistedZoom === null) {
-      void persistZoom(localZoom)
+      queuePersistZoom(localZoom)
       return
     }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,12 @@ import App from './app'
 import './index.css'
 import { initializeAppearance } from './lib/appearance'
 import { initializeTheme } from './lib/theme'
+import { initializeWindowZoom } from './lib/window-zoom'
 
 // Apply saved theme and appearance settings before render
 initializeTheme()
 initializeAppearance()
+initializeWindowZoom()
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 createRoot(document.getElementById('root')!).render(

--- a/src/scripts/rebase-pr.test.ts
+++ b/src/scripts/rebase-pr.test.ts
@@ -114,7 +114,7 @@ describe('scripts/rebase-pr.sh', () => {
     expect(result.stdout).toContain('Clean rebase succeeded')
     expect(git(repo, ['merge-base', '--is-ancestor', 'origin/main', 'feature'])).toBe('')
     expect(git(repo, ['status', '--porcelain'])).toBe('')
-  })
+  }, 30_000)
 
   it('marks manual review and does not push when the guarded fallback fails type-check', () => {
     const { root, repo, origin } = setupRepo()
@@ -142,6 +142,8 @@ describe('scripts/rebase-pr.sh', () => {
     const marker = join(repo, '.git', 'bentoya', 'needs-manual-review-feature.txt')
     expect(existsSync(marker)).toBe(true)
     expect(readFileSync(marker, 'utf8')).toContain('file.txt')
-    expect(git(repo, ['ls-remote', origin, 'refs/heads/feature']).split(/\s+/)[0]).toBe(remoteBefore)
-  })
+    expect(git(repo, ['ls-remote', origin, 'refs/heads/feature']).split(/\s+/)[0]).toBe(
+      remoteBefore,
+    )
+  }, 30_000)
 })


### PR DESCRIPTION
## Description

Persist Tauri window state across launches: size, position, maximized state, zoom level. Use tauri-plugin-window-state or implement custom via app config. Acceptance: resize+move window, restart app, window restores to last position. cargo check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/window-state-persistence-remember-size-position-zo` → `staging/overnight-20260430-bento-ya`

## Commits

```
87529bb Clean up window zoom quality issues
bed1793 Harden window zoom persistence
975c2ec Persist window state and zoom
32f7c84 Harden window zoom persistence
df433ba Persist window state and zoom
```

## Changes

```
Cargo.lock                             |  16 +++
 src-tauri/Cargo.toml                   |   1 +
 src-tauri/capabilities/default.json    |   1 +
 src-tauri/src/commands/mod.rs          |   1 +
 src-tauri/src/commands/window_state.rs | 133 ++++++++++++++++++++++++
 src-tauri/src/lib.rs                   |   9 ++
 src/lib/browser-mock.ts                |   8 ++
 src/lib/window-zoom.test.ts            | 185 +++++++++++++++++++++++++++++++++
 src/lib/window-zoom.ts                 | 143 +++++++++++++++++++++++++
 src/main.tsx                           |   2 +
 src/scripts/rebase-pr.test.ts          |   8 +-
 11 files changed, 504 insertions(+), 3 deletions(-)
```