### PR TITLE
Per-column metrics card (avg time, success rate, throughput)

### DIFF
--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -278,6 +278,7 @@ pub struct ColumnTimingAverage {
     pub task_count: i64,
     pub success_count: i64,
     pub failure_count: i64,
+    pub throughput_per_day: f64,
 }
 
 // ─── Usage Tracking Entities ────────────────────────────────────────────────

--- a/src-tauri/src/db/pipeline_timing.rs
+++ b/src-tauri/src/db/pipeline_timing.rs
@@ -101,7 +101,7 @@ pub fn get_pipeline_timing(
     rows.collect()
 }
 
-/// Get average timing per column for a workspace.
+/// Get average timing per column for a workspace, filtered to the last 30 days.
 pub fn get_average_pipeline_timing(
     conn: &Connection,
     workspace_id: &str,
@@ -111,10 +111,13 @@ pub fn get_average_pipeline_timing(
                 COALESCE(AVG(pt.duration_seconds), 0) as avg_duration,
                 COUNT(*) as task_count,
                 SUM(CASE WHEN pt.success = 1 THEN 1 ELSE 0 END) as success_count,
-                SUM(CASE WHEN pt.success = 0 THEN 1 ELSE 0 END) as failure_count
+                SUM(CASE WHEN pt.success = 0 THEN 1 ELSE 0 END) as failure_count,
+                CAST(COUNT(*) AS REAL) / 30.0 as throughput_per_day
          FROM pipeline_timing pt
          JOIN tasks t ON pt.task_id = t.id
-         WHERE t.workspace_id = ?1 AND pt.duration_seconds IS NOT NULL
+         WHERE t.workspace_id = ?1
+           AND pt.duration_seconds IS NOT NULL
+           AND pt.exited_at >= datetime('now', '-30 days')
          GROUP BY pt.column_id, pt.column_name
          ORDER BY pt.column_name ASC",
     )?;
@@ -126,6 +129,7 @@ pub fn get_average_pipeline_timing(
             task_count: row.get(3)?,
             success_count: row.get(4)?,
             failure_count: row.get(5)?,
+            throughput_per_day: row.get(6)?,
         })
     })?;
     rows.collect()

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,6 +1,8 @@
 import { memo, useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { IconButton } from '@/components/shared/icon-button'
+import { Tooltip } from '@/components/shared/tooltip'
+import type { ColumnMetrics } from '@/lib/ipc/pipeline'
 
 type ScriptTriggerInfo = {
   scriptName: string
@@ -20,11 +22,33 @@ type ColumnHeaderProps = {
   scriptTrigger?: ScriptTriggerInfo
   isBacklog?: boolean
   batchQueue?: BatchQueueState
+  metrics?: ColumnMetrics
   onConfigure: () => void
   onDelete: () => void
   onAddTask: () => void
   onRunAll?: () => void
   onCancelQueue?: () => void
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`
+  const h = Math.floor(seconds / 3600)
+  const m = Math.round((seconds % 3600) / 60)
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}
+
+function buildMetricsTooltip(m: ColumnMetrics): string {
+  const duration = formatDuration(m.avgDurationSeconds)
+  const rate = m.taskCount > 0 ? Math.round((m.successCount / m.taskCount) * 100) : 0
+  const throughput = m.throughputPerDay.toFixed(1)
+  return [
+    `Avg time: ${duration}`,
+    `Success rate: ${rate}% (${m.successCount}/${m.taskCount} tasks)`,
+    `Throughput: ${throughput} tasks/day`,
+    `(last 30 days)`,
+  ].join('\n')
 }
 
 // Icon components
@@ -92,6 +116,7 @@ export const ColumnHeader = memo(function ColumnHeader({
   scriptTrigger,
   isBacklog,
   batchQueue,
+  metrics,
   onConfigure,
   onDelete,
   onAddTask,
@@ -248,6 +273,29 @@ export const ColumnHeader = memo(function ColumnHeader({
           </div>
         </div>
       </div>
+
+      {/* Per-column metrics row */}
+      {metrics && metrics.taskCount > 0 && (
+        <Tooltip
+          content={buildMetricsTooltip(metrics)}
+          side="bottom"
+          wrap
+        >
+          <div className="flex items-center gap-2 px-3 pb-1.5">
+            <span className="text-[10px] text-text-secondary/60 tabular-nums">
+              ⏱ {formatDuration(metrics.avgDurationSeconds)}
+            </span>
+            <span className="text-[10px] text-text-secondary/40">·</span>
+            <span className="text-[10px] text-text-secondary/60 tabular-nums">
+              ✓ {metrics.taskCount > 0 ? Math.round((metrics.successCount / metrics.taskCount) * 100) : 0}%
+            </span>
+            <span className="text-[10px] text-text-secondary/40">·</span>
+            <span className="text-[10px] text-text-secondary/60 tabular-nums">
+              {metrics.throughputPerDay.toFixed(1)}/d
+            </span>
+          </div>
+        </Tooltip>
+      )}
 
       {/* Run All confirmation dialog */}
       {showConfirm && (

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -31,21 +31,25 @@ type ColumnHeaderProps = {
 }
 
 function formatDuration(seconds: number): string {
-  if (seconds < 60) return `${Math.round(seconds)}s`
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m`
+  if (seconds < 60) return `${String(Math.round(seconds))}s`
+  if (seconds < 3600) return `${String(Math.round(seconds / 60))}m`
   const h = Math.floor(seconds / 3600)
   const m = Math.round((seconds % 3600) / 60)
-  if (m === 0) return `${h}h`
-  return `${h}h ${m}m`
+  if (m === 0) return `${String(h)}h`
+  return `${String(h)}h ${String(m)}m`
+}
+
+function successRatePct(m: ColumnMetrics): number {
+  return Math.round((m.successCount / m.taskCount) * 100)
 }
 
 function buildMetricsTooltip(m: ColumnMetrics): string {
   const duration = formatDuration(m.avgDurationSeconds)
-  const rate = m.taskCount > 0 ? Math.round((m.successCount / m.taskCount) * 100) : 0
+  const rate = successRatePct(m)
   const throughput = m.throughputPerDay.toFixed(1)
   return [
     `Avg time: ${duration}`,
-    `Success rate: ${rate}% (${m.successCount}/${m.taskCount} tasks)`,
+    `Success rate: ${String(rate)}% (${String(m.successCount)}/${String(m.taskCount)} tasks)`,
     `Throughput: ${throughput} tasks/day`,
     `(last 30 days)`,
   ].join('\n')
@@ -287,7 +291,7 @@ export const ColumnHeader = memo(function ColumnHeader({
             </span>
             <span className="text-[10px] text-text-secondary/40">·</span>
             <span className="text-[10px] text-text-secondary/60 tabular-nums">
-              ✓ {metrics.taskCount > 0 ? Math.round((metrics.successCount / metrics.taskCount) * 100) : 0}%
+              ✓ {successRatePct(metrics)}%
             </span>
             <span className="text-[10px] text-text-secondary/40">·</span>
             <span className="text-[10px] text-text-secondary/60 tabular-nums">

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -42,8 +42,7 @@ export const Column = memo(function Column({
   const addTask = useTaskStore((s) => s.add)
   const remove = useColumnStore((s) => s.remove)
   const getScriptName = useScriptStore((s) => s.getScriptName)
-  const getMetrics = useColumnMetricsStore((s) => s.getMetrics)
-  const columnMetrics = getMetrics(column.id)
+  const columnMetrics = useColumnMetricsStore((s) => s.metricsById[column.id])
 
   // Memoize filtered tasks to prevent infinite loops
   const tasks = useMemo(

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -9,6 +9,7 @@ import { useTaskStore } from '@/stores/task-store'
 import { useColumnStore } from '@/stores/column-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useScriptStore } from '@/stores/script-store'
+import { useColumnMetricsStore } from '@/stores/column-metrics-store'
 import { queueBacklog, cancelBacklogQueue } from '@/lib/ipc/pipeline'
 import { ColumnHeader } from './column-header'
 import { TaskCard } from './task-card'
@@ -41,6 +42,8 @@ export const Column = memo(function Column({
   const addTask = useTaskStore((s) => s.add)
   const remove = useColumnStore((s) => s.remove)
   const getScriptName = useScriptStore((s) => s.getScriptName)
+  const getMetrics = useColumnMetricsStore((s) => s.getMetrics)
+  const columnMetrics = getMetrics(column.id)
 
   // Memoize filtered tasks to prevent infinite loops
   const tasks = useMemo(
@@ -216,6 +219,7 @@ export const Column = memo(function Column({
             scriptTrigger={scriptTrigger}
             isBacklog={column.position === 0}
             batchQueue={batchQueueState.isQueuing ? { total: batchQueueState.total, completed: batchQueueState.completed } : undefined}
+            metrics={columnMetrics}
             onConfigure={handleConfigure}
             onDelete={handleDelete}
             onAddTask={handleAddTask}

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -13,6 +13,7 @@ import { useColumnStore } from '@/stores/column-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useScriptStore } from '@/stores/script-store'
+import { useColumnMetricsStore } from '@/stores/column-metrics-store'
 import { Column } from '@/components/kanban/column'
 import { DragOverlayContent } from '@/components/kanban/drag-overlay'
 import { DependencyLines } from '@/components/kanban/dependency-lines'
@@ -38,6 +39,7 @@ export function Board() {
   const bulkMoveTasks = useTaskStore((s) => s.bulkMove)
   const bulkRemoveTasks = useTaskStore((s) => s.bulkRemove)
   const loadScripts = useScriptStore((s) => s.load)
+  const loadColumnMetrics = useColumnMetricsStore((s) => s.load)
 
   const [newColumnId, setNewColumnId] = useState<string | null>(null)
   const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(() => new Set())
@@ -112,8 +114,9 @@ export function Board() {
       void loadColumns(activeWorkspaceId)
       void loadTasks(activeWorkspaceId)
       void loadScripts()
+      void loadColumnMetrics(activeWorkspaceId)
     }
-  }, [activeWorkspaceId, loadColumns, loadTasks, loadScripts])
+  }, [activeWorkspaceId, loadColumns, loadTasks, loadScripts, loadColumnMetrics])
 
   useEffect(() => {
     setSelectedTaskIds((current) => {

--- a/src/hooks/use-task-sync.ts
+++ b/src/hooks/use-task-sync.ts
@@ -7,6 +7,7 @@
 import { useEffect, useRef } from 'react'
 import { listen, type UnlistenFn } from '@/lib/ipc'
 import { useTaskStore } from '@/stores/task-store'
+import { useColumnMetricsStore } from '@/stores/column-metrics-store'
 
 type TasksChangedPayload = {
   workspaceId: string
@@ -15,6 +16,7 @@ type TasksChangedPayload = {
 
 export function useTaskSync(workspaceId: string | null) {
   const loadTasks = useTaskStore((s) => s.load)
+  const loadMetrics = useColumnMetricsStore((s) => s.load)
   const unlistenRef = useRef<UnlistenFn | null>(null)
 
   useEffect(() => {
@@ -26,6 +28,7 @@ export function useTaskSync(workspaceId: string | null) {
       if (cancelled) return
       if (payload.workspaceId === workspaceId) {
         void loadTasks(workspaceId)
+        void loadMetrics(workspaceId)
       }
     }).then((unlisten) => {
       if (cancelled) {
@@ -40,5 +43,5 @@ export function useTaskSync(workspaceId: string | null) {
       unlistenRef.current?.()
       unlistenRef.current = null
     }
-  }, [workspaceId, loadTasks])
+  }, [workspaceId, loadTasks, loadMetrics])
 }

--- a/src/lib/ipc/pipeline.ts
+++ b/src/lib/ipc/pipeline.ts
@@ -1,6 +1,22 @@
 import { invoke, listen, type EventCallback, type UnlistenFn } from './invoke'
 import type { Task } from '@/types'
 
+// ─── Column metrics ────────────────────────────────────────────────────────
+
+export type ColumnMetrics = {
+  columnId: string
+  columnName: string
+  avgDurationSeconds: number
+  taskCount: number
+  successCount: number
+  failureCount: number
+  throughputPerDay: number
+}
+
+export async function getColumnMetrics(workspaceId: string): Promise<ColumnMetrics[]> {
+  return invoke<ColumnMetrics[]>('get_average_pipeline_timing', { workspaceId })
+}
+
 // ─── Pipeline commands ─────────────────────────────────────────────────────
 
 export type PipelineEvent = {

--- a/src/stores/column-metrics-store.ts
+++ b/src/stores/column-metrics-store.ts
@@ -4,16 +4,13 @@ import { getColumnMetrics, type ColumnMetrics } from '@/lib/ipc/pipeline'
 
 type ColumnMetricsState = {
   metricsById: Record<string, ColumnMetrics>
-  loadedWorkspaceId: string | null
   load: (workspaceId: string) => Promise<void>
-  getMetrics: (columnId: string) => ColumnMetrics | undefined
 }
 
 export const useColumnMetricsStore = create<ColumnMetricsState>()(
   devtools(
-    (set, get) => ({
+    (set) => ({
       metricsById: {},
-      loadedWorkspaceId: null,
 
       load: async (workspaceId) => {
         const metrics = await getColumnMetrics(workspaceId)
@@ -21,10 +18,8 @@ export const useColumnMetricsStore = create<ColumnMetricsState>()(
         for (const m of metrics) {
           metricsById[m.columnId] = m
         }
-        set({ metricsById, loadedWorkspaceId: workspaceId })
+        set({ metricsById })
       },
-
-      getMetrics: (columnId) => get().metricsById[columnId],
     }),
     { name: 'column-metrics-store' },
   ),

--- a/src/stores/column-metrics-store.ts
+++ b/src/stores/column-metrics-store.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import { getColumnMetrics, type ColumnMetrics } from '@/lib/ipc/pipeline'
+
+type ColumnMetricsState = {
+  metricsById: Record<string, ColumnMetrics>
+  loadedWorkspaceId: string | null
+  load: (workspaceId: string) => Promise<void>
+  getMetrics: (columnId: string) => ColumnMetrics | undefined
+}
+
+export const useColumnMetricsStore = create<ColumnMetricsState>()(
+  devtools(
+    (set, get) => ({
+      metricsById: {},
+      loadedWorkspaceId: null,
+
+      load: async (workspaceId) => {
+        const metrics = await getColumnMetrics(workspaceId)
+        const metricsById: Record<string, ColumnMetrics> = {}
+        for (const m of metrics) {
+          metricsById[m.columnId] = m
+        }
+        set({ metricsById, loadedWorkspaceId: workspaceId })
+      },
+
+      getMetrics: (columnId) => get().metricsById[columnId],
+    }),
+    { name: 'column-metrics-store' },
+  ),
+)


### PR DESCRIPTION
## Description

Show a small metrics card in each column header: avg time tasks spent in this column (last 30 days), success rate (% reached next column without retry), tasks-per-day throughput. Query existing tasks + agent_sessions tables. Acceptance: metrics show on every column, hover for detail, npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/per-column-metrics-card-avg-time-success-rate-thro` → `staging/2026-05-01-bento-ya-recovery`