### PR TITLE
Custom column creation, rename, and delete UI

### DIFF
--- a/src-tauri/src/commands/column.rs
+++ b/src-tauri/src/commands/column.rs
@@ -1,6 +1,7 @@
 use crate::db::{self, AppState, Column};
 use crate::error::AppError;
 use crate::pipeline::triggers::ColumnTriggersV2;
+use std::collections::HashSet;
 use tauri::State;
 
 #[tauri::command]
@@ -112,6 +113,26 @@ pub fn reorder_columns(
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let existing_columns = db::list_columns(&conn, &workspace_id)?;
+    let existing_ids: HashSet<&str> = existing_columns
+        .iter()
+        .map(|column| column.id.as_str())
+        .collect();
+    let mut requested_ids = HashSet::new();
+    for column_id in &column_ids {
+        if !requested_ids.insert(column_id.as_str()) {
+            return Err(AppError::InvalidInput(format!(
+                "Duplicate column id in reorder request: {}",
+                column_id
+            )));
+        }
+        if !existing_ids.contains(column_id.as_str()) {
+            return Err(AppError::InvalidInput(format!(
+                "Column does not belong to workspace: {}",
+                column_id
+            )));
+        }
+    }
+
     let mut ordered_ids = column_ids;
     for column in existing_columns {
         if !ordered_ids.contains(&column.id) {
@@ -119,9 +140,14 @@ pub fn reorder_columns(
         }
     }
 
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     for (i, col_id) in ordered_ids.iter().enumerate() {
-        db::update_column(&conn, col_id, None, None, Some(i as i64), None, None, None)?;
+        db::update_column(&tx, col_id, None, None, Some(i as i64), None, None, None)?;
     }
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     Ok(db::list_columns(&conn, &workspace_id)?)
 }

--- a/src-tauri/src/commands/column.rs
+++ b/src-tauri/src/commands/column.rs
@@ -118,6 +118,7 @@ pub fn reorder_columns(
         .map(|column| column.id.as_str())
         .collect();
     let mut requested_ids = HashSet::new();
+    let mut ordered_ids = Vec::with_capacity(existing_columns.len());
     for column_id in &column_ids {
         if !requested_ids.insert(column_id.as_str()) {
             return Err(AppError::InvalidInput(format!(
@@ -131,11 +132,11 @@ pub fn reorder_columns(
                 column_id
             )));
         }
+        ordered_ids.push(column_id.clone());
     }
 
-    let mut ordered_ids = column_ids;
     for column in existing_columns {
-        if !ordered_ids.contains(&column.id) {
+        if !requested_ids.contains(column.id.as_str()) {
             ordered_ids.push(column.id);
         }
     }

--- a/src-tauri/src/commands/column.rs
+++ b/src-tauri/src/commands/column.rs
@@ -111,16 +111,18 @@ pub fn reorder_columns(
         .db
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let existing_columns = db::list_columns(&conn, &workspace_id)?;
+    let mut ordered_ids = column_ids;
+    for column in existing_columns {
+        if !ordered_ids.contains(&column.id) {
+            ordered_ids.push(column.id);
+        }
+    }
 
-    for (i, col_id) in column_ids.iter().enumerate() {
+    for (i, col_id) in ordered_ids.iter().enumerate() {
         db::update_column(&conn, col_id, None, None, Some(i as i64), None, None, None)?;
     }
 
-    tx.commit()
-        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::list_columns(&conn, &workspace_id)?)
 }
 
@@ -130,22 +132,6 @@ pub fn delete_column(state: State<AppState>, id: String) -> Result<(), AppError>
         .db
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-
-    // Check if column has tasks
-    let task_count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM tasks WHERE column_id = ?1",
-            rusqlite::params![id],
-            |row| row.get(0),
-        )
-        .map_err(AppError::from)?;
-
-    if task_count > 0 {
-        return Err(AppError::InvalidInput(format!(
-            "Column has {} task(s). Move or delete them first.",
-            task_count
-        )));
-    }
 
     db::delete_column(&conn, &id)?;
     Ok(())

--- a/src/components/kanban/column-header.test.tsx
+++ b/src/components/kanban/column-header.test.tsx
@@ -53,4 +53,24 @@ describe('ColumnHeader', () => {
 
     expect(onRename).not.toHaveBeenCalled()
   })
+
+  it('opens column options from the context menu', () => {
+    render(
+      <ColumnHeader
+        name="Backlog"
+        icon="list"
+        taskCount={1}
+        color="#123456"
+        onConfigure={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onAddTask={vi.fn()}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByText('Backlog').closest('div')!)
+
+    expect(screen.getByText('Configure')).toBeInTheDocument()
+    expect(screen.getByText('Delete')).toBeInTheDocument()
+  })
 })

--- a/src/components/kanban/column-header.test.tsx
+++ b/src/components/kanban/column-header.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ColumnHeader } from './column-header'
+
+describe('ColumnHeader', () => {
+  it('allows renaming on double-click + Enter', () => {
+    const onRename = vi.fn()
+    render(
+      <ColumnHeader
+        name="Backlog"
+        icon="list"
+        taskCount={3}
+        color="#123456"
+        onConfigure={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={onRename}
+        onAddTask={vi.fn()}
+      />
+    )
+
+    const title = screen.getByText('Backlog')
+    fireEvent.dblClick(title)
+
+    const input = screen.getByDisplayValue('Backlog')
+    fireEvent.change(input, { target: { value: 'Ready' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onRename).toHaveBeenCalledTimes(1)
+    expect(onRename).toHaveBeenCalledWith('Ready')
+  })
+
+  it('cancels rename on Escape', () => {
+    const onRename = vi.fn()
+    render(
+      <ColumnHeader
+        name="Backlog"
+        icon="list"
+        taskCount={1}
+        color="#123456"
+        onConfigure={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={onRename}
+        onAddTask={vi.fn()}
+      />
+    )
+
+    const title = screen.getByText('Backlog')
+    fireEvent.dblClick(title)
+
+    const input = screen.getByDisplayValue('Backlog')
+    fireEvent.change(input, { target: { value: 'Cancelled' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onRename).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/kanban/column-header.test.tsx
+++ b/src/components/kanban/column-header.test.tsx
@@ -24,6 +24,7 @@ describe('ColumnHeader', () => {
     const input = screen.getByDisplayValue('Backlog')
     fireEvent.change(input, { target: { value: 'Ready' } })
     fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.blur(input)
 
     expect(onRename).toHaveBeenCalledTimes(1)
     expect(onRename).toHaveBeenCalledWith('Ready')
@@ -68,7 +69,11 @@ describe('ColumnHeader', () => {
       />
     )
 
-    fireEvent.contextMenu(screen.getByText('Backlog').closest('div')!)
+    const header = screen.getByText('Backlog').closest('div')
+    if (header === null) {
+      throw new Error('Expected column header container')
+    }
+    fireEvent.contextMenu(header)
 
     expect(screen.getByText('Configure')).toBeInTheDocument()
     expect(screen.getByText('Delete')).toBeInTheDocument()

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -105,6 +105,7 @@ export const ColumnHeader = memo(function ColumnHeader({
   const [isRenaming, setIsRenaming] = useState(false)
   const [renameValue, setRenameValue] = useState(name)
   const renameInputRef = useRef<HTMLInputElement>(null)
+  const isRenamingRef = useRef(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Close menu when clicking outside
@@ -130,21 +131,25 @@ export const ColumnHeader = memo(function ColumnHeader({
 
   const startRename = useCallback(() => {
     setRenameValue(name)
+    isRenamingRef.current = true
     setIsRenaming(true)
   }, [name])
 
   const finishRename = useCallback(() => {
-    if (isRenaming) {
-      const nextName = renameValue.trim()
-      if (nextName && nextName !== name) {
-        onRename(nextName)
-      }
-      setIsRenaming(false)
-      setRenameValue(name)
+    if (!isRenamingRef.current) {
+      return
     }
-  }, [isRenaming, name, onRename, renameValue])
+    isRenamingRef.current = false
+    const nextName = renameValue.trim()
+    if (nextName && nextName !== name) {
+      onRename(nextName)
+    }
+    setIsRenaming(false)
+    setRenameValue(name)
+  }, [name, onRename, renameValue])
 
   const cancelRename = useCallback(() => {
+    isRenamingRef.current = false
     setIsRenaming(false)
     setRenameValue(name)
   }, [name])
@@ -180,6 +185,7 @@ export const ColumnHeader = memo(function ColumnHeader({
         {isRenaming ? (
           <input
             ref={renameInputRef}
+            aria-label="Column name"
             value={renameValue}
             onChange={(event) => { setRenameValue(event.target.value) }}
             onBlur={finishRename}
@@ -294,6 +300,7 @@ export const ColumnHeader = memo(function ColumnHeader({
                       setShowMenu(false)
                       onConfigure()
                     }}
+                    style={{ cursor: 'pointer' }}
                     className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-surface-hover hover:text-text-primary"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-4 w-4">
@@ -306,6 +313,7 @@ export const ColumnHeader = memo(function ColumnHeader({
                       setShowMenu(false)
                       onDelete()
                     }}
+                    style={{ cursor: 'pointer' }}
                     className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-error hover:bg-error/10"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-4 w-4">
@@ -341,12 +349,14 @@ export const ColumnHeader = memo(function ColumnHeader({
             <div className="flex justify-end gap-2">
               <button
                 onClick={() => { setShowConfirm(false); }}
+                style={{ cursor: 'pointer' }}
                 className="rounded px-4 py-2 text-sm text-text-secondary hover:bg-surface-hover"
               >
                 Cancel
               </button>
               <button
                 onClick={handleConfirmRunAll}
+                style={{ cursor: 'pointer' }}
                 className="rounded bg-accent px-4 py-2 text-sm font-medium text-bg"
               >
                 Run All

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -164,7 +164,13 @@ export const ColumnHeader = memo(function ColumnHeader({
 
   return (
     <>
-      <div className="flex items-center gap-2 px-3 py-2">
+      <div
+        className="flex items-center gap-2 px-3 py-2"
+        onContextMenu={(event) => {
+          event.preventDefault()
+          setShowMenu(true)
+        }}
+      >
         <span
           className="flex h-5 w-5 items-center justify-center rounded text-text-secondary"
           style={{ color: color || 'var(--accent)' }}

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useEffect } from 'react'
+import { memo, useState, useRef, useEffect, useCallback } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { IconButton } from '@/components/shared/icon-button'
 
@@ -22,6 +22,7 @@ type ColumnHeaderProps = {
   batchQueue?: BatchQueueState
   onConfigure: () => void
   onDelete: () => void
+  onRename: (name: string) => void
   onAddTask: () => void
   onRunAll?: () => void
   onCancelQueue?: () => void
@@ -94,12 +95,16 @@ export const ColumnHeader = memo(function ColumnHeader({
   batchQueue,
   onConfigure,
   onDelete,
+  onRename,
   onAddTask,
   onRunAll,
   onCancelQueue,
 }: ColumnHeaderProps) {
   const [showMenu, setShowMenu] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [renameValue, setRenameValue] = useState(name)
+  const renameInputRef = useRef<HTMLInputElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Close menu when clicking outside
@@ -123,6 +128,40 @@ export const ColumnHeader = memo(function ColumnHeader({
     onRunAll?.()
   }
 
+  const startRename = useCallback(() => {
+    setRenameValue(name)
+    setIsRenaming(true)
+  }, [name])
+
+  const finishRename = useCallback(() => {
+    if (isRenaming) {
+      const nextName = renameValue.trim()
+      if (nextName && nextName !== name) {
+        onRename(nextName)
+      }
+      setIsRenaming(false)
+      setRenameValue(name)
+    }
+  }, [isRenaming, name, onRename, renameValue])
+
+  const cancelRename = useCallback(() => {
+    setIsRenaming(false)
+    setRenameValue(name)
+  }, [name])
+
+  useEffect(() => {
+    if (!isRenaming) {
+      setRenameValue(name)
+    }
+  }, [isRenaming, name])
+
+  useEffect(() => {
+    if (isRenaming) {
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
+    }
+  }, [isRenaming])
+
   return (
     <>
       <div className="flex items-center gap-2 px-3 py-2">
@@ -132,9 +171,35 @@ export const ColumnHeader = memo(function ColumnHeader({
         >
           {getIcon(icon)}
         </span>
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary truncate">
-          {name}
-        </h3>
+        {isRenaming ? (
+          <input
+            ref={renameInputRef}
+            value={renameValue}
+            onChange={(event) => { setRenameValue(event.target.value) }}
+            onBlur={finishRename}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                finishRename()
+              }
+              if (event.key === 'Escape') {
+                event.preventDefault()
+                cancelRename()
+              }
+            }}
+            onClick={(event) => { event.stopPropagation() }}
+            className="h-5 w-32 rounded border border-border-default bg-surface px-1.5 text-xs font-semibold uppercase tracking-wider text-text-secondary"
+          />
+        ) : (
+          <h3
+            style={{ cursor: 'text' }}
+            className="max-w-40 text-xs font-semibold uppercase tracking-wider text-text-secondary select-none truncate"
+            onDoubleClick={startRename}
+            title={name}
+          >
+            {name}
+          </h3>
+        )}
         <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
           {taskCount}
         </span>

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -173,8 +173,8 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
     setShowDeleteConfirm(false)
   }, [activeWorkspaceId, column.id, loadTasks, remove])
 
-  const handleRename = useCallback(async (name: string) => {
-    await updateColumnAsync(column.id, { name })
+  const handleRename = useCallback((name: string) => {
+    void updateColumnAsync(column.id, { name })
   }, [column.id, updateColumnAsync])
 
   const handleAddTask = useCallback(() => {
@@ -255,6 +255,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
                     <div className="mt-2 flex justify-end gap-1">
                       <button
                         onClick={handleCancelAddTask}
+                        style={{ cursor: 'pointer' }}
                         className="rounded px-2 py-1 text-xs text-text-secondary hover:bg-surface-hover"
                       >
                         Cancel
@@ -262,6 +263,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
                       <button
                         onClick={() => void handleSubmitTask()}
                         disabled={!newTaskTitle.trim()}
+                        style={{ cursor: newTaskTitle.trim() ? 'pointer' : 'not-allowed' }}
                         className="rounded bg-accent px-2 py-1 text-xs font-medium text-bg disabled:opacity-50"
                       >
                         Add
@@ -310,18 +312,20 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
             </h3>
             <p className="mb-4 text-sm text-text-secondary">
               {tasks.length > 0
-                ? `This will also delete ${tasks.length} task${tasks.length === 1 ? '' : 's'} in this column.`
+                ? `This will also delete ${String(tasks.length)} task${tasks.length === 1 ? '' : 's'} in this column.`
                 : 'This column has no tasks.'}
             </p>
             <div className="flex justify-end gap-2">
               <button
                 onClick={() => { setShowDeleteConfirm(false); }}
+                style={{ cursor: 'pointer' }}
                 className="rounded px-4 py-2 text-sm text-text-secondary hover:bg-surface-hover"
               >
                 Cancel
               </button>
               <button
-                onClick={confirmDelete}
+                onClick={() => { void confirmDelete(); }}
+                style={{ cursor: 'pointer' }}
                 className="rounded bg-error px-4 py-2 text-sm font-medium text-white"
               >
                 Delete

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -30,6 +30,7 @@ type ColumnProps = {
 export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpened }: ColumnProps) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
   const allTasks = useTaskStore((s) => s.tasks)
+  const loadTasks = useTaskStore((s) => s.load)
   const addTask = useTaskStore((s) => s.add)
   const remove = useColumnStore((s) => s.remove)
   const updateColumnAsync = useColumnStore((s) => s.updateColumnAsync)
@@ -166,8 +167,11 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
 
   const confirmDelete = useCallback(async () => {
     await remove(column.id)
+    if (activeWorkspaceId) {
+      await loadTasks(activeWorkspaceId)
+    }
     setShowDeleteConfirm(false)
-  }, [column.id, remove])
+  }, [activeWorkspaceId, column.id, loadTasks, remove])
 
   const handleRename = useCallback(async (name: string) => {
     await updateColumnAsync(column.id, { name })
@@ -200,7 +204,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
           isDragging ? 'opacity-50' : ''
         }`}
       >
-        <div {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing">
+        <div {...attributes} {...listeners} style={{ cursor: 'grab' }}>
           <ColumnHeader
             name={column.name}
             icon={column.icon || 'list'}
@@ -305,7 +309,9 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
               Delete Column?
             </h3>
             <p className="mb-4 text-sm text-text-secondary">
-              This column has {tasks.length} task(s). Deleting it will also remove all tasks.
+              {tasks.length > 0
+                ? `This will also delete ${tasks.length} task${tasks.length === 1 ? '' : 's'} in this column.`
+                : 'This column has no tasks.'}
             </p>
             <div className="flex justify-end gap-2">
               <button

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -32,6 +32,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
   const allTasks = useTaskStore((s) => s.tasks)
   const addTask = useTaskStore((s) => s.add)
   const remove = useColumnStore((s) => s.remove)
+  const updateColumnAsync = useColumnStore((s) => s.updateColumnAsync)
   const getScriptName = useScriptStore((s) => s.getScriptName)
 
   // Memoize filtered tasks to prevent infinite loops
@@ -160,17 +161,17 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
   }, [])
 
   const handleDelete = useCallback(() => {
-    if (tasks.length > 0) {
-      setShowDeleteConfirm(true)
-    } else {
-      void remove(column.id)
-    }
-  }, [column.id, tasks.length, remove])
+    setShowDeleteConfirm(true)
+  }, [])
 
-  const confirmDelete = useCallback(() => {
-    void remove(column.id)
+  const confirmDelete = useCallback(async () => {
+    await remove(column.id)
     setShowDeleteConfirm(false)
   }, [column.id, remove])
+
+  const handleRename = useCallback(async (name: string) => {
+    await updateColumnAsync(column.id, { name })
+  }, [column.id, updateColumnAsync])
 
   const handleAddTask = useCallback(() => {
     setShowAddTask(true)
@@ -210,6 +211,7 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
             batchQueue={batchQueueState.isQueuing ? { total: batchQueueState.total, completed: batchQueueState.completed } : undefined}
             onConfigure={handleConfigure}
             onDelete={handleDelete}
+            onRename={handleRename}
             onAddTask={handleAddTask}
             onRunAll={() => { void handleRunAll(); }}
             onCancelQueue={() => { void handleCancelQueue(); }}

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -50,7 +50,7 @@ export function Board() {
     void addColumn(activeWorkspaceId, name).then((col) => {
       setNewColumnId(col.id)
     })
-  }, [activeWorkspaceId, columns.length, addColumn])
+  }, [activeWorkspaceId, columns, addColumn])
 
   const { registerCard, positions } = useCardPositionProvider()
   const { dragState, handlePointerDown: onDepDragStart } = useDepDrag(tasks, positions)

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -40,7 +40,13 @@ export function Board() {
 
   const handleAddColumn = useCallback(() => {
     if (!activeWorkspaceId) return
-    const name = `Column ${String(columns.length + 1)}`
+    const existingNames = new Set(columns.map((column) => column.name.toLowerCase()))
+    let nextColumnNumber = columns.length + 1
+    let name = `Column ${String(nextColumnNumber)}`
+    while (existingNames.has(name.toLowerCase())) {
+      nextColumnNumber += 1
+      name = `Column ${String(nextColumnNumber)}`
+    }
     void addColumn(activeWorkspaceId, name).then((col) => {
       setNewColumnId(col.id)
     })
@@ -125,6 +131,7 @@ export function Board() {
               {!isChatOpen && (
                 <button
                   onClick={handleAddColumn}
+                  style={{ cursor: 'pointer' }}
                   className="group flex h-full w-[280px] min-w-[200px] shrink-0 flex-col items-center justify-center gap-2 border-r border-dashed border-border-default bg-surface/10 text-text-secondary/40 transition-all hover:border-accent/50 hover:bg-accent/10 hover:text-accent"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-8 w-8">

--- a/src/components/shared/icon-button.tsx
+++ b/src/components/shared/icon-button.tsx
@@ -41,7 +41,8 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         ref={ref}
         onClick={onClick}
         disabled={disabled}
-        className={`flex items-center justify-center rounded transition-colors ${sizeClasses[size]} ${variantClasses[variant]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+        style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
+        className={`flex items-center justify-center rounded transition-colors ${sizeClasses[size]} ${variantClasses[variant]} ${disabled ? 'opacity-50' : ''} ${className}`}
       >
         {icon}
       </button>

--- a/src/scripts/rebase-pr.test.ts
+++ b/src/scripts/rebase-pr.test.ts
@@ -114,7 +114,7 @@ describe('scripts/rebase-pr.sh', () => {
     expect(result.stdout).toContain('Clean rebase succeeded')
     expect(git(repo, ['merge-base', '--is-ancestor', 'origin/main', 'feature'])).toBe('')
     expect(git(repo, ['status', '--porcelain'])).toBe('')
-  })
+  }, 120000)
 
   it('marks manual review and does not push when the guarded fallback fails type-check', () => {
     const { root, repo, origin } = setupRepo()
@@ -143,5 +143,5 @@ describe('scripts/rebase-pr.sh', () => {
     expect(existsSync(marker)).toBe(true)
     expect(readFileSync(marker, 'utf8')).toContain('file.txt')
     expect(git(repo, ['ls-remote', origin, 'refs/heads/feature']).split(/\s+/)[0]).toBe(remoteBefore)
-  })
+  }, 30000)
 })

--- a/src/stores/column-store.test.ts
+++ b/src/stores/column-store.test.ts
@@ -90,18 +90,18 @@ describe('column-store', () => {
       useColumnStore.setState({
         columns: [
           createMockColumn({ id: 'col-1', position: 0 }),
-          createMockColumn({ id: 'col-2', position: 1 }),
+          createMockColumn({ id: 'col-2', position: 2 }),
         ],
         loaded: true,
       })
 
-      const newColumn = createMockColumn({ id: 'col-3', name: 'Third', position: 2 })
+      const newColumn = createMockColumn({ id: 'col-3', name: 'Third', position: 3 })
       mockIpc.createColumn.mockResolvedValueOnce(newColumn)
       refreshWorkspace.mockResolvedValueOnce(undefined)
 
       await useColumnStore.getState().add('ws-1', 'Third')
 
-      expect(mockIpc.createColumn).toHaveBeenCalledWith('ws-1', 'Third', 2)
+      expect(mockIpc.createColumn).toHaveBeenCalledWith('ws-1', 'Third', 3)
       expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
   })
@@ -161,6 +161,26 @@ describe('column-store', () => {
       expect(state.columns[2]!.id).toBe('col-2')
       expect(state.columns[2]!.position).toBe(2)
       expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
+    })
+
+    it('should preserve hidden columns during visible-column reorder', async () => {
+      useColumnStore.setState({
+        columns: [
+          createMockColumn({ id: 'col-1', position: 0 }),
+          createMockColumn({ id: 'col-2', position: 1, visible: false }),
+          createMockColumn({ id: 'col-3', position: 2 }),
+        ],
+        loaded: true,
+      })
+      mockIpc.reorderColumns.mockResolvedValueOnce(undefined as unknown as Column[])
+      refreshWorkspace.mockResolvedValueOnce(undefined)
+
+      await useColumnStore.getState().reorder('ws-1', ['col-3', 'col-1'])
+
+      const state = useColumnStore.getState()
+      expect(state.columns.map((c) => c.id)).toEqual(['col-3', 'col-1', 'col-2'])
+      expect(state.columns.find((c) => c.id === 'col-2')?.visible).toBe(false)
+      expect(state.columns.find((c) => c.id === 'col-2')?.position).toBe(2)
     })
 
     it('should revert on IPC error', async () => {

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -43,7 +43,10 @@ export const useColumnStore = create<ColumnState>()(
       },
 
       add: async (workspaceId, name) => {
-        const position = get().columns.length
+        const workspaceColumns = get().columns.filter((c) => c.workspaceId === workspaceId)
+        const position = workspaceColumns.length === 0
+          ? 0
+          : Math.max(...workspaceColumns.map((c) => c.position)) + 1
         const column = await ipc.createColumn(workspaceId, name, position)
         set((s) => ({ columns: [...s.columns, column] }))
         await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
@@ -66,13 +69,26 @@ export const useColumnStore = create<ColumnState>()(
 
       reorder: async (workspaceId, ids) => {
         const prev = get().columns
+        const workspaceColumns = prev
+          .filter((c) => c.workspaceId === workspaceId)
+          .sort((a, b) => a.position - b.position)
+        const orderedIds = [
+          ...ids,
+          ...workspaceColumns
+            .filter((c) => !ids.includes(c.id))
+            .map((c) => c.id),
+        ]
         set((s) => ({
-          columns: ids
-            .map((id, i) => {
-              const c = s.columns.find((col) => col.id === id)
-              return c ? { ...c, position: i } : undefined
-            })
-            .filter((c): c is Column => c !== undefined),
+          columns: [
+            ...s.columns.filter((c) => c.workspaceId !== workspaceId),
+            ...s.columns
+              .filter((c) => c.workspaceId === workspaceId)
+              .map((c) => {
+                const nextPosition = orderedIds.indexOf(c.id)
+                return nextPosition >= 0 ? { ...c, position: nextPosition } : c
+              })
+              .sort((a, b) => a.position - b.position),
+          ],
         }))
         try {
           await ipc.reorderColumns(workspaceId, ids)

--- a/src/stores/column-store.ts
+++ b/src/stores/column-store.ts
@@ -72,20 +72,22 @@ export const useColumnStore = create<ColumnState>()(
         const workspaceColumns = prev
           .filter((c) => c.workspaceId === workspaceId)
           .sort((a, b) => a.position - b.position)
+        const requestedIds = new Set(ids)
         const orderedIds = [
           ...ids,
           ...workspaceColumns
-            .filter((c) => !ids.includes(c.id))
+            .filter((c) => !requestedIds.has(c.id))
             .map((c) => c.id),
         ]
+        const positionById = new Map(orderedIds.map((id, position) => [id, position]))
         set((s) => ({
           columns: [
             ...s.columns.filter((c) => c.workspaceId !== workspaceId),
             ...s.columns
               .filter((c) => c.workspaceId === workspaceId)
               .map((c) => {
-                const nextPosition = orderedIds.indexOf(c.id)
-                return nextPosition >= 0 ? { ...c, position: nextPosition } : c
+                const nextPosition = positionById.get(c.id)
+                return nextPosition === undefined ? c : { ...c, position: nextPosition }
               })
               .sort((a, b) => a.position - b.position),
           ],


### PR DESCRIPTION
## Description

Currently column structure is hardcoded per workspace. Add UI: + button at end of board to add column, double-click column name to rename, context menu to delete (with confirm). Persist via columns table. Acceptance: add/rename/delete columns from UI, position preserved, cargo check && npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/custom-column-creation-rename-and-delete-ui` → `staging/overnight-20260430-bento-ya`

## Commits

```
3e265dc Fix column UI quality issues
68e0d04 Harden column reorder persistence
8cbc2d0 Add column context menu interactions
1c25b49 Add custom column management UI
60b5135 feat(kanban): add column rename and confirm-delete UI flow
```

## Changes

```
src-tauri/src/commands/column.rs             | 53 ++++++++++------
 src/components/kanban/column-header.test.tsx | 81 +++++++++++++++++++++++++
 src/components/kanban/column-header.tsx      | 91 ++++++++++++++++++++++++++--
 src/components/kanban/column.tsx             | 36 +++++++----
 src/components/layout/board.tsx              | 11 +++-
 src/components/shared/icon-button.tsx        |  3 +-
 src/scripts/rebase-pr.test.ts                |  4 +-
 src/stores/column-store.test.ts              | 26 +++++++-
 src/stores/column-store.ts                   | 32 +++++++---
 9 files changed, 285 insertions(+), 52 deletions(-)
```