### PR TITLE
Task archiving — separate from delete with archive view

### DIFF
--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -382,6 +382,32 @@ pub fn delete_task(app: AppHandle, state: State<AppState>, id: String) -> Result
     Ok(())
 }
 
+#[tauri::command]
+pub fn archive_task(app: AppHandle, state: State<AppState>, id: String) -> Result<Task, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let task = db::set_task_archived(&conn, &id, true)?;
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_archived");
+    Ok(task)
+}
+
+#[tauri::command]
+pub fn unarchive_task(
+    app: AppHandle,
+    state: State<AppState>,
+    id: String,
+) -> Result<Task, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let task = db::set_task_archived(&conn, &id, false)?;
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_unarchived");
+    Ok(task)
+}
+
 /// Approve a task - sets review_status to "approved" and triggers auto-advance if exit_type is manual_approval
 #[tauri::command]
 pub async fn approve_task(

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -804,12 +804,15 @@ pub async fn queue_backlog(
         .ok_or_else(|| AppError::InvalidInput("No 'Backlog' column found".to_string()))?;
 
     // Get first N tasks from Backlog ordered by position
-    let backlog_tasks = db::list_tasks_by_column(&conn, &backlog_column.id)?;
+    let backlog_tasks: Vec<Task> = db::list_tasks_by_column(&conn, &backlog_column.id)?
+        .into_iter()
+        .filter(|task| task.archived_at.is_none())
+        .collect();
     let to_queue: Vec<&Task> = backlog_tasks.iter().take(count as usize).collect();
 
     if to_queue.is_empty() {
         return Err(AppError::InvalidInput(
-            "No tasks in Backlog to queue".to_string(),
+            "No unarchived tasks in Backlog to queue".to_string(),
         ));
     }
 

--- a/src-tauri/src/db/migrations/032_task_archived_at.sql
+++ b/src-tauri/src/db/migrations/032_task_archived_at.sql
@@ -1,0 +1,4 @@
+-- Soft archive tasks separately from permanent deletion.
+ALTER TABLE tasks ADD COLUMN archived_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_archived ON tasks(workspace_id, archived_at);

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -279,6 +279,25 @@ mod tests {
     }
 
     #[test]
+    fn test_task_archive_unarchive_and_delete() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        let task = insert_task(&conn, &ws.id, &col.id, "Archive me", None).unwrap();
+        assert!(task.archived_at.is_none());
+
+        let archived = set_task_archived(&conn, &task.id, true).unwrap();
+        assert!(archived.archived_at.is_some());
+        assert_eq!(get_task(&conn, &task.id).unwrap().archived_at, archived.archived_at);
+
+        let unarchived = set_task_archived(&conn, &task.id, false).unwrap();
+        assert!(unarchived.archived_at.is_none());
+
+        delete_task(&conn, &task.id).unwrap();
+        assert!(get_task(&conn, &task.id).is_err());
+    }
+
+    #[test]
     fn test_agent_session_crud() {
         let conn = init_test().unwrap();
         let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -298,6 +298,29 @@ mod tests {
     }
 
     #[test]
+    fn test_archived_tasks_are_excluded_from_agent_queues() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        let archived_task = insert_task(&conn, &ws.id, &col.id, "Archived", None).unwrap();
+        let active_task = insert_task(&conn, &ws.id, &col.id, "Active", None).unwrap();
+        let queued_at = now();
+
+        update_task_agent_status(&conn, &archived_task.id, Some("queued"), Some(&queued_at))
+            .unwrap();
+        set_task_archived(&conn, &archived_task.id, true).unwrap();
+        update_task_agent_status(&conn, &active_task.id, Some("queued"), Some(&queued_at))
+            .unwrap();
+
+        let queued = get_queued_tasks(&conn, &ws.id).unwrap();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].id, active_task.id);
+
+        let next = get_next_queued_task(&conn, &ws.id).unwrap().unwrap();
+        assert_eq!(next.id, active_task.id);
+    }
+
+    #[test]
     fn test_agent_session_crud() {
         let conn = init_test().unwrap();
         let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -140,6 +140,7 @@ fn run_migrations(conn: &Connection) -> SqlResult<()> {
         ("030_pipeline_timing", include_str!("migrations/030_pipeline_timing.sql")),
         ("030_usage_column_duration", include_str!("migrations/030_usage_column_duration.sql")),
         ("031_task_batch_id", include_str!("migrations/031_task_batch_id.sql")),
+        ("032_task_archived_at", include_str!("migrations/032_task_archived_at.sql")),
     ];
 
     for (name, sql) in migrations {
@@ -202,8 +203,8 @@ mod tests {
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
             .unwrap();
-        // We have 33 migrations, including split 019 and 030 migration files.
-        assert_eq!(count, 33);
+        // We have 34 migrations, including split 019 and 030 migration files.
+        assert_eq!(count, 34);
     }
 
     #[test]

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -62,6 +62,8 @@ pub struct Task {
     pub branch_name: Option<String>,
     /// Batch identifier used to group related pipeline PRs.
     pub batch_id: Option<String>,
+    /// Timestamp when the task was archived. Archived tasks are hidden by default.
+    pub archived_at: Option<String>,
     pub files_touched: String,
     pub checklist: Option<String>,
     pub pipeline_state: String,

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     agent_mode TEXT,
     branch_name TEXT,
     batch_id TEXT,
+    archived_at TEXT,
     files_touched TEXT DEFAULT '[]',
     checklist TEXT,
     created_at TEXT NOT NULL,
@@ -64,6 +65,7 @@ pub const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_columns_workspace ON columns(workspace_id, position)",
     "CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id)",
     "CREATE INDEX IF NOT EXISTS idx_tasks_column ON tasks(column_id, position)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_archived ON tasks(workspace_id, archived_at)",
     "CREATE INDEX IF NOT EXISTS idx_agent_sessions_task ON agent_sessions(task_id)",
 ];
 

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -3,8 +3,8 @@ use rusqlite::{params, Connection, Result as SqlResult};
 use super::models::Task;
 use super::{new_id, now};
 
-/// Shared SELECT columns for tasks (46 fields).
-const TASK_COLUMNS: &str = "id, workspace_id, column_id, title, description, position, priority, agent_mode, branch_name, files_touched, checklist, pipeline_state, pipeline_triggered_at, pipeline_error, agent_session_id, last_script_exit_code, review_status, pr_number, pr_url, siege_iteration, siege_active, siege_max_iterations, siege_last_checked, pr_mergeable, pr_ci_status, pr_review_decision, pr_comment_count, pr_is_draft, pr_labels, pr_last_fetched, pr_head_sha, notify_stakeholders, notification_sent_at, trigger_overrides, trigger_prompt, last_output, dependencies, blocked, created_at, updated_at, agent_status, queued_at, retry_count, model, worktree_path, batch_id";
+/// Shared SELECT columns for tasks (47 fields).
+const TASK_COLUMNS: &str = "id, workspace_id, column_id, title, description, position, priority, agent_mode, branch_name, files_touched, checklist, pipeline_state, pipeline_triggered_at, pipeline_error, agent_session_id, last_script_exit_code, review_status, pr_number, pr_url, siege_iteration, siege_active, siege_max_iterations, siege_last_checked, pr_mergeable, pr_ci_status, pr_review_decision, pr_comment_count, pr_is_draft, pr_labels, pr_last_fetched, pr_head_sha, notify_stakeholders, notification_sent_at, trigger_overrides, trigger_prompt, last_output, dependencies, blocked, created_at, updated_at, agent_status, queued_at, retry_count, model, worktree_path, batch_id, archived_at";
 
 /// Generate a sortable task batch identifier for staging PR workflows.
 pub fn generate_batch_id() -> String {
@@ -26,6 +26,7 @@ fn map_task_row(row: &rusqlite::Row) -> rusqlite::Result<Task> {
         queued_at: row.get(41)?,
         branch_name: row.get(8)?,
         batch_id: row.get(45)?,
+        archived_at: row.get(46)?,
         files_touched: row.get::<_, String>(9).unwrap_or_else(|_| "[]".to_string()),
         checklist: row.get(10)?,
         pipeline_state: row
@@ -165,6 +166,16 @@ pub fn update_task(
 pub fn delete_task(conn: &Connection, id: &str) -> SqlResult<()> {
     conn.execute("DELETE FROM tasks WHERE id = ?1", params![id])?;
     Ok(())
+}
+
+pub fn set_task_archived(conn: &Connection, id: &str, archived: bool) -> SqlResult<Task> {
+    let ts = now();
+    let archived_at = archived.then_some(ts.as_str());
+    conn.execute(
+        "UPDATE tasks SET archived_at = ?1, updated_at = ?2 WHERE id = ?3",
+        params![archived_at, ts, id],
+    )?;
+    get_task(conn, id)
 }
 
 /// List tasks by column ID

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -320,7 +320,7 @@ pub fn update_task_agent_status(
 /// Get tasks with agent_status = 'queued' ordered by queued_at (oldest first)
 pub fn get_queued_tasks(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<Task>> {
     let mut stmt = conn.prepare(
-        &format!("SELECT {} FROM tasks WHERE workspace_id = ?1 AND agent_status = 'queued' ORDER BY queued_at ASC", TASK_COLUMNS),
+        &format!("SELECT {} FROM tasks WHERE workspace_id = ?1 AND agent_status = 'queued' AND archived_at IS NULL ORDER BY queued_at ASC", TASK_COLUMNS),
     )?;
     let rows = stmt.query_map(params![workspace_id], map_task_row)?;
     rows.collect()
@@ -451,7 +451,7 @@ pub fn mark_task_notification_sent(conn: &Connection, id: &str) -> SqlResult<Tas
 pub fn get_next_queued_task(conn: &Connection, workspace_id: &str) -> SqlResult<Option<Task>> {
     let result = conn.query_row(
         &format!(
-            "SELECT {} FROM tasks WHERE workspace_id = ?1 AND queued_at IS NOT NULL AND pipeline_state = 'idle' AND column_id IN (SELECT id FROM columns WHERE name = 'Backlog' AND workspace_id = ?1) ORDER BY position LIMIT 1",
+            "SELECT {} FROM tasks WHERE workspace_id = ?1 AND queued_at IS NOT NULL AND pipeline_state = 'idle' AND archived_at IS NULL AND column_id IN (SELECT id FROM columns WHERE name = 'Backlog' AND workspace_id = ?1) ORDER BY position LIMIT 1",
             TASK_COLUMNS
         ),
         params![workspace_id],

--- a/src-tauri/src/db/workspace.rs
+++ b/src-tauri/src/db/workspace.rs
@@ -4,7 +4,7 @@ use super::models::Workspace;
 use super::{new_id, now};
 
 /// Shared SELECT columns for workspaces.
-const WORKSPACE_COLUMNS: &str = "id, name, repo_path, tab_order, is_active, COALESCE((SELECT COUNT(*) FROM tasks WHERE workspace_id = workspaces.id AND column_id != (SELECT id FROM columns WHERE workspace_id = workspaces.id ORDER BY position DESC LIMIT 1)), 0) AS active_task_count, config, created_at, updated_at, discord_guild_id, discord_category_id, discord_chef_channel_id, discord_notifications_channel_id, discord_enabled";
+const WORKSPACE_COLUMNS: &str = "id, name, repo_path, tab_order, is_active, COALESCE((SELECT COUNT(*) FROM tasks WHERE workspace_id = workspaces.id AND archived_at IS NULL AND column_id != (SELECT id FROM columns WHERE workspace_id = workspaces.id ORDER BY position DESC LIMIT 1)), 0) AS active_task_count, config, created_at, updated_at, discord_guild_id, discord_category_id, discord_chef_channel_id, discord_notifications_channel_id, discord_enabled";
 
 /// Map a database row to a Workspace struct.
 fn map_workspace_row(row: &rusqlite::Row) -> rusqlite::Result<Workspace> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,8 @@ pub fn run() {
             commands::task::update_task_triggers,
             commands::task::move_task,
             commands::task::reorder_tasks,
+            commands::task::archive_task,
+            commands::task::unarchive_task,
             commands::task::delete_task,
             commands::task::approve_task,
             commands::task::reject_task,

--- a/src-tauri/src/llm/context.rs
+++ b/src-tauri/src/llm/context.rs
@@ -348,6 +348,7 @@ mod tests {
             agent_mode: None,
             branch_name: None,
             batch_id: None,
+            archived_at: None,
             files_touched: "[]".to_string(),
             checklist: None,
             pipeline_state: "idle".to_string(),

--- a/src-tauri/src/pipeline/completion.rs
+++ b/src-tauri/src/pipeline/completion.rs
@@ -252,6 +252,7 @@ mod tests {
             queued_at: None,
             branch_name: None,
             batch_id: None,
+            archived_at: None,
             files_touched: "[]".into(),
             checklist: None,
             pipeline_state: "running".into(),

--- a/src-tauri/src/pipeline/exit.rs
+++ b/src-tauri/src/pipeline/exit.rs
@@ -248,6 +248,7 @@ mod tests {
             queued_at: None,
             branch_name: None,
             batch_id: None,
+            archived_at: None,
             files_touched: "[]".into(),
             checklist: None,
             pipeline_state: pipeline_state.into(),

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -851,6 +851,7 @@ mod tests {
             queued_at: None,
             branch_name: None,
             batch_id: None,
+            archived_at: None,
             files_touched: "[]".into(),
             checklist: None,
             pipeline_state: pipeline_state.into(),

--- a/src-tauri/src/pipeline/template.rs
+++ b/src-tauri/src/pipeline/template.rs
@@ -108,6 +108,7 @@ mod tests {
             queued_at: None,
             branch_name: None,
             batch_id: None,
+            archived_at: None,
             files_touched: "[]".to_string(),
             checklist: None,
             pipeline_state: "idle".to_string(),

--- a/src-tauri/src/pipeline/test_utils.rs
+++ b/src-tauri/src/pipeline/test_utils.rs
@@ -14,6 +14,7 @@ pub fn make_task(retry_count: i64, pipeline_state: &str) -> Task {
         queued_at: None,
         branch_name: None,
         batch_id: None,
+        archived_at: None,
         files_touched: "[]".into(),
         checklist: None,
         pipeline_state: pipeline_state.into(),

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -23,11 +23,12 @@ type BatchQueueLocalState = {
 
 type ColumnProps = {
   column: ColumnType
+  showArchived?: boolean
   autoOpenConfig?: boolean
   onConfigOpened?: () => void
 }
 
-export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpened }: ColumnProps) {
+export const Column = memo(function Column({ column, showArchived = false, autoOpenConfig, onConfigOpened }: ColumnProps) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
   const allTasks = useTaskStore((s) => s.tasks)
   const addTask = useTaskStore((s) => s.add)
@@ -37,9 +38,9 @@ export const Column = memo(function Column({ column, autoOpenConfig, onConfigOpe
   // Memoize filtered tasks to prevent infinite loops
   const tasks = useMemo(
     () => allTasks
-      .filter((t) => t.columnId === column.id)
+      .filter((t) => t.columnId === column.id && (showArchived || !t.archivedAt))
       .sort((a, b) => a.position - b.position),
-    [allTasks, column.id]
+    [allTasks, column.id, showArchived]
   )
   const taskIds = useMemo(() => tasks.map((t) => t.id), [tasks])
 

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -42,6 +42,10 @@ export const Column = memo(function Column({ column, showArchived = false, autoO
       .sort((a, b) => a.position - b.position),
     [allTasks, column.id, showArchived]
   )
+  const totalTasksInColumn = useMemo(
+    () => allTasks.filter((t) => t.columnId === column.id).length,
+    [allTasks, column.id]
+  )
   const taskIds = useMemo(() => tasks.map((t) => t.id), [tasks])
 
   const scriptTrigger = useMemo(() => {
@@ -161,12 +165,12 @@ export const Column = memo(function Column({ column, showArchived = false, autoO
   }, [])
 
   const handleDelete = useCallback(() => {
-    if (tasks.length > 0) {
+    if (totalTasksInColumn > 0) {
       setShowDeleteConfirm(true)
     } else {
       void remove(column.id)
     }
-  }, [column.id, tasks.length, remove])
+  }, [column.id, totalTasksInColumn, remove])
 
   const confirmDelete = useCallback(() => {
     void remove(column.id)
@@ -304,7 +308,7 @@ export const Column = memo(function Column({ column, showArchived = false, autoO
               Delete Column?
             </h3>
             <p className="mb-4 text-sm text-text-secondary">
-              This column has {tasks.length} task(s). Deleting it will also remove all tasks.
+              This column has {totalTasksInColumn} task(s). Deleting it will also remove all tasks.
             </p>
             <div className="flex justify-end gap-2">
               <button

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -90,7 +90,7 @@ export const Column = memo(function Column({ column, showArchived = false, autoO
   }, [allTasks, batchQueueState.isQueuing, batchQueueState.queuedTaskIds, batchQueueState.total, batchQueueState.completed])
 
   const handleRunAll = useCallback(async () => {
-    const ids = tasks.map((t) => t.id)
+    const ids = tasks.filter((t) => !t.archivedAt).map((t) => t.id)
     if (ids.length === 0) return
     try {
       await queueBacklog(ids)

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -238,6 +238,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
   const canToggleAgent = canTriggerWork || task.agentStatus === 'running'
   const isPipelineActive = task.pipelineState !== 'idle'
   const hasPipelineError = !!task.pipelineError
+  const isArchived = !!task.archivedAt
 
   // Count incoming dependency links
   const depCount = useMemo(() => parseDeps(task.dependencies).length, [task.dependencies])
@@ -275,7 +276,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
       style={{
         ...style,
         cursor: 'pointer',
-        opacity: isDragging ? 0.4 : isDimmed ? 0.3 : task.blocked ? 0.7 : isInDoneColumn ? 0.6 : 1,
+        opacity: isDragging ? 0.4 : isDimmed ? 0.3 : isArchived ? 0.5 : task.blocked ? 0.7 : isInDoneColumn ? 0.6 : 1,
         transition: 'transform 200ms ease, opacity 200ms ease',
       }}
       onClick={handleClick}
@@ -346,6 +347,8 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
         'border-border-default hover:border-accent/50 hover:bg-surface-hover'
       } ${isDragging ? 'z-0' : !isConnectedToHovered && !isHovered ? 'hover:z-10' : ''} ${
         hasPipelineError ? 'border-l-4 border-l-error' : isPipelineActive ? `border-l-4 ${PIPELINE_COLORS[task.pipelineState]}` : ''
+      } ${
+        isArchived ? 'grayscale' : ''
       }`}
       onPointerDownCapture={(e) => {
         if (e.metaKey || e.ctrlKey) {
@@ -381,6 +384,11 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
           <h4 className="flex-1 text-sm font-medium text-text-primary leading-snug line-clamp-2">
             {task.title}
           </h4>
+          {isArchived && (
+            <span className="shrink-0 rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+              Archived
+            </span>
+          )}
         </div>
 
         {/* Description — hidden when expanded (expanded view shows full description) */}
@@ -492,6 +500,7 @@ export const TaskCard = memo(function TaskCard({ task }: { task: Task }) {
         onOpenTask={handleClick}
         onDuplicateTask={actions.handleDuplicateTask}
         onArchiveTask={actions.handleArchiveTask}
+        onUnarchiveTask={actions.handleUnarchiveTask}
         onDeleteTask={actions.handleDeleteTask}
         onRunAgent={actions.handleRunAgent}
         onStopAgent={actions.handleStopAgent}

--- a/src/components/kanban/task-context-menu.tsx
+++ b/src/components/kanban/task-context-menu.tsx
@@ -30,6 +30,7 @@ type TaskContextMenuProps = {
   onOpenTask: () => void
   onDuplicateTask: () => void
   onArchiveTask: () => void
+  onUnarchiveTask: () => void
   onDeleteTask: () => void
   onRunAgent: () => void
   onStopAgent: () => void
@@ -175,6 +176,7 @@ export function TaskContextMenu({
   onOpenTask,
   onDuplicateTask,
   onArchiveTask,
+  onUnarchiveTask,
   onDeleteTask,
   onRunAgent,
   onStopAgent,
@@ -252,7 +254,9 @@ export function TaskContextMenu({
     },
     { label: 'Duplicate', icon: Icons.duplicate, shortcut: 'D', onClick: onDuplicateTask },
     { type: 'divider' },
-    { label: 'Archive', icon: Icons.archive, onClick: onArchiveTask },
+    task.archivedAt
+      ? { label: 'Unarchive', icon: Icons.archive, onClick: onUnarchiveTask }
+      : { label: 'Archive', icon: Icons.archive, onClick: onArchiveTask },
     { label: 'Delete', icon: Icons.trash, variant: 'danger' as const, onClick: onDeleteTask },
   ]
 

--- a/src/components/kanban/use-task-card-actions.ts
+++ b/src/components/kanban/use-task-card-actions.ts
@@ -6,6 +6,8 @@ import * as ipc from '@/lib/ipc'
 /** Encapsulates all task card action handlers (context menu, keyboard, quick actions). */
 export function useTaskCardActions(task: Task) {
   const moveTask = useTaskStore((s) => s.move)
+  const archiveTask = useTaskStore((s) => s.archive)
+  const unarchiveTask = useTaskStore((s) => s.unarchive)
   const removeTask = useTaskStore((s) => s.remove)
   const updateTask = useTaskStore((s) => s.updateTask)
   const duplicateTask = useTaskStore((s) => s.duplicate)
@@ -48,8 +50,12 @@ export function useTaskCardActions(task: Task) {
   }, [task.id, updateTask])
 
   const handleArchiveTask = useCallback(() => {
-    void removeTask(task.id)
-  }, [task.id, removeTask])
+    void archiveTask(task.id)
+  }, [task.id, archiveTask])
+
+  const handleUnarchiveTask = useCallback(() => {
+    void unarchiveTask(task.id)
+  }, [task.id, unarchiveTask])
 
   const handleDeleteTask = useCallback(() => {
     void removeTask(task.id)
@@ -87,6 +93,7 @@ export function useTaskCardActions(task: Task) {
     handleStartSiege,
     handleStopSiege,
     handleArchiveTask,
+    handleUnarchiveTask,
     handleDeleteTask,
     handleDuplicateTask,
     handleToggleAgent,

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -25,6 +25,7 @@ import { useChatPanel } from '@/hooks/use-chat-panel'
 import { useUIStore } from '@/stores/ui-store'
 import { CardPositionContext, useCardPositionProvider } from '@/hooks/use-card-positions'
 import { DepDragContext } from '@/hooks/use-dep-drag-context'
+import { Toggle } from '@/components/shared/toggle'
 
 export function Board() {
   const panelDock = useUIStore((s) => s.panelDock)
@@ -37,6 +38,7 @@ export function Board() {
   const loadScripts = useScriptStore((s) => s.load)
 
   const [newColumnId, setNewColumnId] = useState<string | null>(null)
+  const [showArchived, setShowArchived] = useState(false)
 
   const handleAddColumn = useCallback(() => {
     if (!activeWorkspaceId) return
@@ -65,6 +67,7 @@ export function Board() {
   const columnIds = sortedColumns.map((c) => c.id)
 
   const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd()
+  const archivedTaskCount = tasks.filter((task) => task.archivedAt).length
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -109,12 +112,25 @@ export function Board() {
         <div className="flex h-full" data-board-container>
           {/* Board + orchestrator panel (left side, shrinks when task panel open) */}
           <div className="flex flex-1 flex-col overflow-hidden">
+            <div className="flex h-10 shrink-0 items-center justify-end gap-2 border-b border-border-default bg-bg px-3">
+              <span className="text-xs text-text-secondary">
+                Archived {archivedTaskCount}
+              </span>
+              <Toggle
+                checked={showArchived}
+                onChange={setShowArchived}
+                disabled={archivedTaskCount === 0}
+                size="sm"
+                ariaLabel="Show archived tasks"
+              />
+            </div>
             <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
               <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
                 {sortedColumns.map((col) => (
                   <Column
                     key={col.id}
                     column={col}
+                    showArchived={showArchived}
                     autoOpenConfig={col.id === newColumnId}
                     onConfigOpened={col.id === newColumnId ? () => { setNewColumnId(null) } : undefined}
                   />

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -69,6 +69,12 @@ export function Board() {
   const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd(showArchived)
   const archivedTaskCount = tasks.filter((task) => task.archivedAt).length
 
+  useEffect(() => {
+    if (archivedTaskCount === 0 && showArchived) {
+      setShowArchived(false)
+    }
+  }, [archivedTaskCount, showArchived])
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 8 },

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react'
+import { useEffect, useCallback, useMemo, useState } from 'react'
 import {
   DndContext,
   DragOverlay,
@@ -8,7 +8,11 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
-import { SortableContext, horizontalListSortingStrategy, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
 import { useColumnStore } from '@/stores/column-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -61,13 +65,11 @@ export function Board() {
     collapseTask()
   }, [closeChat, collapseTask])
 
-  const sortedColumns = columns
-    .filter((c) => c.visible)
-    .sort((a, b) => a.position - b.position)
+  const sortedColumns = columns.filter((c) => c.visible).sort((a, b) => a.position - b.position)
   const columnIds = sortedColumns.map((c) => c.id)
 
   const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd(showArchived)
-  const archivedTaskCount = tasks.filter((task) => task.archivedAt).length
+  const archivedTaskCount = useMemo(() => tasks.filter((task) => task.archivedAt).length, [tasks])
 
   useEffect(() => {
     if (archivedTaskCount === 0 && showArchived) {
@@ -107,80 +109,102 @@ export function Board() {
 
   return (
     <CardPositionContext.Provider value={{ registerCard, positions }}>
-    <DepDragContext.Provider value={{ onDepDragStart, isDraggingDep: !!dragState, hoveredTaskId, setHoveredTaskId }}>
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCorners}
-        onDragStart={(e) => { setHoveredTaskId(null); collapseTask(); onDragStart(e) }}
-        onDragOver={onDragOver}
-        onDragEnd={onDragEnd}
+      <DepDragContext.Provider
+        value={{ onDepDragStart, isDraggingDep: !!dragState, hoveredTaskId, setHoveredTaskId }}
       >
-        <div className="flex h-full" data-board-container>
-          {/* Board + orchestrator panel (left side, shrinks when task panel open) */}
-          <div className="flex flex-1 flex-col overflow-hidden">
-            <div className="flex h-10 shrink-0 items-center justify-end gap-2 border-b border-border-default bg-bg px-3">
-              <span className="text-xs text-text-secondary">
-                Archived {archivedTaskCount}
-              </span>
-              <Toggle
-                checked={showArchived}
-                onChange={setShowArchived}
-                disabled={archivedTaskCount === 0}
-                size="sm"
-                ariaLabel="Show archived tasks"
-              />
-            </div>
-            <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
-              <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
-                {sortedColumns.map((col) => (
-                  <Column
-                    key={col.id}
-                    column={col}
-                    showArchived={showArchived}
-                    autoOpenConfig={col.id === newColumnId}
-                    onConfigOpened={col.id === newColumnId ? () => { setNewColumnId(null) } : undefined}
-                  />
-                ))}
-              </SortableContext>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCorners}
+          onDragStart={(e) => {
+            setHoveredTaskId(null)
+            collapseTask()
+            onDragStart(e)
+          }}
+          onDragOver={onDragOver}
+          onDragEnd={onDragEnd}
+        >
+          <div className="flex h-full" data-board-container>
+            {/* Board + orchestrator panel (left side, shrinks when task panel open) */}
+            <div className="flex flex-1 flex-col overflow-hidden">
+              <div className="flex h-10 shrink-0 items-center justify-end gap-2 border-b border-border-default bg-bg px-3">
+                <span className="text-xs text-text-secondary">Archived {archivedTaskCount}</span>
+                <Toggle
+                  checked={showArchived}
+                  onChange={setShowArchived}
+                  disabled={archivedTaskCount === 0}
+                  size="sm"
+                  ariaLabel="Show archived tasks"
+                />
+              </div>
+              <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
+                <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
+                  {sortedColumns.map((col) => (
+                    <Column
+                      key={col.id}
+                      column={col}
+                      showArchived={showArchived}
+                      autoOpenConfig={col.id === newColumnId}
+                      onConfigOpened={
+                        col.id === newColumnId
+                          ? () => {
+                              setNewColumnId(null)
+                            }
+                          : undefined
+                      }
+                    />
+                  ))}
+                </SortableContext>
 
-              {/* Add column button */}
-              {!isChatOpen && (
-                <button
-                  onClick={handleAddColumn}
-                  className="group flex h-full w-[280px] min-w-[200px] shrink-0 flex-col items-center justify-center gap-2 border-r border-dashed border-border-default bg-surface/10 text-text-secondary/40 transition-all hover:border-accent/50 hover:bg-accent/10 hover:text-accent"
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-8 w-8">
-                    <path d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4M9 3v18M9 3h6m-6 18h6m0-18h4a2 2 0 0 1 2 2v6m-6-8v10" strokeLinecap="round"/>
-                    <path d="M19 15v3m0 3v-3m0 0h-3m3 0h3" strokeLinecap="round"/>
-                  </svg>
-                  <span className="text-xs font-medium">Add Column</span>
-                </button>
+                {/* Add column button */}
+                {!isChatOpen && (
+                  <button
+                    onClick={handleAddColumn}
+                    className="group flex h-full w-[280px] min-w-[200px] shrink-0 flex-col items-center justify-center gap-2 border-r border-dashed border-border-default bg-surface/10 text-text-secondary/40 transition-all hover:border-accent/50 hover:bg-accent/10 hover:text-accent"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      className="h-8 w-8"
+                    >
+                      <path
+                        d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4M9 3v18M9 3h6m-6 18h6m0-18h4a2 2 0 0 1 2 2v6m-6-8v10"
+                        strokeLinecap="round"
+                      />
+                      <path d="M19 15v3m0 3v-3m0 0h-3m3 0h3" strokeLinecap="round" />
+                    </svg>
+                    <span className="text-xs font-medium">Add Column</span>
+                  </button>
+                )}
+
+                {/* Dependency lines overlay */}
+                <DependencyLines
+                  tasks={tasks}
+                  positions={positions}
+                  hoveredTaskId={hoveredTaskId}
+                />
+                {dragState && <DepDragPreview dragState={dragState} positions={positions} />}
+              </div>
+
+              {/* Orchestrator panel - bottom dock */}
+              {activeWorkspaceId && panelDock === 'bottom' && (
+                <OrchestratorPanel workspaceId={activeWorkspaceId} />
               )}
-
-              {/* Dependency lines overlay */}
-              <DependencyLines tasks={tasks} positions={positions} hoveredTaskId={hoveredTaskId} />
-              {dragState && <DepDragPreview dragState={dragState} positions={positions} />}
             </div>
 
-            {/* Orchestrator panel - bottom dock */}
-            {activeWorkspaceId && panelDock === 'bottom' && (
+            {/* Orchestrator panel - right dock */}
+            {activeWorkspaceId && panelDock === 'right' && (
               <OrchestratorPanel workspaceId={activeWorkspaceId} />
             )}
+
+            {/* Task side panel (slides in from right, board stays visible) */}
+            <TaskSidePanel taskId={activeTaskId} onClose={handleCloseAll} />
           </div>
-
-          {/* Orchestrator panel - right dock */}
-          {activeWorkspaceId && panelDock === 'right' && (
-            <OrchestratorPanel workspaceId={activeWorkspaceId} />
-          )}
-
-          {/* Task side panel (slides in from right, board stays visible) */}
-          <TaskSidePanel taskId={activeTaskId} onClose={handleCloseAll} />
-        </div>
-        <DragOverlay dropAnimation={null}>
-          {overlayContent}
-        </DragOverlay>
-      </DndContext>
-    </DepDragContext.Provider>
+          <DragOverlay dropAnimation={null}>{overlayContent}</DragOverlay>
+        </DndContext>
+      </DepDragContext.Provider>
     </CardPositionContext.Provider>
   )
 }

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -66,7 +66,7 @@ export function Board() {
     .sort((a, b) => a.position - b.position)
   const columnIds = sortedColumns.map((c) => c.id)
 
-  const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd()
+  const { activeItem, onDragStart, onDragOver, onDragEnd } = useDnd(showArchived)
   const archivedTaskCount = tasks.filter((task) => task.archivedAt).length
 
   const sensors = useSensors(

--- a/src/components/panel/pipeline-dashboard.test.ts
+++ b/src/components/panel/pipeline-dashboard.test.ts
@@ -39,6 +39,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     agentMode: null,
     agentStatus: null,
     queuedAt: null,
+    archivedAt: null,
     pipelineState: 'idle',
     pipelineTriggeredAt: null,
     pipelineError: null,

--- a/src/components/shared/toggle.tsx
+++ b/src/components/shared/toggle.tsx
@@ -13,7 +13,13 @@ const sizes = {
   md: { track: 'h-6 w-11', thumb: 'h-5 w-5', translate: 'translate-x-5' },
 }
 
-export function Toggle({ checked, onChange, disabled = false, size = 'sm', ariaLabel }: ToggleProps) {
+export function Toggle({
+  checked,
+  onChange,
+  disabled = false,
+  size = 'sm',
+  ariaLabel,
+}: ToggleProps) {
   const s = sizes[size]
 
   return (
@@ -22,7 +28,10 @@ export function Toggle({ checked, onChange, disabled = false, size = 'sm', ariaL
       aria-checked={checked}
       aria-label={ariaLabel}
       disabled={disabled}
-      onClick={() => { onChange(!checked); }}
+      type="button"
+      onClick={() => {
+        onChange(!checked)
+      }}
       style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
       className={`relative inline-flex shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:opacity-50 ${s.track} ${
         checked ? 'bg-accent' : 'bg-surface-hover'
@@ -31,6 +40,7 @@ export function Toggle({ checked, onChange, disabled = false, size = 'sm', ariaL
       <motion.span
         layout
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+        style={{ cursor: 'inherit' }}
         className={`inline-block rounded-full bg-white shadow-sm ${s.thumb} ${
           checked ? s.translate : 'translate-x-0.5'
         }`}

--- a/src/components/shared/toggle.tsx
+++ b/src/components/shared/toggle.tsx
@@ -5,6 +5,7 @@ type ToggleProps = {
   onChange: (checked: boolean) => void
   disabled?: boolean
   size?: 'sm' | 'md'
+  ariaLabel?: string
 }
 
 const sizes = {
@@ -12,16 +13,18 @@ const sizes = {
   md: { track: 'h-6 w-11', thumb: 'h-5 w-5', translate: 'translate-x-5' },
 }
 
-export function Toggle({ checked, onChange, disabled = false, size = 'sm' }: ToggleProps) {
+export function Toggle({ checked, onChange, disabled = false, size = 'sm', ariaLabel }: ToggleProps) {
   const s = sizes[size]
 
   return (
     <button
       role="switch"
       aria-checked={checked}
+      aria-label={ariaLabel}
       disabled={disabled}
       onClick={() => { onChange(!checked); }}
-      className={`relative inline-flex shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:cursor-not-allowed disabled:opacity-50 ${s.track} ${
+      style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
+      className={`relative inline-flex shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:opacity-50 ${s.track} ${
         checked ? 'bg-accent' : 'bg-surface-hover'
       }`}
     >

--- a/src/hooks/use-dnd.ts
+++ b/src/hooks/use-dnd.ts
@@ -1,6 +1,6 @@
 /** Hook for drag-and-drop task reordering across kanban columns (dnd-kit). */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import type {
   DragStartEvent,
   DragOverEvent,
@@ -15,7 +15,7 @@ type ActiveItem =
   | { type: 'column'; id: string }
   | { type: 'task'; id: string }
 
-export function useDnd() {
+export function useDnd(showArchived = false) {
   const [activeItem, setActiveItem] = useState<ActiveItem | null>(null)
   const columns = useColumnStore((s) => s.columns)
   const reorderColumns = useColumnStore((s) => s.reorder)
@@ -23,11 +23,16 @@ export function useDnd() {
   const moveTask = useTaskStore((s) => s.move)
   const reorderTasks = useTaskStore((s) => s.reorder)
 
+  const visibleTasks = useMemo(
+    () => showArchived ? tasks : tasks.filter((t) => !t.archivedAt),
+    [showArchived, tasks],
+  )
+
   const findColumnOfTask = useCallback(
     (taskId: UniqueIdentifier): string | undefined => {
-      return tasks.find((t) => t.id === taskId)?.columnId
+      return visibleTasks.find((t) => t.id === taskId)?.columnId
     },
-    [tasks],
+    [visibleTasks],
   )
 
   const onDragStart = useCallback((event: DragStartEvent) => {
@@ -68,7 +73,7 @@ export function useDnd() {
       if (!activeColumn || !overColumn || activeColumn === overColumn) return
 
       // Moving task to a different column
-      const overColumnTasks = tasks
+      const overColumnTasks = visibleTasks
         .filter((t) => t.columnId === overColumn)
         .sort((a, b) => a.position - b.position)
 
@@ -77,7 +82,7 @@ export function useDnd() {
 
       void moveTask(activeTaskId, overColumn, newPosition)
     },
-    [findColumnOfTask, tasks, moveTask],
+    [findColumnOfTask, visibleTasks, moveTask],
   )
 
   const onDragEnd = useCallback(
@@ -107,7 +112,7 @@ export function useDnd() {
         const columnId = findColumnOfTask(String(active.id))
         if (!columnId) return
 
-        const columnTasks = tasks
+        const columnTasks = visibleTasks
           .filter((t) => t.columnId === columnId)
           .sort((a, b) => a.position - b.position)
         const taskIds = columnTasks.map((t) => t.id)
@@ -119,7 +124,7 @@ export function useDnd() {
         }
       }
     },
-    [columns, tasks, findColumnOfTask, reorderColumns, reorderTasks],
+    [columns, visibleTasks, findColumnOfTask, reorderColumns, reorderTasks],
   )
 
   return { activeItem, onDragStart, onDragOver, onDragEnd }

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -130,6 +130,7 @@ let mockTasks: Task[] = [
     blocked: false,
     worktreePath: null,
     queuedAt: null,
+    archivedAt: null,
     position: 0,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -305,6 +306,7 @@ const mockCommands: Record<string, CommandHandler> = {
       blocked: false,
       worktreePath: null,
       queuedAt: null,
+      archivedAt: null,
       position: mockTasks.filter((t) => t.columnId === args?.columnId).length,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -344,6 +346,24 @@ const mockCommands: Record<string, CommandHandler> = {
   },
   delete_task: (args) => {
     mockTasks = mockTasks.filter((t) => t.id !== args?.id)
+  },
+  archive_task: (args) => {
+    const task = mockTasks.find((t) => t.id === args?.id)
+    if (task) {
+      task.archivedAt = new Date().toISOString()
+      task.updatedAt = new Date().toISOString()
+      return task
+    }
+    throw new Error('Task not found')
+  },
+  unarchive_task: (args) => {
+    const task = mockTasks.find((t) => t.id === args?.id)
+    if (task) {
+      task.archivedAt = null
+      task.updatedAt = new Date().toISOString()
+      return task
+    }
+    throw new Error('Task not found')
   },
   reorder_tasks: (args) => {
     const taskIds = args?.taskIds as string[]
@@ -832,6 +852,7 @@ export function resetMockData() {
       blocked: false,
       worktreePath: null,
       queuedAt: null,
+      archivedAt: null,
       position: 0,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -877,6 +898,7 @@ export function resetMockData() {
       blocked: false,
       worktreePath: null,
       queuedAt: null,
+      archivedAt: null,
       position: 0,
       createdAt: new Date(Date.now() - 3600000).toISOString(),
       updatedAt: new Date(Date.now() - 1800000).toISOString(),
@@ -922,6 +944,7 @@ export function resetMockData() {
       blocked: false,
       worktreePath: null,
       queuedAt: null,
+      archivedAt: null,
       position: 1,
       createdAt: new Date(Date.now() - 86400000).toISOString(),
       updatedAt: new Date(Date.now() - 7200000).toISOString(),

--- a/src/lib/ipc/task.ts
+++ b/src/lib/ipc/task.ts
@@ -55,6 +55,14 @@ export async function deleteTask(id: string): Promise<void> {
   return invoke('delete_task', { id })
 }
 
+export async function archiveTask(id: string): Promise<Task> {
+  return invoke<Task>('archive_task', { id })
+}
+
+export async function unarchiveTask(id: string): Promise<Task> {
+  return invoke<Task>('unarchive_task', { id })
+}
+
 // ─── Review actions ─────────────────────────────────────────────────────────
 
 export async function approveTask(id: string): Promise<Task> {

--- a/src/scripts/rebase-pr.test.ts
+++ b/src/scripts/rebase-pr.test.ts
@@ -22,6 +22,7 @@ const env = {
 }
 
 const tempDirs: string[] = []
+const GIT_SCRIPT_TIMEOUT_MS = 30_000
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, env, encoding: 'utf8', stdio: 'pipe' }).trim()
@@ -114,7 +115,7 @@ describe('scripts/rebase-pr.sh', () => {
     expect(result.stdout).toContain('Clean rebase succeeded')
     expect(git(repo, ['merge-base', '--is-ancestor', 'origin/main', 'feature'])).toBe('')
     expect(git(repo, ['status', '--porcelain'])).toBe('')
-  })
+  }, GIT_SCRIPT_TIMEOUT_MS)
 
   it('marks manual review and does not push when the guarded fallback fails type-check', () => {
     const { root, repo, origin } = setupRepo()
@@ -143,5 +144,5 @@ describe('scripts/rebase-pr.sh', () => {
     expect(existsSync(marker)).toBe(true)
     expect(readFileSync(marker, 'utf8')).toContain('file.txt')
     expect(git(repo, ['ls-remote', origin, 'refs/heads/feature']).split(/\s+/)[0]).toBe(remoteBefore)
-  })
+  }, GIT_SCRIPT_TIMEOUT_MS)
 })

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -16,6 +16,8 @@ vi.mock('./workspace-store', () => ({
 vi.mock('@/lib/ipc', () => ({
   getTasks: vi.fn(),
   createTask: vi.fn(),
+  archiveTask: vi.fn(),
+  unarchiveTask: vi.fn(),
   deleteTask: vi.fn(),
   moveTask: vi.fn(),
   reorderTasks: vi.fn(),
@@ -67,6 +69,7 @@ const createMockTask = (overrides: Partial<Task> = {}): Task => ({
   siegeMaxIterations: 3,
   siegeLastChecked: null,
   queuedAt: null,
+  archivedAt: null,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
   ...overrides,
@@ -150,6 +153,66 @@ describe('task-store', () => {
 
       const state = useTaskStore.getState()
       expect(state.tasks).toHaveLength(2)
+    })
+  })
+
+  describe('archive', () => {
+    beforeEach(() => {
+      useTaskStore.setState({
+        tasks: [createMockTask({ id: 'task-1' }), createMockTask({ id: 'task-2', position: 1 })],
+      })
+    })
+
+    it('should optimistically archive task and persist via IPC', async () => {
+      const archivedTask = createMockTask({
+        id: 'task-1',
+        archivedAt: '2024-01-02T00:00:00Z',
+      })
+      mockIpc.archiveTask.mockResolvedValueOnce(archivedTask)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
+
+      await useTaskStore.getState().archive('task-1')
+
+      const state = useTaskStore.getState()
+      expect(state.tasks.find((t) => t.id === 'task-1')?.archivedAt).toBe('2024-01-02T00:00:00Z')
+      expect(mockIpc.archiveTask).toHaveBeenCalledWith('task-1')
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
+    })
+
+    it('should revert archive on IPC error', async () => {
+      mockIpc.archiveTask.mockRejectedValueOnce(new Error('Failed'))
+
+      await useTaskStore.getState().archive('task-1')
+
+      expect(useTaskStore.getState().tasks.find((t) => t.id === 'task-1')?.archivedAt).toBeNull()
+    })
+  })
+
+  describe('unarchive', () => {
+    beforeEach(() => {
+      useTaskStore.setState({
+        tasks: [createMockTask({ id: 'task-1', archivedAt: '2024-01-02T00:00:00Z' })],
+      })
+    })
+
+    it('should optimistically unarchive task and persist via IPC', async () => {
+      const unarchivedTask = createMockTask({ id: 'task-1', archivedAt: null })
+      mockIpc.unarchiveTask.mockResolvedValueOnce(unarchivedTask)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
+
+      await useTaskStore.getState().unarchive('task-1')
+
+      expect(useTaskStore.getState().tasks[0]?.archivedAt).toBeNull()
+      expect(mockIpc.unarchiveTask).toHaveBeenCalledWith('task-1')
+      expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
+    })
+
+    it('should revert unarchive on IPC error', async () => {
+      mockIpc.unarchiveTask.mockRejectedValueOnce(new Error('Failed'))
+
+      await useTaskStore.getState().unarchive('task-1')
+
+      expect(useTaskStore.getState().tasks[0]?.archivedAt).toBe('2024-01-02T00:00:00Z')
     })
   })
 

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -11,6 +11,8 @@ type TaskState = {
 
   load: (workspaceId: string) => Promise<void>
   add: (workspaceId: string, columnId: string, title: string, description: string) => Promise<Task>
+  archive: (id: string) => Promise<void>
+  unarchive: (id: string) => Promise<void>
   remove: (id: string) => Promise<void>
   move: (id: string, targetColumnId: string, position: number) => Promise<void>
   reorder: (columnId: string, ids: string[]) => Promise<void>
@@ -35,6 +37,50 @@ export const useTaskStore = create<TaskState>()(
         set((s) => ({ tasks: [...s.tasks, task] }))
         await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
         return task
+      },
+
+      archive: async (id) => {
+        const prev = get().tasks
+        const task = prev.find((t) => t.id === id)
+        const workspaceId = task?.workspaceId
+        set((s) => ({
+          tasks: s.tasks.map((t) =>
+            t.id === id ? { ...t, archivedAt: new Date().toISOString() } : t,
+          ),
+        }))
+        const ui = useUIStore.getState()
+        if (ui.expandedTaskId === id) ui.collapseTask()
+        if (ui.activeTaskId === id) ui.closeChat()
+        try {
+          const archived = await ipc.archiveTask(id)
+          set((s) => ({
+            tasks: s.tasks.map((t) => (t.id === id ? archived : t)),
+          }))
+          if (workspaceId) {
+            await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+          }
+        } catch {
+          set({ tasks: prev })
+        }
+      },
+
+      unarchive: async (id) => {
+        const prev = get().tasks
+        const workspaceId = prev.find((t) => t.id === id)?.workspaceId
+        set((s) => ({
+          tasks: s.tasks.map((t) => (t.id === id ? { ...t, archivedAt: null } : t)),
+        }))
+        try {
+          const unarchived = await ipc.unarchiveTask(id)
+          set((s) => ({
+            tasks: s.tasks.map((t) => (t.id === id ? unarchived : t)),
+          }))
+          if (workspaceId) {
+            await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+          }
+        } catch {
+          set({ tasks: prev })
+        }
       },
 
       remove: async (id) => {

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -23,38 +23,28 @@ type TaskState = {
 
 export const useTaskStore = create<TaskState>()(
   devtools(
-    (set, get) => ({
-      tasks: [],
-      loaded: false,
-
-      load: async (workspaceId) => {
-        const tasks = await ipc.getTasks(workspaceId)
-        set({ tasks, loaded: true })
-      },
-
-      add: async (workspaceId, columnId, title, description) => {
-        const task = await ipc.createTask(workspaceId, columnId, title, description)
-        set((s) => ({ tasks: [...s.tasks, task] }))
-        await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
-        return task
-      },
-
-      archive: async (id) => {
+    (set, get) => {
+      const setArchivedState = async (id: string, archived: boolean) => {
         const prev = get().tasks
         const task = prev.find((t) => t.id === id)
         const workspaceId = task?.workspaceId
+        const optimisticArchivedAt = archived ? new Date().toISOString() : null
+        const persist = archived ? ipc.archiveTask : ipc.unarchiveTask
+
         set((s) => ({
-          tasks: s.tasks.map((t) =>
-            t.id === id ? { ...t, archivedAt: new Date().toISOString() } : t,
-          ),
+          tasks: s.tasks.map((t) => (t.id === id ? { ...t, archivedAt: optimisticArchivedAt } : t)),
         }))
-        const ui = useUIStore.getState()
-        if (ui.expandedTaskId === id) ui.collapseTask()
-        if (ui.activeTaskId === id) ui.closeChat()
+
+        if (archived) {
+          const ui = useUIStore.getState()
+          if (ui.expandedTaskId === id) ui.collapseTask()
+          if (ui.activeTaskId === id) ui.closeChat()
+        }
+
         try {
-          const archived = await ipc.archiveTask(id)
+          const persistedTask = await persist(id)
           set((s) => ({
-            tasks: s.tasks.map((t) => (t.id === id ? archived : t)),
+            tasks: s.tasks.map((t) => (t.id === id ? persistedTask : t)),
           }))
           if (workspaceId) {
             await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
@@ -62,108 +52,110 @@ export const useTaskStore = create<TaskState>()(
         } catch {
           set({ tasks: prev })
         }
-      },
+      }
 
-      unarchive: async (id) => {
-        const prev = get().tasks
-        const workspaceId = prev.find((t) => t.id === id)?.workspaceId
-        set((s) => ({
-          tasks: s.tasks.map((t) => (t.id === id ? { ...t, archivedAt: null } : t)),
-        }))
-        try {
-          const unarchived = await ipc.unarchiveTask(id)
+      return {
+        tasks: [],
+        loaded: false,
+
+        load: async (workspaceId) => {
+          const tasks = await ipc.getTasks(workspaceId)
+          set({ tasks, loaded: true })
+        },
+
+        add: async (workspaceId, columnId, title, description) => {
+          const task = await ipc.createTask(workspaceId, columnId, title, description)
+          set((s) => ({ tasks: [...s.tasks, task] }))
+          await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+          return task
+        },
+
+        archive: (id) => setArchivedState(id, true),
+
+        unarchive: (id) => setArchivedState(id, false),
+
+        remove: async (id) => {
+          const prev = get().tasks
+          const workspaceId = prev.find((t) => t.id === id)?.workspaceId
+          set((s) => ({ tasks: s.tasks.filter((t) => t.id !== id) }))
+          // Clear stale UI references to deleted task
+          const ui = useUIStore.getState()
+          if (ui.expandedTaskId === id) ui.collapseTask()
+          if (ui.activeTaskId === id) ui.closeChat()
+          try {
+            await ipc.deleteTask(id)
+            if (workspaceId) {
+              await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+            }
+          } catch {
+            set({ tasks: prev })
+          }
+        },
+
+        move: async (id, targetColumnId, position) => {
+          const prev = get().tasks
+          const workspaceId = prev.find((t) => t.id === id)?.workspaceId
           set((s) => ({
-            tasks: s.tasks.map((t) => (t.id === id ? unarchived : t)),
+            tasks: s.tasks.map((t) =>
+              t.id === id ? { ...t, columnId: targetColumnId, position } : t,
+            ),
           }))
-          if (workspaceId) {
-            await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+          try {
+            await ipc.moveTask(id, targetColumnId, position)
+            if (workspaceId) {
+              await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+            }
+          } catch {
+            set({ tasks: prev })
           }
-        } catch {
-          set({ tasks: prev })
-        }
-      },
+        },
 
-      remove: async (id) => {
-        const prev = get().tasks
-        const workspaceId = prev.find((t) => t.id === id)?.workspaceId
-        set((s) => ({ tasks: s.tasks.filter((t) => t.id !== id) }))
-        // Clear stale UI references to deleted task
-        const ui = useUIStore.getState()
-        if (ui.expandedTaskId === id) ui.collapseTask()
-        if (ui.activeTaskId === id) ui.closeChat()
-        try {
-          await ipc.deleteTask(id)
-          if (workspaceId) {
-            await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
+        reorder: async (columnId, ids) => {
+          const prev = get().tasks
+          set((s) => ({
+            tasks: s.tasks.map((t) => {
+              if (t.columnId !== columnId) return t
+              const idx = ids.indexOf(t.id)
+              return idx >= 0 ? { ...t, position: idx } : t
+            }),
+          }))
+          try {
+            await ipc.reorderTasks(columnId, ids)
+          } catch {
+            set({ tasks: prev })
           }
-        } catch {
-          set({ tasks: prev })
-        }
-      },
+        },
 
-      move: async (id, targetColumnId, position) => {
-        const prev = get().tasks
-        const workspaceId = prev.find((t) => t.id === id)?.workspaceId
-        set((s) => ({
-          tasks: s.tasks.map((t) =>
-            t.id === id ? { ...t, columnId: targetColumnId, position } : t,
-          ),
-        }))
-        try {
-          await ipc.moveTask(id, targetColumnId, position)
-          if (workspaceId) {
-            await useWorkspaceStore.getState().refreshWorkspace(workspaceId)
-          }
-        } catch {
-          set({ tasks: prev })
-        }
-      },
+        updateTask: (id, updates) => {
+          set((s) => ({
+            tasks: s.tasks.map((t) => (t.id === id ? { ...t, ...updates } : t)),
+          }))
+        },
 
-      reorder: async (columnId, ids) => {
-        const prev = get().tasks
-        set((s) => ({
-          tasks: s.tasks.map((t) => {
-            if (t.columnId !== columnId) return t
-            const idx = ids.indexOf(t.id)
-            return idx >= 0 ? { ...t, position: idx } : t
-          }),
-        }))
-        try {
-          await ipc.reorderTasks(columnId, ids)
-        } catch {
-          set({ tasks: prev })
-        }
-      },
+        getByColumn: (columnId) => {
+          return get()
+            .tasks.filter((t) => t.columnId === columnId)
+            .sort((a, b) => a.position - b.position)
+        },
 
-      updateTask: (id, updates) => {
-        set((s) => ({
-          tasks: s.tasks.map((t) => (t.id === id ? { ...t, ...updates } : t)),
-        }))
-      },
-
-      getByColumn: (columnId) => {
-        return get()
-          .tasks.filter((t) => t.columnId === columnId)
-          .sort((a, b) => a.position - b.position)
-      },
-
-      duplicate: async (id) => {
-        const original = get().tasks.find((t) => t.id === id)
-        if (!original) return null
-        const newTitle = original.title.endsWith(' (Copy)')
-          ? original.title
-          : `${original.title} (Copy)`
-        const task = await ipc.createTask(
-          original.workspaceId,
-          original.columnId,
-          newTitle,
-          original.description,
-        )
-        set((s) => ({ tasks: [...s.tasks, task] }))
-        await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
-        return task
-      },
-    }),
+        duplicate: async (id) => {
+          const original = get().tasks.find((t) => t.id === id)
+          if (!original) return null
+          const newTitle = original.title.endsWith(' (Copy)')
+            ? original.title
+            : `${original.title} (Copy)`
+          const task = await ipc.createTask(
+            original.workspaceId,
+            original.columnId,
+            newTitle,
+            original.description,
+          )
+          set((s) => ({ tasks: [...s.tasks, task] }))
+          await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
+          return task
+        },
+      }
+    },
     { name: 'task-store' },
   ),
 )

--- a/src/test/mocks/tauri.ts
+++ b/src/test/mocks/tauri.ts
@@ -85,6 +85,7 @@ export const mockTask = (overrides: Partial<Task> = {}): Task => ({
   blocked: false,
   worktreePath: null,
   queuedAt: null,
+  archivedAt: null,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   ...overrides,

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -27,6 +27,7 @@ export type Task = {
   agentStatus: AgentStatus | null
   queuedAt: string | null
   batchId?: string | null
+  archivedAt: string | null
   pipelineState: PipelineState
   pipelineTriggeredAt: string | null
   pipelineError: string | null


### PR DESCRIPTION
## Description

Add archived_at timestamp column to tasks. Add Archive action (vs Delete which is permanent). Add toggle in board header to show/hide archived tasks. Archived tasks show grayed in their column position. Acceptance: archive task hides it from default view, unarchive restores, cargo check passes, npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/task-archiving-separate-from-delete-with-archive-v` → `staging/overnight-20260430-bento-ya`

## Commits

```
ae1b6de Clean up task archive UI state handling
6480047 Fix archived task queue edge cases
cd3f504 Add task archive regression test
11cda58 Polish archived task board behavior
639b55b fix: exclude archived tasks from backlog queue actions
fd25153 Add task archiving workflow
```

## Changes

```
src-tauri/src/commands/task.rs                     |  33 +++-
 .../src/db/migrations/032_task_archived_at.sql     |   4 +
 src-tauri/src/db/mod.rs                            |  47 ++++-
 src-tauri/src/db/models.rs                         |   2 +
 src-tauri/src/db/schema.rs                         |   2 +
 src-tauri/src/db/task.rs                           |  19 +-
 src-tauri/src/db/workspace.rs                      |   2 +-
 src-tauri/src/lib.rs                               |   2 +
 src-tauri/src/llm/context.rs                       |   1 +
 src-tauri/src/pipeline/completion.rs               |   1 +
 src-tauri/src/pipeline/exit.rs                     |   1 +
 src-tauri/src/pipeline/mod.rs                      |   1 +
 src-tauri/src/pipeline/template.rs                 |   1 +
 src-tauri/src/pipeline/test_utils.rs               |   1 +
 src/components/kanban/column.tsx                   |  17 +-
 src/components/kanban/task-card.tsx                |  11 +-
 src/components/kanban/task-context-menu.tsx        |   6 +-
 src/components/kanban/use-task-card-actions.ts     |  11 +-
 src/components/layout/board.tsx                    | 166 +++++++++++------
 src/components/panel/pipeline-dashboard.test.ts    |   1 +
 src/components/shared/toggle.tsx                   |  19 +-
 src/hooks/use-dnd.ts                               |  21 ++-
 src/lib/browser-mock.ts                            |  23 +++
 src/lib/ipc/task.ts                                |   8 +
 src/scripts/rebase-pr.test.ts                      |   5 +-
 src/stores/task-store.test.ts                      |  63 +++++++
 src/stores/task-store.ts                           | 206 ++++++++++++---------
 src/test/mocks/tauri.ts                            |   1 +
 src/types/task.ts                                  |   1 +
 29 files changed, 500 insertions(+), 176 deletions(-)
```