### PR TITLE
Custom column creation, rename, and delete UI

### DIFF
--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -106,9 +106,12 @@ export const ColumnHeader = memo(function ColumnHeader({
   const [renameValue, setRenameValue] = useState('')
   const menuRef = useRef<HTMLDivElement>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
+  // Prevents blur from submitting after Enter or Escape already resolved the rename
+  const renameResolvedRef = useRef(false)
 
   useEffect(() => {
     if (isRenaming) {
+      renameResolvedRef.current = false
       renameInputRef.current?.focus()
       renameInputRef.current?.select()
     }
@@ -120,6 +123,8 @@ export const ColumnHeader = memo(function ColumnHeader({
   }
 
   const submitRename = () => {
+    if (renameResolvedRef.current) return
+    renameResolvedRef.current = true
     const trimmed = renameValue.trim()
     if (trimmed && trimmed !== name) {
       onRenameSubmit(trimmed)
@@ -128,6 +133,8 @@ export const ColumnHeader = memo(function ColumnHeader({
   }
 
   const cancelRename = () => {
+    if (renameResolvedRef.current) return
+    renameResolvedRef.current = true
     setIsRenaming(false)
   }
 

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useEffect } from 'react'
+import { memo, useState, useRef, useEffect, type ChangeEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { IconButton } from '@/components/shared/icon-button'
 
@@ -107,7 +107,7 @@ export const ColumnHeader = memo(function ColumnHeader({
   const menuRef = useRef<HTMLDivElement>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
   // Prevents blur from submitting after Enter or Escape already resolved the rename
-  const renameResolvedRef = useRef(false)
+  const renameResolvedRef = useRef<boolean>(false)
 
   useEffect(() => {
     if (isRenaming) {
@@ -136,6 +136,19 @@ export const ColumnHeader = memo(function ColumnHeader({
     if (renameResolvedRef.current) return
     renameResolvedRef.current = true
     setIsRenaming(false)
+  }
+
+  const handleRenameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setRenameValue(e.target.value)
+  }
+
+  const handleRenameKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') { e.preventDefault(); submitRename() }
+    if (e.key === 'Escape') { e.preventDefault(); cancelRename() }
+  }
+
+  const stopInputPropagation = (e: ReactMouseEvent) => {
+    e.stopPropagation()
   }
 
   // Close menu when clicking outside
@@ -173,14 +186,11 @@ export const ColumnHeader = memo(function ColumnHeader({
             ref={renameInputRef}
             type="text"
             value={renameValue}
-            onChange={(e) => { setRenameValue(e.target.value) }}
+            onChange={handleRenameChange}
             onBlur={submitRename}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); submitRename() }
-              if (e.key === 'Escape') { e.preventDefault(); cancelRename() }
-            }}
-            onMouseDown={(e) => { e.stopPropagation() }}
-            onClick={(e) => { e.stopPropagation() }}
+            onKeyDown={handleRenameKeyDown}
+            onMouseDown={stopInputPropagation}
+            onClick={stopInputPropagation}
             className="min-w-0 flex-1 bg-transparent text-xs font-semibold uppercase tracking-wider text-text-primary outline-none border-b border-accent pb-px"
           />
         ) : (

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -23,6 +23,7 @@ type ColumnHeaderProps = {
   onConfigure: () => void
   onDelete: () => void
   onAddTask: () => void
+  onRenameSubmit: (name: string) => void
   onRunAll?: () => void
   onCancelQueue?: () => void
 }
@@ -95,12 +96,40 @@ export const ColumnHeader = memo(function ColumnHeader({
   onConfigure,
   onDelete,
   onAddTask,
+  onRenameSubmit,
   onRunAll,
   onCancelQueue,
 }: ColumnHeaderProps) {
   const [showMenu, setShowMenu] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [renameValue, setRenameValue] = useState('')
   const menuRef = useRef<HTMLDivElement>(null)
+  const renameInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (isRenaming) {
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
+    }
+  }, [isRenaming])
+
+  const handleNameDoubleClick = () => {
+    setRenameValue(name)
+    setIsRenaming(true)
+  }
+
+  const submitRename = () => {
+    const trimmed = renameValue.trim()
+    if (trimmed && trimmed !== name) {
+      onRenameSubmit(trimmed)
+    }
+    setIsRenaming(false)
+  }
+
+  const cancelRename = () => {
+    setIsRenaming(false)
+  }
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -132,9 +161,29 @@ export const ColumnHeader = memo(function ColumnHeader({
         >
           {getIcon(icon)}
         </span>
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary truncate">
-          {name}
-        </h3>
+        {isRenaming ? (
+          <input
+            ref={renameInputRef}
+            type="text"
+            value={renameValue}
+            onChange={(e) => { setRenameValue(e.target.value) }}
+            onBlur={submitRename}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') { e.preventDefault(); submitRename() }
+              if (e.key === 'Escape') { e.preventDefault(); cancelRename() }
+            }}
+            onMouseDown={(e) => { e.stopPropagation() }}
+            onClick={(e) => { e.stopPropagation() }}
+            className="min-w-0 flex-1 bg-transparent text-xs font-semibold uppercase tracking-wider text-text-primary outline-none border-b border-accent pb-px"
+          />
+        ) : (
+          <h3
+            className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wider text-text-secondary truncate cursor-default select-none"
+            onDoubleClick={handleNameDoubleClick}
+          >
+            {name}
+          </h3>
+        )}
         <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
           {taskCount}
         </span>

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -40,6 +40,7 @@ export const Column = memo(function Column({
   const allTasks = useTaskStore((s) => s.tasks)
   const addTask = useTaskStore((s) => s.add)
   const remove = useColumnStore((s) => s.remove)
+  const updateColumnAsync = useColumnStore((s) => s.updateColumnAsync)
   const getScriptName = useScriptStore((s) => s.getScriptName)
 
   // Memoize filtered tasks to prevent infinite loops
@@ -163,6 +164,10 @@ export const Column = memo(function Column({
     }
   }, [autoOpenConfig, onConfigOpened])
 
+  const handleRename = useCallback((newName: string) => {
+    void updateColumnAsync(column.id, { name: newName })
+  }, [column.id, updateColumnAsync])
+
   const handleConfigure = useCallback(() => {
     setShowConfigDialog(true)
   }, [])
@@ -219,6 +224,7 @@ export const Column = memo(function Column({
             onConfigure={handleConfigure}
             onDelete={handleDelete}
             onAddTask={handleAddTask}
+            onRenameSubmit={handleRename}
             onRunAll={() => { void handleRunAll(); }}
             onCancelQueue={() => { void handleCancelQueue(); }}
           />

--- a/src/components/settings/tabs/github-tab.tsx
+++ b/src/components/settings/tabs/github-tab.tsx
@@ -52,7 +52,7 @@ export function GithubTab() {
       setLastSyncedAt(new Date().toISOString())
       setMessage({
         type: 'success',
-        text: `Synced: ${result.tasksCreated} task(s) created, ${result.issuesFetched} issue(s) fetched`,
+        text: `Synced: ${String(result.tasksCreated)} task(s) created, ${String(result.issuesFetched)} issue(s) fetched`,
       })
     } catch (err) {
       setMessage({


### PR DESCRIPTION
## Description

Currently column structure is hardcoded per workspace. Add UI: + button at end of board to add column, double-click column name to rename, context menu to delete (with confirm). Persist via columns table. Acceptance: add/rename/delete columns from UI, position preserved, cargo check && npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/custom-column-creation-rename-and-delete-ui` → `staging/2026-05-01-bento-ya-recovery`

## Commits

```
b4f494c Refactor rename handlers and fix lint errors
c629230 Fix blur-after-Escape race in column rename input
1cf7ad5 Add inline double-click rename to column header
```

## Changes

```
src/components/kanban/column-header.tsx     | 74 +++++++++++++++++++++++++++--
 src/components/kanban/column.tsx            |  6 +++
 src/components/settings/tabs/github-tab.tsx |  2 +-
 3 files changed, 77 insertions(+), 5 deletions(-)
```