### PR TITLE
Task duplication via context menu

### DIFF
--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -149,6 +149,23 @@ pub fn update_task(
     Ok(task)
 }
 
+#[tauri::command]
+pub fn duplicate_task(
+    app: AppHandle,
+    state: State<AppState>,
+    id: String,
+) -> Result<Task, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    let task = db::duplicate_task(&conn, &id)?;
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_duplicated");
+
+    Ok(task)
+}
+
 /// Update task trigger settings (overrides, prompt, dependencies)
 #[tauri::command(rename_all = "camelCase")]
 pub fn update_task_triggers(

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -286,7 +286,7 @@ mod tests {
         let later = insert_task(&conn, &ws.id, &col.id, "Later task", None).unwrap();
 
         conn.execute(
-            "UPDATE tasks SET priority = 'high', agent_mode = 'auto', files_touched = ?1, checklist = ?2, agent_session_id = 'session-1', pr_labels = ?3, notify_stakeholders = ?4, trigger_overrides = ?5, trigger_prompt = ?6, dependencies = ?7, blocked = 1, model = 'gpt-test', branch_name = 'feature/original', pr_number = 42, worktree_path = '/tmp/worktree' WHERE id = ?8",
+            "UPDATE tasks SET priority = 'high', agent_mode = 'auto', files_touched = ?1, checklist = ?2, agent_session_id = 'session-1', pr_labels = ?3, notify_stakeholders = ?4, trigger_overrides = ?5, trigger_prompt = ?6, dependencies = ?7, blocked = 1, model = 'gpt-test', siege_max_iterations = 9, branch_name = 'feature/original', pr_number = 42, worktree_path = '/tmp/worktree' WHERE id = ?8",
             params![
                 "[\"src/lib.rs\"]",
                 "[{\"id\":\"check-1\",\"text\":\"Verify\",\"checked\":false}]",
@@ -316,6 +316,7 @@ mod tests {
         assert_eq!(copy.dependencies.as_deref(), Some("[{\"task_id\":\"dep-1\"}]"));
         assert!(copy.blocked);
         assert_eq!(copy.model.as_deref(), Some("gpt-test"));
+        assert_eq!(copy.siege_max_iterations, 9);
         assert_eq!(copy.agent_session_id, None);
         assert_eq!(copy.agent_status.as_deref(), Some("idle"));
         assert_eq!(copy.branch_name, None);

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -278,6 +278,55 @@ mod tests {
     }
 
     #[test]
+    fn test_duplicate_task_copies_metadata_without_session_state() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        let original = insert_task(&conn, &ws.id, &col.id, "Fix bug", Some("Critical issue")).unwrap();
+        let later = insert_task(&conn, &ws.id, &col.id, "Later task", None).unwrap();
+
+        conn.execute(
+            "UPDATE tasks SET priority = 'high', agent_mode = 'auto', files_touched = ?1, checklist = ?2, agent_session_id = 'session-1', pr_labels = ?3, notify_stakeholders = ?4, trigger_overrides = ?5, trigger_prompt = ?6, dependencies = ?7, blocked = 1, model = 'gpt-test', branch_name = 'feature/original', pr_number = 42, worktree_path = '/tmp/worktree' WHERE id = ?8",
+            params![
+                "[\"src/lib.rs\"]",
+                "[{\"id\":\"check-1\",\"text\":\"Verify\",\"checked\":false}]",
+                "[\"bug\",\"urgent\"]",
+                "[\"ops@example.com\"]",
+                "{\"on_entry\":{\"type\":\"none\"}}",
+                "Custom prompt",
+                "[{\"task_id\":\"dep-1\"}]",
+                &original.id,
+            ],
+        )
+        .unwrap();
+
+        let copy = duplicate_task(&conn, &original.id).unwrap();
+        assert_eq!(copy.title, "Fix bug (copy)");
+        assert_eq!(copy.description.as_deref(), Some("Critical issue"));
+        assert_eq!(copy.column_id, original.column_id);
+        assert_eq!(copy.position, original.position + 1);
+        assert_eq!(copy.priority, "high");
+        assert_eq!(copy.agent_mode.as_deref(), Some("auto"));
+        assert_eq!(copy.files_touched, "[\"src/lib.rs\"]");
+        assert_eq!(copy.checklist.as_deref(), Some("[{\"id\":\"check-1\",\"text\":\"Verify\",\"checked\":false}]"));
+        assert_eq!(copy.pr_labels, "[\"bug\",\"urgent\"]");
+        assert_eq!(copy.notify_stakeholders.as_deref(), Some("[\"ops@example.com\"]"));
+        assert_eq!(copy.trigger_overrides.as_deref(), Some("{\"on_entry\":{\"type\":\"none\"}}"));
+        assert_eq!(copy.trigger_prompt.as_deref(), Some("Custom prompt"));
+        assert_eq!(copy.dependencies.as_deref(), Some("[{\"task_id\":\"dep-1\"}]"));
+        assert!(copy.blocked);
+        assert_eq!(copy.model.as_deref(), Some("gpt-test"));
+        assert_eq!(copy.agent_session_id, None);
+        assert_eq!(copy.agent_status.as_deref(), Some("idle"));
+        assert_eq!(copy.branch_name, None);
+        assert_eq!(copy.pr_number, None);
+        assert_eq!(copy.worktree_path, None);
+
+        let shifted = get_task(&conn, &later.id).unwrap();
+        assert_eq!(shifted.position, 2);
+    }
+
+    #[test]
     fn test_agent_session_crud() {
         let conn = init_test().unwrap();
         let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -114,12 +114,12 @@ pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
             id, workspace_id, column_id, title, description, position, priority,
             agent_mode, files_touched, checklist, pipeline_state,
             pr_labels, notify_stakeholders, trigger_overrides, trigger_prompt,
-            dependencies, blocked, model, created_at, updated_at
+            dependencies, blocked, model, siege_max_iterations, created_at, updated_at
         ) VALUES (
             ?1, ?2, ?3, ?4, ?5, ?6, ?7,
             ?8, ?9, ?10, 'idle',
             ?11, ?12, ?13, ?14,
-            ?15, ?16, ?17, ?18, ?19
+            ?15, ?16, ?17, ?18, ?19, ?20
         )",
         params![
             &copy_id,
@@ -139,6 +139,7 @@ pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
             original.dependencies.as_deref(),
             original.blocked as i64,
             original.model.as_deref(),
+            original.siege_max_iterations,
             &ts,
             &ts,
         ],

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -91,6 +91,63 @@ pub fn insert_task(
     get_task(conn, &id)
 }
 
+/// Duplicate a task immediately after the original in the same column.
+///
+/// User-editable metadata is copied, while execution/session state is reset so
+/// the copy does not share an agent session, PR, branch, or worktree.
+pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
+    let original = get_task(conn, id)?;
+    let copy_id = new_id();
+    let ts = now();
+    let copy_position = original.position + 1;
+    let copy_title = format!("{} (copy)", original.title);
+
+    let tx = conn.unchecked_transaction()?;
+
+    tx.execute(
+        "UPDATE tasks SET position = position + 1, updated_at = ?1 WHERE workspace_id = ?2 AND column_id = ?3 AND position >= ?4",
+        params![&ts, &original.workspace_id, &original.column_id, copy_position],
+    )?;
+
+    tx.execute(
+        "INSERT INTO tasks (
+            id, workspace_id, column_id, title, description, position, priority,
+            agent_mode, files_touched, checklist, pipeline_state,
+            pr_labels, notify_stakeholders, trigger_overrides, trigger_prompt,
+            dependencies, blocked, model, created_at, updated_at
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7,
+            ?8, ?9, ?10, 'idle',
+            ?11, ?12, ?13, ?14,
+            ?15, ?16, ?17, ?18, ?19
+        )",
+        params![
+            &copy_id,
+            &original.workspace_id,
+            &original.column_id,
+            &copy_title,
+            original.description.as_deref(),
+            copy_position,
+            &original.priority,
+            original.agent_mode.as_deref(),
+            &original.files_touched,
+            original.checklist.as_deref(),
+            &original.pr_labels,
+            original.notify_stakeholders.as_deref(),
+            original.trigger_overrides.as_deref(),
+            original.trigger_prompt.as_deref(),
+            original.dependencies.as_deref(),
+            original.blocked as i64,
+            original.model.as_deref(),
+            &ts,
+            &ts,
+        ],
+    )?;
+
+    tx.commit()?;
+    get_task(conn, &copy_id)
+}
+
 /// Move a task to the end of a column, resetting its pipeline state to idle.
 pub fn append_task_to_column(conn: &Connection, task_id: &str, column_id: &str) -> SqlResult<Task> {
     let max_pos: i64 = conn

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ pub fn run() {
             commands::task::get_task,
             commands::task::list_tasks,
             commands::task::update_task,
+            commands::task::duplicate_task,
             commands::task::update_task_triggers,
             commands::task::move_task,
             commands::task::reorder_tasks,

--- a/src/components/kanban/task-card.test.tsx
+++ b/src/components/kanban/task-card.test.tsx
@@ -5,7 +5,7 @@ import { useColumnStore } from '@/stores/column-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useUIStore } from '@/stores/ui-store'
 import type { Task } from '@/types'
-import { mockKanbanColumn, mockKanbanTask, setupInvokeMock } from '@/test/mocks/tauri'
+import { mockKanbanColumn, mockKanbanTask, mockWorkspace, setupInvokeMock } from '@/test/mocks/tauri'
 
 vi.mock('@dnd-kit/sortable', () => ({
   useSortable: () => ({
@@ -140,5 +140,28 @@ describe('TaskCard quick-action keyboard behavior', () => {
     await waitFor(() => {
       expect(invoke).toHaveBeenCalledWith('delete_task', { id: 't1' })
     })
+  })
+
+  it('duplicates the task from the context menu', async () => {
+    const task = mockKanbanTask()
+    const duplicatedTask = mockKanbanTask({
+      id: 't1-copy',
+      title: 'Test task (copy)',
+      position: 1,
+    })
+    const invoke = await setupInvokeMock({
+      duplicate_task: duplicatedTask,
+      get_workspace: mockWorkspace({ id: 'ws-1' }),
+    })
+    resetStores(task)
+    render(<TaskCard task={task} />)
+
+    fireEvent.contextMenu(screen.getByText('Test task'))
+    fireEvent.click(screen.getByText('Duplicate'))
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('duplicate_task', { id: 't1' })
+    })
+    expect(useTaskStore.getState().tasks).toContainEqual(duplicatedTask)
   })
 })

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -312,6 +312,58 @@ const mockCommands: Record<string, CommandHandler> = {
     mockTasks.push(task)
     return task
   },
+  duplicate_task: (args) => {
+    const original = mockTasks.find((t) => t.id === args?.id)
+    if (!original) {
+      throw new Error('Task not found')
+    }
+
+    const now = new Date().toISOString()
+    const position = original.position + 1
+    mockTasks = mockTasks.map((task) =>
+      task.workspaceId === original.workspaceId &&
+      task.columnId === original.columnId &&
+      task.position >= position
+        ? { ...task, position: task.position + 1, updatedAt: now }
+        : task,
+    )
+
+    const task: Task = {
+      ...original,
+      id: generateId('task'),
+      title: `${original.title} (copy)`,
+      position,
+      branch: null,
+      agentStatus: 'idle',
+      queuedAt: null,
+      batchId: null,
+      pipelineState: 'idle',
+      pipelineTriggeredAt: null,
+      pipelineError: null,
+      retryCount: 0,
+      lastScriptExitCode: null,
+      reviewStatus: null,
+      prNumber: null,
+      prUrl: null,
+      siegeIteration: 0,
+      siegeActive: false,
+      siegeLastChecked: null,
+      prMergeable: null,
+      prCiStatus: null,
+      prReviewDecision: null,
+      prCommentCount: 0,
+      prIsDraft: false,
+      prLastFetched: null,
+      prHeadSha: null,
+      notificationSentAt: null,
+      lastOutput: null,
+      worktreePath: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    mockTasks.push(task)
+    return task
+  },
   update_task: (args) => {
     const existing = mockTasks.find((t) => t.id === args?.id)
     if (existing) {

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -162,6 +162,38 @@ const withActiveTaskCount = (workspace: Workspace): Workspace => ({
   activeTaskCount: getActiveTaskCount(workspace.id),
 })
 
+const resetDuplicatedTaskState = (task: Task, now: string): Task => ({
+  ...task,
+  branch: null,
+  agentType: null,
+  agentStatus: 'idle',
+  queuedAt: null,
+  batchId: null,
+  pipelineState: 'idle',
+  pipelineTriggeredAt: null,
+  pipelineError: null,
+  retryCount: 0,
+  lastScriptExitCode: null,
+  reviewStatus: null,
+  prNumber: null,
+  prUrl: null,
+  siegeIteration: 0,
+  siegeActive: false,
+  siegeLastChecked: null,
+  prMergeable: null,
+  prCiStatus: null,
+  prReviewDecision: null,
+  prCommentCount: 0,
+  prIsDraft: false,
+  prLastFetched: null,
+  prHeadSha: null,
+  notificationSentAt: null,
+  lastOutput: null,
+  worktreePath: null,
+  createdAt: now,
+  updatedAt: now,
+})
+
 // ─── Mock Command Handlers ──────────────────────────────────────────────────
 
 type CommandHandler = (args?: Record<string, unknown>) => unknown
@@ -328,39 +360,15 @@ const mockCommands: Record<string, CommandHandler> = {
         : task,
     )
 
-    const task: Task = {
-      ...original,
-      id: generateId('task'),
-      title: `${original.title} (copy)`,
-      position,
-      branch: null,
-      agentStatus: 'idle',
-      queuedAt: null,
-      batchId: null,
-      pipelineState: 'idle',
-      pipelineTriggeredAt: null,
-      pipelineError: null,
-      retryCount: 0,
-      lastScriptExitCode: null,
-      reviewStatus: null,
-      prNumber: null,
-      prUrl: null,
-      siegeIteration: 0,
-      siegeActive: false,
-      siegeLastChecked: null,
-      prMergeable: null,
-      prCiStatus: null,
-      prReviewDecision: null,
-      prCommentCount: 0,
-      prIsDraft: false,
-      prLastFetched: null,
-      prHeadSha: null,
-      notificationSentAt: null,
-      lastOutput: null,
-      worktreePath: null,
-      createdAt: now,
-      updatedAt: now,
-    }
+    const task = resetDuplicatedTaskState(
+      {
+        ...original,
+        id: generateId('task'),
+        title: `${original.title} (copy)`,
+        position,
+      },
+      now,
+    )
     mockTasks.push(task)
     return task
   },

--- a/src/lib/ipc/task.ts
+++ b/src/lib/ipc/task.ts
@@ -27,6 +27,10 @@ export async function updateTask(
   return invoke<Task>('update_task', { id, ...updates })
 }
 
+export async function duplicateTask(id: string): Promise<Task> {
+  return invoke<Task>('duplicate_task', { id })
+}
+
 export async function updateTaskTriggers(
   id: string,
   updates: {

--- a/src/scripts/rebase-pr.test.ts
+++ b/src/scripts/rebase-pr.test.ts
@@ -13,6 +13,7 @@ import { join, resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const scriptPath = resolve(process.cwd(), 'scripts/rebase-pr.sh')
+const GIT_INTEGRATION_TIMEOUT_MS = 30_000
 const env = {
   ...process.env,
   GIT_AUTHOR_NAME: 'Test User',
@@ -114,7 +115,7 @@ describe('scripts/rebase-pr.sh', () => {
     expect(result.stdout).toContain('Clean rebase succeeded')
     expect(git(repo, ['merge-base', '--is-ancestor', 'origin/main', 'feature'])).toBe('')
     expect(git(repo, ['status', '--porcelain'])).toBe('')
-  })
+  }, GIT_INTEGRATION_TIMEOUT_MS)
 
   it('marks manual review and does not push when the guarded fallback fails type-check', () => {
     const { root, repo, origin } = setupRepo()
@@ -143,5 +144,5 @@ describe('scripts/rebase-pr.sh', () => {
     expect(existsSync(marker)).toBe(true)
     expect(readFileSync(marker, 'utf8')).toContain('file.txt')
     expect(git(repo, ['ls-remote', origin, 'refs/heads/feature']).split(/\s+/)[0]).toBe(remoteBefore)
-  })
+  }, GIT_INTEGRATION_TIMEOUT_MS)
 })

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -312,6 +312,7 @@ describe('task-store', () => {
           createMockTask({ id: 'task-1', columnId: 'col-1', position: 0 }),
           createMockTask({ id: 'task-2', columnId: 'col-1', position: 1 }),
           createMockTask({ id: 'task-3', columnId: 'col-2', position: 1 }),
+          createMockTask({ id: 'task-4', workspaceId: 'ws-2', columnId: 'col-1', position: 1 }),
         ],
       })
       const duplicatedTask = createMockTask({
@@ -325,10 +326,40 @@ describe('task-store', () => {
       await useTaskStore.getState().duplicate('task-1')
 
       const state = useTaskStore.getState()
-      expect(state.tasks).toHaveLength(4)
+      expect(state.tasks).toHaveLength(5)
       expect(state.tasks).toContainEqual(duplicatedTask)
       expect(state.tasks.find((task) => task.id === 'task-2')?.position).toBe(2)
       expect(state.tasks.find((task) => task.id === 'task-3')?.position).toBe(1)
+      expect(state.tasks.find((task) => task.id === 'task-4')?.position).toBe(1)
+    })
+
+    it('should not add or shift again if sync already loaded the duplicate', async () => {
+      const duplicatedTask = createMockTask({
+        id: 'task-dup',
+        title: 'Original Task (copy)',
+        columnId: 'col-1',
+        position: 1,
+      })
+      useTaskStore.setState({
+        tasks: [
+          createMockTask({ id: 'task-1', columnId: 'col-1', position: 0 }),
+          duplicatedTask,
+          createMockTask({ id: 'task-2', columnId: 'col-1', position: 2 }),
+        ],
+      })
+      mockIpc.duplicateTask.mockResolvedValueOnce({
+        ...duplicatedTask,
+        title: 'Original Task (copy updated)',
+      })
+
+      await useTaskStore.getState().duplicate('task-1')
+
+      const state = useTaskStore.getState()
+      expect(state.tasks).toHaveLength(3)
+      expect(state.tasks.find((task) => task.id === 'task-dup')?.title).toBe(
+        'Original Task (copy updated)',
+      )
+      expect(state.tasks.find((task) => task.id === 'task-2')?.position).toBe(2)
     })
 
     it('should return null for non-existent task', async () => {

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -16,6 +16,7 @@ vi.mock('./workspace-store', () => ({
 vi.mock('@/lib/ipc', () => ({
   getTasks: vi.fn(),
   createTask: vi.fn(),
+  duplicateTask: vi.fn(),
   deleteTask: vi.fn(),
   moveTask: vi.fn(),
   reorderTasks: vi.fn(),
@@ -288,55 +289,53 @@ describe('task-store', () => {
       })
     })
 
-    it('should create a copy of the task with "(Copy)" suffix', async () => {
+    it('should duplicate the task through IPC', async () => {
       const duplicatedTask = createMockTask({
         id: 'task-dup',
-        title: 'Original Task (Copy)',
+        title: 'Original Task (copy)',
         description: 'Some description',
+        position: 1,
       })
-      mockIpc.createTask.mockResolvedValueOnce(duplicatedTask)
+      mockIpc.duplicateTask.mockResolvedValueOnce(duplicatedTask)
       refreshWorkspace.mockResolvedValueOnce(undefined)
 
       const result = await useTaskStore.getState().duplicate('task-1')
 
       expect(result).toEqual(duplicatedTask)
-      expect(mockIpc.createTask).toHaveBeenCalledWith(
-        'ws-1',
-        'col-1',
-        'Original Task (Copy)',
-        'Some description',
-      )
+      expect(mockIpc.duplicateTask).toHaveBeenCalledWith('task-1')
       expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
-    it('should add duplicated task to store', async () => {
-      const duplicatedTask = createMockTask({ id: 'task-dup', title: 'Original Task (Copy)' })
-      mockIpc.createTask.mockResolvedValueOnce(duplicatedTask)
+    it('should add duplicated task to store and shift later local positions', async () => {
+      useTaskStore.setState({
+        tasks: [
+          createMockTask({ id: 'task-1', columnId: 'col-1', position: 0 }),
+          createMockTask({ id: 'task-2', columnId: 'col-1', position: 1 }),
+          createMockTask({ id: 'task-3', columnId: 'col-2', position: 1 }),
+        ],
+      })
+      const duplicatedTask = createMockTask({
+        id: 'task-dup',
+        title: 'Original Task (copy)',
+        columnId: 'col-1',
+        position: 1,
+      })
+      mockIpc.duplicateTask.mockResolvedValueOnce(duplicatedTask)
 
       await useTaskStore.getState().duplicate('task-1')
 
       const state = useTaskStore.getState()
-      expect(state.tasks).toHaveLength(2)
+      expect(state.tasks).toHaveLength(4)
       expect(state.tasks).toContainEqual(duplicatedTask)
-    })
-
-    it('should not add extra "(Copy)" if title already ends with it', async () => {
-      useTaskStore.setState({
-        tasks: [createMockTask({ id: 'task-1', title: 'Already Copied (Copy)' })],
-      })
-      const duplicatedTask = createMockTask({ id: 'task-dup', title: 'Already Copied (Copy)' })
-      mockIpc.createTask.mockResolvedValueOnce(duplicatedTask)
-
-      await useTaskStore.getState().duplicate('task-1')
-
-      expect(mockIpc.createTask).toHaveBeenCalledWith('ws-1', 'col-1', 'Already Copied (Copy)', '')
+      expect(state.tasks.find((task) => task.id === 'task-2')?.position).toBe(2)
+      expect(state.tasks.find((task) => task.id === 'task-3')?.position).toBe(1)
     })
 
     it('should return null for non-existent task', async () => {
       const result = await useTaskStore.getState().duplicate('non-existent')
 
       expect(result).toBeNull()
-      expect(mockIpc.createTask).not.toHaveBeenCalled()
+      expect(mockIpc.duplicateTask).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -107,14 +107,18 @@ export const useTaskStore = create<TaskState>()(
 
         const task = await ipc.duplicateTask(id)
         set((s) => ({
-          tasks: [
-            ...s.tasks.map((existing) =>
-              existing.columnId === task.columnId && existing.position >= task.position
-                ? { ...existing, position: existing.position + 1 }
-                : existing,
-            ),
-            task,
-          ],
+          tasks: s.tasks.some((existing) => existing.id === task.id)
+            ? s.tasks.map((existing) => (existing.id === task.id ? task : existing))
+            : [
+                ...s.tasks.map((existing) =>
+                  existing.workspaceId === task.workspaceId &&
+                  existing.columnId === task.columnId &&
+                  existing.position >= task.position
+                    ? { ...existing, position: existing.position + 1 }
+                    : existing,
+                ),
+                task,
+              ],
         }))
         await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
         return task

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -19,6 +19,23 @@ type TaskState = {
   duplicate: (id: string) => Promise<Task | null>
 }
 
+function insertDuplicatedTask(tasks: Task[], duplicatedTask: Task): Task[] {
+  if (tasks.some((task) => task.id === duplicatedTask.id)) {
+    return tasks.map((task) => (task.id === duplicatedTask.id ? duplicatedTask : task))
+  }
+
+  return [
+    ...tasks.map((task) =>
+      task.workspaceId === duplicatedTask.workspaceId &&
+      task.columnId === duplicatedTask.columnId &&
+      task.position >= duplicatedTask.position
+        ? { ...task, position: task.position + 1 }
+        : task,
+    ),
+    duplicatedTask,
+  ]
+}
+
 export const useTaskStore = create<TaskState>()(
   devtools(
     (set, get) => ({
@@ -107,18 +124,7 @@ export const useTaskStore = create<TaskState>()(
 
         const task = await ipc.duplicateTask(id)
         set((s) => ({
-          tasks: s.tasks.some((existing) => existing.id === task.id)
-            ? s.tasks.map((existing) => (existing.id === task.id ? task : existing))
-            : [
-                ...s.tasks.map((existing) =>
-                  existing.workspaceId === task.workspaceId &&
-                  existing.columnId === task.columnId &&
-                  existing.position >= task.position
-                    ? { ...existing, position: existing.position + 1 }
-                    : existing,
-                ),
-                task,
-              ],
+          tasks: insertDuplicatedTask(s.tasks, task),
         }))
         await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
         return task

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -104,16 +104,18 @@ export const useTaskStore = create<TaskState>()(
       duplicate: async (id) => {
         const original = get().tasks.find((t) => t.id === id)
         if (!original) return null
-        const newTitle = original.title.endsWith(' (Copy)')
-          ? original.title
-          : `${original.title} (Copy)`
-        const task = await ipc.createTask(
-          original.workspaceId,
-          original.columnId,
-          newTitle,
-          original.description,
-        )
-        set((s) => ({ tasks: [...s.tasks, task] }))
+
+        const task = await ipc.duplicateTask(id)
+        set((s) => ({
+          tasks: [
+            ...s.tasks.map((existing) =>
+              existing.columnId === task.columnId && existing.position >= task.position
+                ? { ...existing, position: existing.position + 1 }
+                : existing,
+            ),
+            task,
+          ],
+        }))
         await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
         return task
       },


### PR DESCRIPTION
## Description

Right-click on task → Duplicate. Creates a copy with title suffixed " (copy)", same description/labels, in the same column, position right after original. Add Tauri command duplicate_task. Acceptance: duplicate works, deep copy of metadata, no shared agent_session reference, npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/task-duplication-via-context-menu` → `staging/overnight-20260430-bento-ya`

## Commits

```
610996d Refine task duplication state handling
187cde7 Fix task duplication edge cases
2b612b4 Test task duplication context menu
184b976 Fix duplicate task mock coverage
776a3fe Add task duplication command
```

## Changes

```
src-tauri/src/commands/task.rs           | 17 ++++++++
 src-tauri/src/db/mod.rs                  | 50 +++++++++++++++++++++++
 src-tauri/src/db/task.rs                 | 58 +++++++++++++++++++++++++++
 src-tauri/src/lib.rs                     |  1 +
 src/components/kanban/task-card.test.tsx | 25 +++++++++++-
 src/lib/browser-mock.ts                  | 60 ++++++++++++++++++++++++++++
 src/lib/ipc/task.ts                      |  4 ++
 src/scripts/rebase-pr.test.ts            |  5 ++-
 src/stores/task-store.test.ts            | 68 +++++++++++++++++++++++---------
 src/stores/task-store.ts                 | 32 ++++++++++-----
 10 files changed, 288 insertions(+), 32 deletions(-)
```