### PR TITLE
Per-column metrics card (avg time, success rate, throughput)

### DIFF
--- a/src-tauri/src/commands/pipeline.rs
+++ b/src-tauri/src/commands/pipeline.rs
@@ -1,6 +1,6 @@
 //! Pipeline commands for Tauri IPC
 
-use crate::db::{self, AppState, ColumnTimingAverage, PipelineTiming, Task};
+use crate::db::{self, AppState, ColumnMetrics, ColumnTimingAverage, PipelineTiming, Task};
 use crate::error::AppError;
 use crate::pipeline;
 use tauri::{AppHandle, State};
@@ -91,4 +91,17 @@ pub fn get_average_pipeline_timing(
 ) -> Result<Vec<ColumnTimingAverage>, AppError> {
     let conn = state.db.lock().map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::get_average_pipeline_timing(&conn, &workspace_id)?)
+}
+
+/// Get per-column board metrics for the last 30 days.
+#[tauri::command(rename_all = "camelCase")]
+pub fn get_column_metrics(
+    state: State<AppState>,
+    workspace_id: String,
+) -> Result<Vec<ColumnMetrics>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(db::get_column_metrics(&conn, &workspace_id)?)
 }

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -274,6 +274,20 @@ pub struct ColumnTimingAverage {
     pub failure_count: i64,
 }
 
+/// Per-column pipeline metrics for the board header.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnMetrics {
+    pub column_id: String,
+    pub column_name: String,
+    pub avg_duration_seconds: f64,
+    pub success_rate: f64,
+    pub throughput_per_day: f64,
+    pub sample_count: i64,
+    pub success_count: i64,
+    pub retry_count: i64,
+}
+
 // ─── Usage Tracking Entities ────────────────────────────────────────────────
 
 /// A record of LLM token usage (per-request).

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -131,21 +131,51 @@ pub fn get_average_pipeline_timing(
 /// Get board header metrics for every column in a workspace.
 pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<ColumnMetrics>> {
     let mut stmt = conn.prepare(
-        "SELECT c.id,
+        "WITH timing_metrics AS (
+             SELECT c.id AS column_id,
+                    COALESCE(AVG(pt.duration_seconds), 0) AS avg_duration,
+                    COALESCE(SUM(CASE WHEN pt.success = 1 AND pt.retry_count = 0 THEN 1 ELSE 0 END), 0) AS success_count,
+                    COALESCE(SUM(CASE WHEN pt.retry_count > 0 THEN 1 ELSE 0 END), 0) AS retry_count,
+                    COUNT(pt.id) AS sample_count
+             FROM columns c
+             LEFT JOIN tasks t
+               ON t.workspace_id = c.workspace_id
+              AND t.column_id = c.id
+             LEFT JOIN pipeline_timing pt
+               ON pt.task_id = t.id
+              AND pt.column_id = c.id
+              AND pt.duration_seconds IS NOT NULL
+              AND datetime(pt.exited_at) >= datetime('now', '-30 days')
+             WHERE c.workspace_id = ?1
+             GROUP BY c.id
+         ),
+         session_metrics AS (
+             SELECT c.id AS column_id,
+                    COALESCE(AVG(CAST((julianday(agent_sessions.updated_at) - julianday(agent_sessions.created_at)) * 86400 AS INTEGER)), 0) AS avg_duration,
+                    COALESCE(SUM(CASE WHEN agent_sessions.exit_code = 0 AND t.retry_count = 0 THEN 1 ELSE 0 END), 0) AS success_count,
+                    COALESCE(SUM(CASE WHEN t.retry_count > 0 OR agent_sessions.exit_code != 0 THEN 1 ELSE 0 END), 0) AS retry_count,
+                    COUNT(agent_sessions.id) AS sample_count
+             FROM columns c
+             LEFT JOIN tasks t
+               ON t.workspace_id = c.workspace_id
+              AND t.column_id = c.id
+             LEFT JOIN agent_sessions
+               ON agent_sessions.task_id = t.id
+              AND agent_sessions.exit_code IS NOT NULL
+              AND datetime(agent_sessions.updated_at) >= datetime('now', '-30 days')
+             WHERE c.workspace_id = ?1
+             GROUP BY c.id
+         )
+         SELECT c.id,
                 c.name,
-                COALESCE(AVG(pt.duration_seconds), 0) AS avg_duration,
-                COALESCE(SUM(CASE WHEN pt.success = 1 AND pt.retry_count = 0 THEN 1 ELSE 0 END), 0) AS success_count,
-                COALESCE(SUM(CASE WHEN pt.retry_count > 0 THEN 1 ELSE 0 END), 0) AS retry_count,
-                COUNT(pt.id) AS sample_count
+                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.avg_duration ELSE session_metrics.avg_duration END AS avg_duration,
+                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.success_count ELSE session_metrics.success_count END AS success_count,
+                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.retry_count ELSE session_metrics.retry_count END AS retry_count,
+                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.sample_count ELSE session_metrics.sample_count END AS sample_count
          FROM columns c
-         LEFT JOIN tasks t ON t.workspace_id = c.workspace_id
-         LEFT JOIN pipeline_timing pt
-           ON pt.task_id = t.id
-          AND pt.column_id = c.id
-          AND pt.duration_seconds IS NOT NULL
-          AND datetime(pt.exited_at) >= datetime('now', '-30 days')
+         LEFT JOIN timing_metrics ON timing_metrics.column_id = c.id
+         LEFT JOIN session_metrics ON session_metrics.column_id = c.id
          WHERE c.workspace_id = ?1
-         GROUP BY c.id, c.name, c.position
          ORDER BY c.position ASC",
     )?;
     let rows = stmt.query_map(params![workspace_id], |row| {
@@ -175,8 +205,8 @@ pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Ve
 mod tests {
     use super::*;
     use crate::db::{
-        complete_pipeline_timing, init_test, insert_column, insert_pipeline_timing, insert_task,
-        insert_workspace, now,
+        complete_pipeline_timing, init_test, insert_agent_session, insert_column,
+        insert_pipeline_timing, insert_task, insert_workspace, now,
     };
     use chrono::{Duration, Utc};
     use rusqlite::params;
@@ -264,5 +294,32 @@ mod tests {
         assert_eq!(metrics[0].sample_count, 1);
         assert_eq!(metrics[0].success_count, 1);
         assert_eq!(metrics[0].avg_duration_seconds, 120.0);
+    }
+
+    #[test]
+    fn column_metrics_fall_back_to_completed_agent_sessions() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        let task = insert_task(&conn, &ws.id, &col.id, "A", None).unwrap();
+        let session = insert_agent_session(&conn, &task.id, "codex", None).unwrap();
+
+        conn.execute(
+            "UPDATE agent_sessions
+             SET exit_code = 0,
+                 created_at = datetime('now', '-1 hour'),
+                 updated_at = datetime('now')
+             WHERE id = ?1",
+            params![session.id],
+        )
+        .unwrap();
+
+        let metrics = get_column_metrics(&conn, &ws.id).unwrap();
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].sample_count, 1);
+        assert_eq!(metrics[0].success_count, 1);
+        assert_eq!(metrics[0].retry_count, 0);
+        assert!((metrics[0].avg_duration_seconds - 3600.0).abs() <= 1.0);
     }
 }

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -132,46 +132,37 @@ pub fn get_average_pipeline_timing(
 pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<ColumnMetrics>> {
     let mut stmt = conn.prepare(
         "WITH timing_metrics AS (
-             SELECT c.id AS column_id,
+             SELECT pt.column_id AS column_id,
                     COALESCE(AVG(pt.duration_seconds), 0) AS avg_duration,
                     COALESCE(SUM(CASE WHEN pt.success = 1 AND pt.retry_count = 0 THEN 1 ELSE 0 END), 0) AS success_count,
                     COALESCE(SUM(CASE WHEN pt.retry_count > 0 THEN 1 ELSE 0 END), 0) AS retry_count,
                     COUNT(pt.id) AS sample_count
-             FROM columns c
-             LEFT JOIN tasks t
-               ON t.workspace_id = c.workspace_id
-              AND t.column_id = c.id
-             LEFT JOIN pipeline_timing pt
-               ON pt.task_id = t.id
-              AND pt.column_id = c.id
-              AND pt.duration_seconds IS NOT NULL
-              AND datetime(pt.exited_at) >= datetime('now', '-30 days')
-             WHERE c.workspace_id = ?1
-             GROUP BY c.id
+             FROM pipeline_timing pt
+             JOIN tasks t ON t.id = pt.task_id
+             WHERE t.workspace_id = ?1
+               AND pt.duration_seconds IS NOT NULL
+               AND datetime(pt.exited_at) >= datetime('now', '-30 days')
+             GROUP BY pt.column_id
          ),
          session_metrics AS (
-             SELECT c.id AS column_id,
+             SELECT t.column_id AS column_id,
                     COALESCE(AVG(CAST((julianday(agent_sessions.updated_at) - julianday(agent_sessions.created_at)) * 86400 AS INTEGER)), 0) AS avg_duration,
                     COALESCE(SUM(CASE WHEN agent_sessions.exit_code = 0 AND t.retry_count = 0 THEN 1 ELSE 0 END), 0) AS success_count,
                     COALESCE(SUM(CASE WHEN t.retry_count > 0 OR agent_sessions.exit_code != 0 THEN 1 ELSE 0 END), 0) AS retry_count,
                     COUNT(agent_sessions.id) AS sample_count
-             FROM columns c
-             LEFT JOIN tasks t
-               ON t.workspace_id = c.workspace_id
-              AND t.column_id = c.id
-             LEFT JOIN agent_sessions
-               ON agent_sessions.task_id = t.id
-              AND agent_sessions.exit_code IS NOT NULL
-              AND datetime(agent_sessions.updated_at) >= datetime('now', '-30 days')
-             WHERE c.workspace_id = ?1
-             GROUP BY c.id
+             FROM agent_sessions
+             JOIN tasks t ON t.id = agent_sessions.task_id
+             WHERE t.workspace_id = ?1
+               AND agent_sessions.exit_code IS NOT NULL
+               AND datetime(agent_sessions.updated_at) >= datetime('now', '-30 days')
+             GROUP BY t.column_id
          )
          SELECT c.id,
                 c.name,
-                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.avg_duration ELSE session_metrics.avg_duration END AS avg_duration,
-                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.success_count ELSE session_metrics.success_count END AS success_count,
-                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.retry_count ELSE session_metrics.retry_count END AS retry_count,
-                CASE WHEN timing_metrics.sample_count > 0 THEN timing_metrics.sample_count ELSE session_metrics.sample_count END AS sample_count
+                CASE WHEN COALESCE(timing_metrics.sample_count, 0) > 0 THEN timing_metrics.avg_duration ELSE COALESCE(session_metrics.avg_duration, 0) END AS avg_duration,
+                CASE WHEN COALESCE(timing_metrics.sample_count, 0) > 0 THEN timing_metrics.success_count ELSE COALESCE(session_metrics.success_count, 0) END AS success_count,
+                CASE WHEN COALESCE(timing_metrics.sample_count, 0) > 0 THEN timing_metrics.retry_count ELSE COALESCE(session_metrics.retry_count, 0) END AS retry_count,
+                CASE WHEN COALESCE(timing_metrics.sample_count, 0) > 0 THEN timing_metrics.sample_count ELSE COALESCE(session_metrics.sample_count, 0) END AS sample_count
          FROM columns c
          LEFT JOIN timing_metrics ON timing_metrics.column_id = c.id
          LEFT JOIN session_metrics ON session_metrics.column_id = c.id
@@ -206,7 +197,7 @@ mod tests {
     use super::*;
     use crate::db::{
         complete_pipeline_timing, init_test, insert_agent_session, insert_column,
-        insert_pipeline_timing, insert_task, insert_workspace, now,
+        insert_pipeline_timing, insert_task, insert_workspace, now, update_task,
     };
     use chrono::{Duration, Utc};
     use rusqlite::params;
@@ -247,6 +238,44 @@ mod tests {
         assert_eq!(metrics[0].retry_count, 1);
         assert_eq!(metrics[0].success_rate, 50.0);
         assert!((metrics[0].throughput_per_day - (2.0 / 30.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn column_metrics_count_historical_timing_after_task_moves_columns() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let working = insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        let done = insert_column(&conn, &ws.id, "Done", 1).unwrap();
+        let task = insert_task(&conn, &ws.id, &working.id, "A", None).unwrap();
+
+        insert_pipeline_timing(&conn, &task.id, &working.id, &working.name).unwrap();
+        complete_pipeline_timing(&conn, &task.id, &working.id, true, 0).unwrap();
+        update_task(
+            &conn,
+            &task.id,
+            None,
+            None,
+            Some(&done.id),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let metrics = get_column_metrics(&conn, &ws.id).unwrap();
+        let working_metrics = metrics
+            .iter()
+            .find(|metric| metric.column_id == working.id)
+            .unwrap();
+        let done_metrics = metrics
+            .iter()
+            .find(|metric| metric.column_id == done.id)
+            .unwrap();
+
+        assert_eq!(working_metrics.sample_count, 1);
+        assert_eq!(working_metrics.success_count, 1);
+        assert_eq!(working_metrics.success_rate, 100.0);
+        assert_eq!(done_metrics.sample_count, 0);
     }
 
     #[test]

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -144,7 +144,6 @@ pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Ve
           AND pt.column_id = c.id
           AND pt.duration_seconds IS NOT NULL
           AND datetime(pt.exited_at) >= datetime('now', '-30 days')
-         LEFT JOIN (SELECT DISTINCT task_id FROM agent_sessions) a ON a.task_id = t.id
          WHERE c.workspace_id = ?1
          GROUP BY c.id, c.name, c.position
          ORDER BY c.position ASC",
@@ -163,7 +162,7 @@ pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Ve
             column_name: row.get(1)?,
             avg_duration_seconds: row.get(2)?,
             success_rate,
-            throughput_per_day: success_count as f64 / 30.0,
+            throughput_per_day: sample_count as f64 / 30.0,
             sample_count,
             success_count,
             retry_count: row.get(4)?,
@@ -177,8 +176,10 @@ mod tests {
     use super::*;
     use crate::db::{
         complete_pipeline_timing, init_test, insert_column, insert_pipeline_timing, insert_task,
-        insert_workspace,
+        insert_workspace, now,
     };
+    use chrono::{Duration, Utc};
+    use rusqlite::params;
 
     #[test]
     fn column_metrics_include_empty_columns() {
@@ -215,6 +216,53 @@ mod tests {
         assert_eq!(metrics[0].success_count, 1);
         assert_eq!(metrics[0].retry_count, 1);
         assert_eq!(metrics[0].success_rate, 50.0);
-        assert!((metrics[0].throughput_per_day - (1.0 / 30.0)).abs() < f64::EPSILON);
+        assert!((metrics[0].throughput_per_day - (2.0 / 30.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn column_metrics_ignore_samples_older_than_30_days() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        let old_task = insert_task(&conn, &ws.id, &col.id, "Old", None).unwrap();
+        let recent_task = insert_task(&conn, &ws.id, &col.id, "Recent", None).unwrap();
+        let old_entered_at = (Utc::now() - Duration::days(40)).to_rfc3339();
+        let old_exited_at = (Utc::now() - Duration::days(39)).to_rfc3339();
+
+        conn.execute(
+            "INSERT INTO pipeline_timing
+             (id, task_id, column_id, column_name, entered_at, exited_at, duration_seconds, success, retry_count)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 3600, 1, 0)",
+            params![
+                "old-timing",
+                old_task.id,
+                col.id,
+                col.name,
+                old_entered_at,
+                old_exited_at,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO pipeline_timing
+             (id, task_id, column_id, column_name, entered_at, exited_at, duration_seconds, success, retry_count)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 120, 1, 0)",
+            params![
+                "recent-timing",
+                recent_task.id,
+                col.id,
+                col.name,
+                now(),
+                now(),
+            ],
+        )
+        .unwrap();
+
+        let metrics = get_column_metrics(&conn, &ws.id).unwrap();
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].sample_count, 1);
+        assert_eq!(metrics[0].success_count, 1);
+        assert_eq!(metrics[0].avg_duration_seconds, 120.0);
     }
 }

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -3,6 +3,8 @@ use rusqlite::{params, Connection, Result as SqlResult};
 use super::models::{ColumnMetrics, ColumnTimingAverage, PipelineTiming};
 use super::{new_id, now};
 
+const COLUMN_METRICS_WINDOW_DAYS: i64 = 30;
+
 /// Map a database row to a PipelineTiming struct.
 fn map_timing_row(row: &rusqlite::Row) -> rusqlite::Result<PipelineTiming> {
     Ok(PipelineTiming {
@@ -130,6 +132,7 @@ pub fn get_average_pipeline_timing(
 
 /// Get board header metrics for every column in a workspace.
 pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<ColumnMetrics>> {
+    let window_modifier = format!("-{COLUMN_METRICS_WINDOW_DAYS} days");
     let mut stmt = conn.prepare(
         "WITH timing_metrics AS (
              SELECT pt.column_id AS column_id,
@@ -141,7 +144,7 @@ pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Ve
              JOIN tasks t ON t.id = pt.task_id
              WHERE t.workspace_id = ?1
                AND pt.duration_seconds IS NOT NULL
-               AND datetime(pt.exited_at) >= datetime('now', '-30 days')
+               AND datetime(pt.exited_at) >= datetime('now', ?2)
              GROUP BY pt.column_id
          ),
          session_metrics AS (
@@ -154,7 +157,7 @@ pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Ve
              JOIN tasks t ON t.id = agent_sessions.task_id
              WHERE t.workspace_id = ?1
                AND agent_sessions.exit_code IS NOT NULL
-               AND datetime(agent_sessions.updated_at) >= datetime('now', '-30 days')
+               AND datetime(agent_sessions.updated_at) >= datetime('now', ?2)
              GROUP BY t.column_id
          )
          SELECT c.id,
@@ -169,7 +172,7 @@ pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Ve
          WHERE c.workspace_id = ?1
          ORDER BY c.position ASC",
     )?;
-    let rows = stmt.query_map(params![workspace_id], |row| {
+    let rows = stmt.query_map(params![workspace_id, window_modifier], |row| {
         let sample_count: i64 = row.get(5)?;
         let success_count: i64 = row.get(3)?;
         let success_rate = if sample_count > 0 {
@@ -183,7 +186,7 @@ pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Ve
             column_name: row.get(1)?,
             avg_duration_seconds: row.get(2)?,
             success_rate,
-            throughput_per_day: sample_count as f64 / 30.0,
+            throughput_per_day: (sample_count as f64) / (COLUMN_METRICS_WINDOW_DAYS as f64),
             sample_count,
             success_count,
             retry_count: row.get(4)?,

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -1,6 +1,6 @@
 use rusqlite::{params, Connection, Result as SqlResult};
 
-use super::models::{ColumnTimingAverage, PipelineTiming};
+use super::models::{ColumnMetrics, ColumnTimingAverage, PipelineTiming};
 use super::{new_id, now};
 
 /// Map a database row to a PipelineTiming struct.
@@ -89,10 +89,7 @@ pub fn complete_pipeline_timing(
 }
 
 /// Get all timing records for a specific task.
-pub fn get_pipeline_timing(
-    conn: &Connection,
-    task_id: &str,
-) -> SqlResult<Vec<PipelineTiming>> {
+pub fn get_pipeline_timing(conn: &Connection, task_id: &str) -> SqlResult<Vec<PipelineTiming>> {
     let mut stmt = conn.prepare(
         "SELECT id, task_id, column_id, column_name, entered_at, exited_at, duration_seconds, success, retry_count
          FROM pipeline_timing WHERE task_id = ?1 ORDER BY entered_at ASC",
@@ -129,4 +126,95 @@ pub fn get_average_pipeline_timing(
         })
     })?;
     rows.collect()
+}
+
+/// Get board header metrics for every column in a workspace.
+pub fn get_column_metrics(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<ColumnMetrics>> {
+    let mut stmt = conn.prepare(
+        "SELECT c.id,
+                c.name,
+                COALESCE(AVG(pt.duration_seconds), 0) AS avg_duration,
+                COALESCE(SUM(CASE WHEN pt.success = 1 AND pt.retry_count = 0 THEN 1 ELSE 0 END), 0) AS success_count,
+                COALESCE(SUM(CASE WHEN pt.retry_count > 0 THEN 1 ELSE 0 END), 0) AS retry_count,
+                COUNT(pt.id) AS sample_count
+         FROM columns c
+         LEFT JOIN tasks t ON t.workspace_id = c.workspace_id
+         LEFT JOIN pipeline_timing pt
+           ON pt.task_id = t.id
+          AND pt.column_id = c.id
+          AND pt.duration_seconds IS NOT NULL
+          AND datetime(pt.exited_at) >= datetime('now', '-30 days')
+         LEFT JOIN (SELECT DISTINCT task_id FROM agent_sessions) a ON a.task_id = t.id
+         WHERE c.workspace_id = ?1
+         GROUP BY c.id, c.name, c.position
+         ORDER BY c.position ASC",
+    )?;
+    let rows = stmt.query_map(params![workspace_id], |row| {
+        let sample_count: i64 = row.get(5)?;
+        let success_count: i64 = row.get(3)?;
+        let success_rate = if sample_count > 0 {
+            (success_count as f64 / sample_count as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        Ok(ColumnMetrics {
+            column_id: row.get(0)?,
+            column_name: row.get(1)?,
+            avg_duration_seconds: row.get(2)?,
+            success_rate,
+            throughput_per_day: success_count as f64 / 30.0,
+            sample_count,
+            success_count,
+            retry_count: row.get(4)?,
+        })
+    })?;
+    rows.collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{
+        complete_pipeline_timing, init_test, insert_column, insert_pipeline_timing, insert_task,
+        insert_workspace,
+    };
+
+    #[test]
+    fn column_metrics_include_empty_columns() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+
+        let metrics = get_column_metrics(&conn, &ws.id).unwrap();
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].column_id, col.id);
+        assert_eq!(metrics[0].sample_count, 0);
+        assert_eq!(metrics[0].success_rate, 0.0);
+        assert_eq!(metrics[0].throughput_per_day, 0.0);
+    }
+
+    #[test]
+    fn column_metrics_summarize_last_30_days() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        let task_a = insert_task(&conn, &ws.id, &col.id, "A", None).unwrap();
+        let task_b = insert_task(&conn, &ws.id, &col.id, "B", None).unwrap();
+
+        insert_pipeline_timing(&conn, &task_a.id, &col.id, &col.name).unwrap();
+        complete_pipeline_timing(&conn, &task_a.id, &col.id, true, 0).unwrap();
+        insert_pipeline_timing(&conn, &task_b.id, &col.id, &col.name).unwrap();
+        complete_pipeline_timing(&conn, &task_b.id, &col.id, false, 1).unwrap();
+
+        let metrics = get_column_metrics(&conn, &ws.id).unwrap();
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].sample_count, 2);
+        assert_eq!(metrics[0].success_count, 1);
+        assert_eq!(metrics[0].retry_count, 1);
+        assert_eq!(metrics[0].success_rate, 50.0);
+        assert!((metrics[0].throughput_per_day - (1.0 / 30.0)).abs() < f64::EPSILON);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,6 +165,7 @@ pub fn run() {
             commands::pipeline::update_script_exit_code,
             commands::pipeline::get_pipeline_timing,
             commands::pipeline::get_average_pipeline_timing,
+            commands::pipeline::get_column_metrics,
             // Siege loop commands
             commands::siege::start_siege,
             commands::siege::stop_siege,

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { IconButton } from '@/components/shared/icon-button'
+import type { ColumnMetrics } from '@/lib/ipc/pipeline'
 
 type ScriptTriggerInfo = {
   scriptName: string
@@ -20,11 +21,67 @@ type ColumnHeaderProps = {
   scriptTrigger?: ScriptTriggerInfo
   isBacklog?: boolean
   batchQueue?: BatchQueueState
+  metrics?: ColumnMetrics
   onConfigure: () => void
   onDelete: () => void
   onAddTask: () => void
   onRunAll?: () => void
   onCancelQueue?: () => void
+}
+
+function formatDuration(seconds: number) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0m'
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const minutes = seconds / 60
+  if (minutes < 60) return `${Math.round(minutes)}m`
+  const hours = minutes / 60
+  if (hours < 24) return `${hours.toFixed(hours < 10 ? 1 : 0)}h`
+  const days = hours / 24
+  return `${days.toFixed(days < 10 ? 1 : 0)}d`
+}
+
+function formatRate(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return '0%'
+  return `${Math.round(value)}%`
+}
+
+function formatThroughput(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return '0/d'
+  if (value < 1) return `${value.toFixed(1)}/d`
+  return `${value.toFixed(value < 10 ? 1 : 0)}/d`
+}
+
+function ColumnMetricsCard({ metrics }: { metrics?: ColumnMetrics }) {
+  const avgDuration = formatDuration(metrics?.avgDurationSeconds ?? 0)
+  const successRate = formatRate(metrics?.successRate ?? 0)
+  const throughput = formatThroughput(metrics?.throughputPerDay ?? 0)
+  const sampleCount = metrics?.sampleCount ?? 0
+  const successCount = metrics?.successCount ?? 0
+  const retryCount = metrics?.retryCount ?? 0
+  const detail = sampleCount > 0
+    ? `Last 30 days: ${sampleCount} completed sample${sampleCount === 1 ? '' : 's'}, ${successCount} reached the next column without retry, ${retryCount} retried.`
+    : 'Last 30 days: no completed samples for this column yet.'
+
+  return (
+    <div
+      className="grid grid-cols-3 gap-px overflow-hidden rounded border border-border-default bg-border-default text-[9px] leading-none"
+      title={detail}
+      aria-label={detail}
+    >
+      <div className="min-w-0 bg-surface px-1 py-1 text-center">
+        <div className="truncate font-semibold text-text-primary">{avgDuration}</div>
+        <div className="mt-0.5 text-[8px] uppercase text-text-secondary">avg</div>
+      </div>
+      <div className="min-w-0 bg-surface px-1 py-1 text-center">
+        <div className="truncate font-semibold text-text-primary">{successRate}</div>
+        <div className="mt-0.5 text-[8px] uppercase text-text-secondary">ok</div>
+      </div>
+      <div className="min-w-0 bg-surface px-1 py-1 text-center">
+        <div className="truncate font-semibold text-text-primary">{throughput}</div>
+        <div className="mt-0.5 text-[8px] uppercase text-text-secondary">flow</div>
+      </div>
+    </div>
+  )
 }
 
 // Icon components
@@ -92,6 +149,7 @@ export const ColumnHeader = memo(function ColumnHeader({
   scriptTrigger,
   isBacklog,
   batchQueue,
+  metrics,
   onConfigure,
   onDelete,
   onAddTask,
@@ -154,6 +212,8 @@ export const ColumnHeader = memo(function ColumnHeader({
             Queued: {batchQueue.completed}/{batchQueue.total}
           </span>
         )}
+
+        <ColumnMetricsCard metrics={metrics} />
 
         <div className="ml-auto flex items-center gap-0.5">
           {/* Run All button (backlog only, when tasks exist and not already queuing) */}

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { IconButton } from '@/components/shared/icon-button'
-import type { ColumnMetrics } from '@/lib/ipc/pipeline'
+import { COLUMN_METRICS_WINDOW_DAYS, type ColumnMetrics } from '@/lib/ipc/pipeline'
 
 type ScriptTriggerInfo = {
   scriptName: string
@@ -31,9 +31,9 @@ type ColumnHeaderProps = {
 
 function formatDuration(seconds: number) {
   if (!Number.isFinite(seconds) || seconds <= 0) return '0m'
-  if (seconds < 60) return `${Math.round(seconds)}s`
+  if (seconds < 60) return `${String(Math.round(seconds))}s`
   const minutes = seconds / 60
-  if (minutes < 60) return `${Math.round(minutes)}m`
+  if (minutes < 60) return `${String(Math.round(minutes))}m`
   const hours = minutes / 60
   if (hours < 24) return `${hours.toFixed(hours < 10 ? 1 : 0)}h`
   const days = hours / 24
@@ -42,7 +42,7 @@ function formatDuration(seconds: number) {
 
 function formatRate(value: number) {
   if (!Number.isFinite(value) || value <= 0) return '0%'
-  return `${Math.round(value)}%`
+  return `${String(Math.round(value))}%`
 }
 
 function formatThroughput(value: number) {
@@ -52,15 +52,18 @@ function formatThroughput(value: number) {
 }
 
 function ColumnMetricsCard({ metrics }: { metrics?: ColumnMetrics }) {
-  const avgDuration = formatDuration(metrics?.avgDurationSeconds ?? 0)
-  const successRate = formatRate(metrics?.successRate ?? 0)
-  const throughput = formatThroughput(metrics?.throughputPerDay ?? 0)
+  const avgDuration = metrics ? formatDuration(metrics.avgDurationSeconds) : '--'
+  const successRate = metrics ? formatRate(metrics.successRate) : '--'
+  const throughput = metrics ? formatThroughput(metrics.throughputPerDay) : '--'
   const sampleCount = metrics?.sampleCount ?? 0
   const successCount = metrics?.successCount ?? 0
   const retryCount = metrics?.retryCount ?? 0
-  const detail = sampleCount > 0
-    ? `Last 30 days: ${sampleCount} completed sample${sampleCount === 1 ? '' : 's'}, ${successCount} reached the next column without retry, ${retryCount} retried.`
-    : 'Last 30 days: no completed samples for this column yet.'
+  const windowDays = String(COLUMN_METRICS_WINDOW_DAYS)
+  const detail = !metrics
+    ? `Last ${windowDays} days: metrics are loading.`
+    : sampleCount > 0
+    ? `Last ${windowDays} days: ${String(sampleCount)} completed sample${sampleCount === 1 ? '' : 's'}, ${String(successCount)} reached the next column without retry, ${String(retryCount)} retried.`
+    : `Last ${windowDays} days: no completed samples for this column yet.`
 
   return (
     <div

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -10,6 +10,7 @@ import { useColumnStore } from '@/stores/column-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useScriptStore } from '@/stores/script-store'
 import { queueBacklog, cancelBacklogQueue } from '@/lib/ipc/pipeline'
+import type { ColumnMetrics } from '@/lib/ipc/pipeline'
 import { ColumnHeader } from './column-header'
 import { TaskCard } from './task-card'
 import { ColumnConfigDialog } from './column-config-dialog'
@@ -23,11 +24,12 @@ type BatchQueueLocalState = {
 
 type ColumnProps = {
   column: ColumnType
+  metrics?: ColumnMetrics
   autoOpenConfig?: boolean
   onConfigOpened?: () => void
 }
 
-export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpened }: ColumnProps) {
+export const Column = memo(function Column({ column, metrics, autoOpenConfig, onConfigOpened }: ColumnProps) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
   const allTasks = useTaskStore((s) => s.tasks)
   const addTask = useTaskStore((s) => s.add)
@@ -208,6 +210,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
             scriptTrigger={scriptTrigger}
             isBacklog={column.position === 0}
             batchQueue={batchQueueState.isQueuing ? { total: batchQueueState.total, completed: batchQueueState.completed } : undefined}
+            metrics={metrics}
             onConfigure={handleConfigure}
             onDelete={handleDelete}
             onAddTask={handleAddTask}

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -25,6 +25,7 @@ import { useChatPanel } from '@/hooks/use-chat-panel'
 import { useUIStore } from '@/stores/ui-store'
 import { CardPositionContext, useCardPositionProvider } from '@/hooks/use-card-positions'
 import { DepDragContext } from '@/hooks/use-dep-drag-context'
+import { getColumnMetrics, type ColumnMetrics } from '@/lib/ipc/pipeline'
 
 export function Board() {
   const panelDock = useUIStore((s) => s.panelDock)
@@ -37,6 +38,7 @@ export function Board() {
   const loadScripts = useScriptStore((s) => s.load)
 
   const [newColumnId, setNewColumnId] = useState<string | null>(null)
+  const [columnMetrics, setColumnMetrics] = useState<Record<string, ColumnMetrics>>({})
 
   const handleAddColumn = useCallback(() => {
     if (!activeWorkspaceId) return
@@ -84,6 +86,20 @@ export function Board() {
     }
   }, [activeWorkspaceId, loadColumns, loadTasks, loadScripts])
 
+  useEffect(() => {
+    if (!activeWorkspaceId) {
+      setColumnMetrics({})
+      return
+    }
+    void getColumnMetrics(activeWorkspaceId)
+      .then((metrics) => {
+        setColumnMetrics(Object.fromEntries(metrics.map((metric) => [metric.columnId, metric])))
+      })
+      .catch((err) => {
+        console.error('[Board] Failed to refresh column metrics:', err)
+      })
+  }, [activeWorkspaceId, tasks])
+
   // Resolve overlay content
   let overlayContent = null
   if (activeItem) {
@@ -115,6 +131,7 @@ export function Board() {
                   <Column
                     key={col.id}
                     column={col}
+                    metrics={columnMetrics[col.id]}
                     autoOpenConfig={col.id === newColumnId}
                     onConfigOpened={col.id === newColumnId ? () => { setNewColumnId(null) } : undefined}
                   />

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -65,6 +65,7 @@ export function Board() {
     .filter((c) => c.visible)
     .sort((a, b) => a.position - b.position)
   const columnIds = sortedColumns.map((c) => c.id)
+  const metricColumnIds = columnIds.join(',')
 
   const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd()
 
@@ -104,7 +105,7 @@ export function Board() {
     return () => {
       cancelled = true
     }
-  }, [activeWorkspaceId, tasks])
+  }, [activeWorkspaceId, tasks, metricColumnIds])
 
   // Resolve overlay content
   let overlayContent = null

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -91,13 +91,19 @@ export function Board() {
       setColumnMetrics({})
       return
     }
+    let cancelled = false
     void getColumnMetrics(activeWorkspaceId)
       .then((metrics) => {
+        if (cancelled) return
         setColumnMetrics(Object.fromEntries(metrics.map((metric) => [metric.columnId, metric])))
       })
       .catch((err) => {
+        if (cancelled) return
         console.error('[Board] Failed to refresh column metrics:', err)
       })
+    return () => {
+      cancelled = true
+    }
   }, [activeWorkspaceId, tasks])
 
   // Resolve overlay content

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react'
+import { useEffect, useCallback, useMemo, useState } from 'react'
 import {
   DndContext,
   DragOverlay,
@@ -61,11 +61,29 @@ export function Board() {
     collapseTask()
   }, [closeChat, collapseTask])
 
-  const sortedColumns = columns
-    .filter((c) => c.visible)
-    .sort((a, b) => a.position - b.position)
-  const columnIds = sortedColumns.map((c) => c.id)
+  const sortedColumns = useMemo(
+    () => columns.filter((c) => c.visible).sort((a, b) => a.position - b.position),
+    [columns],
+  )
+  const columnIds = useMemo(() => sortedColumns.map((c) => c.id), [sortedColumns])
   const metricColumnIds = columnIds.join(',')
+  const metricsRefreshKey = useMemo(
+    () =>
+      tasks
+        .map((task) =>
+          [
+            task.id,
+            task.columnId,
+            task.pipelineState,
+            task.retryCount,
+            task.agentStatus,
+            task.lastScriptExitCode,
+            task.updatedAt,
+          ].join(':'),
+        )
+        .join('|'),
+    [tasks],
+  )
 
   const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd()
 
@@ -98,14 +116,14 @@ export function Board() {
         if (cancelled) return
         setColumnMetrics(Object.fromEntries(metrics.map((metric) => [metric.columnId, metric])))
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         if (cancelled) return
         console.error('[Board] Failed to refresh column metrics:', err)
       })
     return () => {
       cancelled = true
     }
-  }, [activeWorkspaceId, tasks, metricColumnIds])
+  }, [activeWorkspaceId, metricColumnIds, metricsRefreshKey])
 
   // Resolve overlay content
   let overlayContent = null

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -259,6 +259,20 @@ const mockCommands: Record<string, CommandHandler> = {
     })
     return mockColumns.filter((c) => c.workspaceId === args?.workspaceId)
   },
+  get_column_metrics: (args) =>
+    mockColumns
+      .filter((c) => c.workspaceId === args?.workspaceId)
+      .sort((a, b) => a.position - b.position)
+      .map((c) => ({
+        columnId: c.id,
+        columnName: c.name,
+        avgDurationSeconds: 0,
+        successRate: 0,
+        throughputPerDay: 0,
+        sampleCount: 0,
+        successCount: 0,
+        retryCount: 0,
+      })),
 
   // Task commands
   list_tasks: (args) => mockTasks.filter((t) => t.workspaceId === args?.workspaceId),

--- a/src/lib/ipc/pipeline.ts
+++ b/src/lib/ipc/pipeline.ts
@@ -11,6 +11,8 @@ export type PipelineEvent = {
   message: string | null
 }
 
+export const COLUMN_METRICS_WINDOW_DAYS = 30
+
 export type ColumnMetrics = {
   columnId: string
   columnName: string

--- a/src/lib/ipc/pipeline.ts
+++ b/src/lib/ipc/pipeline.ts
@@ -11,6 +11,17 @@ export type PipelineEvent = {
   message: string | null
 }
 
+export type ColumnMetrics = {
+  columnId: string
+  columnName: string
+  avgDurationSeconds: number
+  successRate: number
+  throughputPerDay: number
+  sampleCount: number
+  successCount: number
+  retryCount: number
+}
+
 export async function markPipelineComplete(
   taskId: string,
   success: boolean,
@@ -35,6 +46,10 @@ export async function setPipelineError(
 
 export async function retryPipeline(taskId: string): Promise<Task> {
   return invoke<Task>('retry_pipeline', { taskId })
+}
+
+export async function getColumnMetrics(workspaceId: string): Promise<ColumnMetrics[]> {
+  return invoke<ColumnMetrics[]>('get_column_metrics', { workspaceId })
 }
 
 // ─── Batch Queue ────────────────────────────────────────────────────────────

--- a/src/scripts/rebase-pr.test.ts
+++ b/src/scripts/rebase-pr.test.ts
@@ -114,7 +114,7 @@ describe('scripts/rebase-pr.sh', () => {
     expect(result.stdout).toContain('Clean rebase succeeded')
     expect(git(repo, ['merge-base', '--is-ancestor', 'origin/main', 'feature'])).toBe('')
     expect(git(repo, ['status', '--porcelain'])).toBe('')
-  })
+  }, 120000)
 
   it('marks manual review and does not push when the guarded fallback fails type-check', () => {
     const { root, repo, origin } = setupRepo()
@@ -143,5 +143,5 @@ describe('scripts/rebase-pr.sh', () => {
     expect(existsSync(marker)).toBe(true)
     expect(readFileSync(marker, 'utf8')).toContain('file.txt')
     expect(git(repo, ['ls-remote', origin, 'refs/heads/feature']).split(/\s+/)[0]).toBe(remoteBefore)
-  })
+  }, 120000)
 })


### PR DESCRIPTION
## Description

Show a small metrics card in each column header: avg time tasks spent in this column (last 30 days), success rate (% reached next column without retry), tasks-per-day throughput. Query existing tasks + agent_sessions tables. Acceptance: metrics show on every column, hover for detail, npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/per-column-metrics-card-avg-time-success-rate-thro` → `staging/overnight-20260430-bento-ya`

## Commits

```
fab70cf Polish column metrics implementation
d233242 Fix column metrics aggregation
41a2865 Add column metrics session fallback
86cc739 Stabilize rebase PR integration tests
9bf122a Fix column metrics calculations
6e8d969 Add per-column board metrics
```

## Changes

```
src-tauri/src/commands/pipeline.rs      |  15 +-
 src-tauri/src/db/models.rs              |  14 ++
 src-tauri/src/db/pipeline_timing.rs     | 235 +++++++++++++++++++++++++++++++-
 src-tauri/src/lib.rs                    |   1 +
 src/components/kanban/column-header.tsx |  63 +++++++++
 src/components/kanban/column.tsx        |   5 +-
 src/components/layout/board.tsx         |  52 ++++++-
 src/lib/browser-mock.ts                 |  14 ++
 src/lib/ipc/pipeline.ts                 |  17 +++
 src/scripts/rebase-pr.test.ts           |   4 +-
 10 files changed, 406 insertions(+), 14 deletions(-)
```