### PR TITLE
Task time tracking — estimated vs actual hours

### DIFF
--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -89,7 +89,7 @@ pub fn list_tasks(state: State<AppState>, workspace_id: String) -> Result<Vec<Ta
     Ok(db::list_tasks(&conn, &workspace_id)?)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "camelCase")]
 #[allow(clippy::too_many_arguments)]
 pub fn update_task(
     _app: AppHandle,
@@ -102,6 +102,7 @@ pub fn update_task(
     agent_mode: Option<Option<String>>,
     priority: Option<String>,
     model: Option<Option<String>>,
+    estimated_hours: Option<Option<f64>>,
 ) -> Result<Task, AppError> {
     if let Some(ref t) = title {
         if t.trim().is_empty() {
@@ -114,6 +115,13 @@ pub fn update_task(
         if pos < 0 {
             return Err(AppError::InvalidInput(
                 "Position must be non-negative".to_string(),
+            ));
+        }
+    }
+    if let Some(Some(hours)) = estimated_hours {
+        if !hours.is_finite() || hours < 0.0 {
+            return Err(AppError::InvalidInput(
+                "Estimated hours must be a non-negative number".to_string(),
             ));
         }
     }
@@ -145,6 +153,10 @@ pub fn update_task(
         )
         .map_err(AppError::from)?;
         task = db::get_task(&conn, &id)?;
+    }
+
+    if let Some(hours) = estimated_hours {
+        task = db::update_task_time_tracking(&conn, &id, hours)?;
     }
 
     Ok(task)

--- a/src-tauri/src/db/migrations/034_task_time_tracking.sql
+++ b/src-tauri/src/db/migrations/034_task_time_tracking.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tasks ADD COLUMN estimated_hours REAL;
+ALTER TABLE tasks ADD COLUMN actual_hours REAL NOT NULL DEFAULT 0;

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -144,6 +144,7 @@ fn run_migrations(conn: &Connection) -> SqlResult<()> {
         ("031_task_batch_id", include_str!("migrations/031_task_batch_id.sql")),
         ("032_github_sync", include_str!("migrations/032_github_sync.sql")),
         ("033_github_issue_unique", include_str!("migrations/033_github_issue_unique.sql")),
+        ("034_task_time_tracking", include_str!("migrations/034_task_time_tracking.sql")),
     ];
 
     for (name, sql) in migrations {
@@ -206,8 +207,8 @@ mod tests {
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
             .unwrap();
-        // We have 35 migrations, including split 019 and 030 migration files.
-        assert_eq!(count, 35);
+        // We have 36 migrations, including split 019 and 030 migration files.
+        assert_eq!(count, 36);
     }
 
     #[test]
@@ -264,6 +265,8 @@ mod tests {
         assert_eq!(task.description.as_deref(), Some("Critical issue"));
         assert_eq!(task.position, 0);
         assert_eq!(task.priority, "medium");
+        assert_eq!(task.estimated_hours, None);
+        assert_eq!(task.actual_hours, 0.0);
 
         // Second task gets position 1
         let task2 = insert_task(&conn, &ws.id, &col.id, "Add feature", None).unwrap();
@@ -279,6 +282,31 @@ mod tests {
         delete_task(&conn, &task.id).unwrap();
         let tasks = list_tasks(&conn, &ws.id).unwrap();
         assert_eq!(tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_task_time_tracking() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        let task = insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+
+        let updated = update_task_time_tracking(&conn, &task.id, Some(2.5)).unwrap();
+        assert_eq!(updated.estimated_hours, Some(2.5));
+
+        let session = insert_agent_session(&conn, &task.id, "claude", Some("/tmp")).unwrap();
+        conn.execute(
+            "UPDATE agent_sessions SET created_at = ?1, updated_at = ?2 WHERE id = ?3",
+            params![
+                "2024-01-01 00:00:00",
+                "2024-01-01 01:30:00",
+                session.id,
+            ],
+        )
+        .unwrap();
+
+        let tracked = get_task(&conn, &task.id).unwrap();
+        assert!((tracked.actual_hours - 1.5).abs() < 0.001);
     }
 
     #[test]

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -64,6 +64,8 @@ pub struct Task {
     pub batch_id: Option<String>,
     pub files_touched: String,
     pub checklist: Option<String>,
+    pub estimated_hours: Option<f64>,
+    pub actual_hours: f64,
     pub pipeline_state: String,
     pub pipeline_triggered_at: Option<String>,
     pub pipeline_error: Option<String>,

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -39,6 +39,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     batch_id TEXT,
     files_touched TEXT DEFAULT '[]',
     checklist TEXT,
+    estimated_hours REAL,
+    actual_hours REAL NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -3,8 +3,8 @@ use rusqlite::{params, Connection, Result as SqlResult};
 use super::models::Task;
 use super::{new_id, now};
 
-/// Shared SELECT columns for tasks (49 fields).
-const TASK_COLUMNS: &str = "id, workspace_id, column_id, title, description, position, priority, agent_mode, branch_name, files_touched, checklist, pipeline_state, pipeline_triggered_at, pipeline_error, agent_session_id, last_script_exit_code, review_status, pr_number, pr_url, siege_iteration, siege_active, siege_max_iterations, siege_last_checked, pr_mergeable, pr_ci_status, pr_review_decision, pr_comment_count, pr_is_draft, pr_labels, pr_last_fetched, pr_head_sha, notify_stakeholders, notification_sent_at, trigger_overrides, trigger_prompt, last_output, dependencies, blocked, created_at, updated_at, agent_status, queued_at, retry_count, model, worktree_path, batch_id, github_issue_number, github_issue_commented, github_issue_pr_linked";
+/// Shared SELECT columns for tasks (51 fields).
+const TASK_COLUMNS: &str = "id, workspace_id, column_id, title, description, position, priority, agent_mode, branch_name, files_touched, checklist, estimated_hours, COALESCE((SELECT ROUND(SUM(MAX((julianday(agent_sessions.updated_at) - julianday(agent_sessions.created_at)) * 24.0, 0.0)), 4) FROM agent_sessions WHERE agent_sessions.task_id = tasks.id), actual_hours, 0.0) AS actual_hours, pipeline_state, pipeline_triggered_at, pipeline_error, agent_session_id, last_script_exit_code, review_status, pr_number, pr_url, siege_iteration, siege_active, siege_max_iterations, siege_last_checked, pr_mergeable, pr_ci_status, pr_review_decision, pr_comment_count, pr_is_draft, pr_labels, pr_last_fetched, pr_head_sha, notify_stakeholders, notification_sent_at, trigger_overrides, trigger_prompt, last_output, dependencies, blocked, created_at, updated_at, agent_status, queued_at, retry_count, model, worktree_path, batch_id, github_issue_number, github_issue_commented, github_issue_pr_linked";
 
 /// Generate a sortable task batch identifier for staging PR workflows.
 pub fn generate_batch_id() -> String {
@@ -22,51 +22,53 @@ fn map_task_row(row: &rusqlite::Row) -> rusqlite::Result<Task> {
         position: row.get(5)?,
         priority: row.get(6)?,
         agent_mode: row.get(7)?,
-        agent_status: row.get(40)?,
-        queued_at: row.get(41)?,
+        agent_status: row.get(42)?,
+        queued_at: row.get(43)?,
         branch_name: row.get(8)?,
-        batch_id: row.get(45)?,
+        batch_id: row.get(47)?,
         files_touched: row.get::<_, String>(9).unwrap_or_else(|_| "[]".to_string()),
         checklist: row.get(10)?,
+        estimated_hours: row.get(11)?,
+        actual_hours: row.get::<_, Option<f64>>(12)?.unwrap_or(0.0),
         pipeline_state: row
-            .get::<_, Option<String>>(11)?
+            .get::<_, Option<String>>(13)?
             .unwrap_or_else(|| "idle".to_string()),
-        pipeline_triggered_at: row.get(12)?,
-        pipeline_error: row.get(13)?,
-        retry_count: row.get::<_, Option<i64>>(42)?.unwrap_or(0),
-        model: row.get(43)?,
-        agent_session_id: row.get(14)?,
-        last_script_exit_code: row.get(15)?,
-        review_status: row.get(16)?,
-        pr_number: row.get(17)?,
-        pr_url: row.get(18)?,
-        siege_iteration: row.get::<_, Option<i64>>(19)?.unwrap_or(0),
-        siege_active: row.get::<_, Option<i64>>(20)?.unwrap_or(0) != 0,
-        siege_max_iterations: row.get::<_, Option<i64>>(21)?.unwrap_or(5),
-        siege_last_checked: row.get(22)?,
-        pr_mergeable: row.get(23)?,
-        pr_ci_status: row.get(24)?,
-        pr_review_decision: row.get(25)?,
-        pr_comment_count: row.get::<_, Option<i64>>(26)?.unwrap_or(0),
-        pr_is_draft: row.get::<_, Option<i64>>(27)?.unwrap_or(0) != 0,
+        pipeline_triggered_at: row.get(14)?,
+        pipeline_error: row.get(15)?,
+        retry_count: row.get::<_, Option<i64>>(44)?.unwrap_or(0),
+        model: row.get(45)?,
+        agent_session_id: row.get(16)?,
+        last_script_exit_code: row.get(17)?,
+        review_status: row.get(18)?,
+        pr_number: row.get(19)?,
+        pr_url: row.get(20)?,
+        siege_iteration: row.get::<_, Option<i64>>(21)?.unwrap_or(0),
+        siege_active: row.get::<_, Option<i64>>(22)?.unwrap_or(0) != 0,
+        siege_max_iterations: row.get::<_, Option<i64>>(23)?.unwrap_or(5),
+        siege_last_checked: row.get(24)?,
+        pr_mergeable: row.get(25)?,
+        pr_ci_status: row.get(26)?,
+        pr_review_decision: row.get(27)?,
+        pr_comment_count: row.get::<_, Option<i64>>(28)?.unwrap_or(0),
+        pr_is_draft: row.get::<_, Option<i64>>(29)?.unwrap_or(0) != 0,
         pr_labels: row
-            .get::<_, Option<String>>(28)?
+            .get::<_, Option<String>>(30)?
             .unwrap_or_else(|| "[]".to_string()),
-        pr_last_fetched: row.get(29)?,
-        pr_head_sha: row.get(30)?,
-        notify_stakeholders: row.get(31)?,
-        notification_sent_at: row.get(32)?,
-        trigger_overrides: row.get(33)?,
-        trigger_prompt: row.get(34)?,
-        last_output: row.get(35)?,
-        dependencies: row.get(36)?,
-        blocked: row.get::<_, Option<i64>>(37)?.unwrap_or(0) != 0,
-        worktree_path: row.get(44)?,
-        github_issue_number: row.get(46)?,
-        github_issue_commented: row.get::<_, Option<i64>>(47)?.unwrap_or(0) != 0,
-        github_issue_pr_linked: row.get::<_, Option<i64>>(48)?.unwrap_or(0) != 0,
-        created_at: row.get(38)?,
-        updated_at: row.get(39)?,
+        pr_last_fetched: row.get(31)?,
+        pr_head_sha: row.get(32)?,
+        notify_stakeholders: row.get(33)?,
+        notification_sent_at: row.get(34)?,
+        trigger_overrides: row.get(35)?,
+        trigger_prompt: row.get(36)?,
+        last_output: row.get(37)?,
+        dependencies: row.get(38)?,
+        blocked: row.get::<_, Option<i64>>(39)?.unwrap_or(0) != 0,
+        worktree_path: row.get(46)?,
+        github_issue_number: row.get(48)?,
+        github_issue_commented: row.get::<_, Option<i64>>(49)?.unwrap_or(0) != 0,
+        github_issue_pr_linked: row.get::<_, Option<i64>>(50)?.unwrap_or(0) != 0,
+        created_at: row.get(40)?,
+        updated_at: row.get(41)?,
     })
 }
 
@@ -161,6 +163,19 @@ pub fn update_task(
             ts,
             id,
         ],
+    )?;
+    get_task(conn, id)
+}
+
+pub fn update_task_time_tracking(
+    conn: &Connection,
+    id: &str,
+    estimated_hours: Option<f64>,
+) -> SqlResult<Task> {
+    let ts = now();
+    conn.execute(
+        "UPDATE tasks SET estimated_hours = ?1, updated_at = ?2 WHERE id = ?3",
+        params![estimated_hours, ts, id],
     )?;
     get_task(conn, id)
 }

--- a/src-tauri/src/llm/context.rs
+++ b/src-tauri/src/llm/context.rs
@@ -350,6 +350,8 @@ mod tests {
             batch_id: None,
             files_touched: "[]".to_string(),
             checklist: None,
+            estimated_hours: None,
+            actual_hours: 0.0,
             pipeline_state: "idle".to_string(),
             pipeline_triggered_at: None,
             pipeline_error: None,

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -899,6 +899,8 @@ mod tests {
             batch_id: None,
             files_touched: "[]".into(),
             checklist: None,
+            estimated_hours: None,
+            actual_hours: 0.0,
             pipeline_state: pipeline_state.into(),
             pipeline_triggered_at: None,
             pipeline_error: None,

--- a/src-tauri/src/pipeline/template.rs
+++ b/src-tauri/src/pipeline/template.rs
@@ -110,6 +110,8 @@ mod tests {
             batch_id: None,
             files_touched: "[]".to_string(),
             checklist: None,
+            estimated_hours: None,
+            actual_hours: 0.0,
             pipeline_state: "idle".to_string(),
             pipeline_triggered_at: None,
             pipeline_error: None,

--- a/src/components/kanban/task-card-expanded.test.tsx
+++ b/src/components/kanban/task-card-expanded.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { invoke } from '@tauri-apps/api/core'
+import { TaskCardExpanded } from './task-card-expanded'
+import { useTaskStore } from '@/stores/task-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { mockKanbanTask, mockWorkspace } from '@/test/mocks/tauri'
+
+const mockInvoke = vi.mocked(invoke)
+
+describe('TaskCardExpanded time tracking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({
+      workspaces: [mockWorkspace({ id: 'ws-1' })],
+      activeWorkspaceId: 'ws-1',
+    })
+    useTaskStore.setState({ tasks: [], loaded: true })
+  })
+
+  it('shows estimate and actual hours side-by-side with an overrun warning', () => {
+    const task = mockKanbanTask({ estimatedHours: 1, actualHours: 2.25 })
+
+    render(<TaskCardExpanded task={task} />)
+
+    expect(screen.getByLabelText('Estimate')).toHaveValue(1)
+    expect(screen.getByText('2.3h')).toBeInTheDocument()
+    expect(screen.getByText('Actual time is more than 2x the estimate.')).toBeInTheDocument()
+  })
+
+  it('persists edited estimate values', async () => {
+    const task = mockKanbanTask({ estimatedHours: null, actualHours: 0.5 })
+    const updated = { ...task, estimatedHours: 3 }
+    mockInvoke.mockResolvedValueOnce(updated)
+    useTaskStore.setState({ tasks: [task], loaded: true })
+
+    render(<TaskCardExpanded task={task} />)
+
+    const input = screen.getByLabelText('Estimate')
+    fireEvent.change(input, { target: { value: '3' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('update_task', {
+        id: task.id,
+        estimatedHours: 3,
+      })
+    })
+    expect(useTaskStore.getState().tasks[0]?.estimatedHours).toBe(3)
+  })
+})

--- a/src/components/kanban/task-card-expanded.test.tsx
+++ b/src/components/kanban/task-card-expanded.test.tsx
@@ -48,4 +48,17 @@ describe('TaskCardExpanded time tracking', () => {
     })
     expect(useTaskStore.getState().tasks[0]?.estimatedHours).toBe(3)
   })
+
+  it('cancels estimate edits with Escape without saving', () => {
+    const task = mockKanbanTask({ estimatedHours: 2, actualHours: 0.5 })
+
+    render(<TaskCardExpanded task={task} />)
+
+    const input = screen.getByLabelText('Estimate')
+    fireEvent.change(input, { target: { value: '5' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(input).toHaveValue(2)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/kanban/task-card-expanded.tsx
+++ b/src/components/kanban/task-card-expanded.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { Task } from '@/types'
 import { useTaskDetail } from '@/hooks/use-task-detail'
 import * as ipc from '@/lib/ipc'
@@ -26,6 +26,7 @@ function TimeTrackingSection({
     task.estimatedHours == null ? '' : String(task.estimatedHours),
   )
   const [saving, setSaving] = useState(false)
+  const skipNextBlurSave = useRef(false)
 
   useEffect(() => {
     setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
@@ -75,10 +76,17 @@ function TimeTrackingSection({
               value={estimateInput}
               disabled={saving}
               onChange={(e) => { setEstimateInput(e.target.value) }}
-              onBlur={() => { void saveEstimate() }}
+              onBlur={() => {
+                if (skipNextBlurSave.current) {
+                  skipNextBlurSave.current = false
+                  return
+                }
+                void saveEstimate()
+              }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') e.currentTarget.blur()
                 if (e.key === 'Escape') {
+                  skipNextBlurSave.current = true
                   setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
                   e.currentTarget.blur()
                 }

--- a/src/components/kanban/task-card-expanded.tsx
+++ b/src/components/kanban/task-card-expanded.tsx
@@ -1,11 +1,116 @@
 import { motion } from 'motion/react'
+import { useEffect, useState } from 'react'
 import type { Task } from '@/types'
 import { useTaskDetail } from '@/hooks/use-task-detail'
+import * as ipc from '@/lib/ipc'
 import { ChangesSection } from '@/components/task-detail/changes-section'
 import { CommitsSection } from '@/components/task-detail/commits-section'
 import { SiegeStatus } from '@/components/task-detail/siege-status'
 
 const EXPANDED_MAX_HEIGHT = 400
+
+function formatHours(hours: number) {
+  if (hours === 0) return '0h'
+  if (hours < 0.1) return '<0.1h'
+  return `${hours.toFixed(hours < 10 ? 1 : 0)}h`
+}
+
+function TimeTrackingSection({
+  task,
+  onUpdate,
+}: {
+  task: Task
+  onUpdate: (id: string, updates: Partial<Task>) => void
+}) {
+  const [estimateInput, setEstimateInput] = useState(
+    task.estimatedHours == null ? '' : String(task.estimatedHours),
+  )
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
+  }, [task.estimatedHours])
+
+  const estimatedHours = task.estimatedHours
+  const actualHours = task.actualHours ?? 0
+  const estimateInputId = `task-${task.id}-estimated-hours`
+  const overEstimate = estimatedHours != null && estimatedHours > 0 && actualHours > estimatedHours * 2
+
+  async function saveEstimate() {
+    const trimmed = estimateInput.trim()
+    const parsedEstimate = trimmed === '' ? null : Number(trimmed)
+    if (parsedEstimate != null && (!Number.isFinite(parsedEstimate) || parsedEstimate < 0)) {
+      setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
+      return
+    }
+    const nextEstimate: number | null = parsedEstimate
+    if (nextEstimate === task.estimatedHours) return
+
+    setSaving(true)
+    try {
+      const updated = await ipc.updateTask(task.id, { estimatedHours: nextEstimate })
+      onUpdate(task.id, updated)
+    } catch (err) {
+      console.error('Failed to save task estimate:', err)
+      setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="rounded-md border border-border-default bg-surface px-2.5 py-2">
+      <div className="grid grid-cols-2 gap-2">
+        <label htmlFor={estimateInputId} className="flex min-w-0 flex-col gap-1">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
+            Estimate
+          </span>
+          <div className="flex items-center gap-1">
+            <input
+              id={estimateInputId}
+              aria-label="Estimate"
+              type="number"
+              min="0"
+              step="0.25"
+              value={estimateInput}
+              disabled={saving}
+              onChange={(e) => { setEstimateInput(e.target.value) }}
+              onBlur={() => { void saveEstimate() }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key === 'Escape') {
+                  setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
+                  e.currentTarget.blur()
+                }
+              }}
+              className="h-7 w-full rounded-md border border-border-default bg-surface-hover px-2 text-xs text-text-primary outline-none transition-colors focus:border-accent focus:ring-2 focus:ring-accent/20 disabled:opacity-60"
+              placeholder="0"
+            />
+            <span className="text-xs text-text-secondary">h</span>
+          </div>
+        </label>
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
+            Actual
+          </span>
+          <div className={`flex h-7 items-center rounded-md border px-2 text-xs font-medium ${
+            overEstimate
+              ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+              : 'border-border-default bg-surface-hover text-text-primary'
+          }`}
+          >
+            {formatHours(actualHours)}
+          </div>
+        </div>
+      </div>
+      {overEstimate && (
+        <div className="mt-2 rounded-md bg-amber-500/10 px-2 py-1 text-[11px] text-amber-300">
+          Actual time is more than 2x the estimate.
+        </div>
+      )}
+    </div>
+  )
+}
 
 export function TaskCardExpanded({ task }: { task: Task }) {
   const { updateTask, changes, commits, loading } = useTaskDetail(task)
@@ -30,6 +135,8 @@ export function TaskCardExpanded({ task }: { task: Task }) {
             {task.description}
           </p>
         )}
+
+        <TimeTrackingSection task={task} onUpdate={updateTask} />
 
         {/* Branch & status */}
         <div className="flex items-center gap-2 flex-wrap">

--- a/src/components/kanban/task-card-expanded.tsx
+++ b/src/components/kanban/task-card-expanded.tsx
@@ -15,6 +15,10 @@ function formatHours(hours: number) {
   return `${hours.toFixed(hours < 10 ? 1 : 0)}h`
 }
 
+function formatEstimateInput(estimatedHours: number | null) {
+  return estimatedHours == null ? '' : String(estimatedHours)
+}
+
 function TimeTrackingSection({
   task,
   onUpdate,
@@ -22,26 +26,25 @@ function TimeTrackingSection({
   task: Task
   onUpdate: (id: string, updates: Partial<Task>) => void
 }) {
-  const [estimateInput, setEstimateInput] = useState(
-    task.estimatedHours == null ? '' : String(task.estimatedHours),
-  )
+  const [estimateInput, setEstimateInput] = useState(formatEstimateInput(task.estimatedHours))
   const [saving, setSaving] = useState(false)
   const skipNextBlurSave = useRef(false)
 
   useEffect(() => {
-    setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
-  }, [task.estimatedHours])
+    setEstimateInput(formatEstimateInput(task.estimatedHours))
+  }, [task.id, task.estimatedHours])
 
   const estimatedHours = task.estimatedHours
-  const actualHours = task.actualHours ?? 0
+  const actualHours = task.actualHours
   const estimateInputId = `task-${task.id}-estimated-hours`
-  const overEstimate = estimatedHours != null && estimatedHours > 0 && actualHours > estimatedHours * 2
+  const overEstimate =
+    estimatedHours != null && estimatedHours > 0 && actualHours > estimatedHours * 2
 
   async function saveEstimate() {
     const trimmed = estimateInput.trim()
     const parsedEstimate = trimmed === '' ? null : Number(trimmed)
     if (parsedEstimate != null && (!Number.isFinite(parsedEstimate) || parsedEstimate < 0)) {
-      setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
+      setEstimateInput(formatEstimateInput(task.estimatedHours))
       return
     }
     const nextEstimate: number | null = parsedEstimate
@@ -53,7 +56,7 @@ function TimeTrackingSection({
       onUpdate(task.id, updated)
     } catch (err) {
       console.error('Failed to save task estimate:', err)
-      setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
+      setEstimateInput(formatEstimateInput(task.estimatedHours))
     } finally {
       setSaving(false)
     }
@@ -75,7 +78,9 @@ function TimeTrackingSection({
               step="0.25"
               value={estimateInput}
               disabled={saving}
-              onChange={(e) => { setEstimateInput(e.target.value) }}
+              onChange={(e) => {
+                setEstimateInput(e.target.value)
+              }}
               onBlur={() => {
                 if (skipNextBlurSave.current) {
                   skipNextBlurSave.current = false
@@ -87,7 +92,7 @@ function TimeTrackingSection({
                 if (e.key === 'Enter') e.currentTarget.blur()
                 if (e.key === 'Escape') {
                   skipNextBlurSave.current = true
-                  setEstimateInput(task.estimatedHours == null ? '' : String(task.estimatedHours))
+                  setEstimateInput(formatEstimateInput(task.estimatedHours))
                   e.currentTarget.blur()
                 }
               }}
@@ -101,11 +106,12 @@ function TimeTrackingSection({
           <span className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
             Actual
           </span>
-          <div className={`flex h-7 items-center rounded-md border px-2 text-xs font-medium ${
-            overEstimate
-              ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
-              : 'border-border-default bg-surface-hover text-text-primary'
-          }`}
+          <div
+            className={`flex h-7 items-center rounded-md border px-2 text-xs font-medium ${
+              overEstimate
+                ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+                : 'border-border-default bg-surface-hover text-text-primary'
+            }`}
           >
             {formatHours(actualHours)}
           </div>
@@ -135,13 +141,13 @@ export function TaskCardExpanded({ task }: { task: Task }) {
       <div
         className="border-t border-border-default bg-surface-hover/30 px-3 py-2 space-y-2 overflow-y-auto"
         style={{ maxHeight: EXPANDED_MAX_HEIGHT }}
-        onClick={(e) => { e.stopPropagation() }}
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
       >
         {/* Full description */}
         {task.description && (
-          <p className="text-xs leading-relaxed text-text-secondary">
-            {task.description}
-          </p>
+          <p className="text-xs leading-relaxed text-text-secondary">{task.description}</p>
         )}
 
         <TimeTrackingSection task={task} onUpdate={updateTask} />
@@ -150,7 +156,15 @@ export function TaskCardExpanded({ task }: { task: Task }) {
         <div className="flex items-center gap-2 flex-wrap">
           {task.branch && (
             <div className="flex items-center gap-1.5">
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" className="text-text-secondary shrink-0">
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                className="text-text-secondary shrink-0"
+              >
                 <circle cx="4" cy="3" r="1.5" />
                 <circle cx="8" cy="9" r="1.5" />
                 <path d="M4 4.5V7.5C4 8.5 5 9 8 9M8 7.5V3" />
@@ -159,7 +173,10 @@ export function TaskCardExpanded({ task }: { task: Task }) {
                 {task.branch}
               </span>
               {task.worktreePath && (
-                <span className="rounded bg-purple-500/10 px-1 py-0.5 text-[10px] font-medium text-purple-400" title={task.worktreePath}>
+                <span
+                  className="rounded bg-purple-500/10 px-1 py-0.5 text-[10px] font-medium text-purple-400"
+                  title={task.worktreePath}
+                >
                   worktree
                 </span>
               )}
@@ -197,7 +214,6 @@ export function TaskCardExpanded({ task }: { task: Task }) {
           </h4>
           <CommitsSection commits={commits} />
         </div>
-
       </div>
     </motion.div>
   )

--- a/src/components/panel/pipeline-dashboard.test.ts
+++ b/src/components/panel/pipeline-dashboard.test.ts
@@ -61,6 +61,8 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     prLastFetched: null,
     prHeadSha: null,
     checklist: null,
+    estimatedHours: null,
+    actualHours: 0,
     notifyStakeholders: null,
     notificationSentAt: null,
     triggerOverrides: null,

--- a/src/components/settings/tabs/github-tab.tsx
+++ b/src/components/settings/tabs/github-tab.tsx
@@ -26,22 +26,30 @@ export function GithubTab() {
   // Load last-synced timestamp on mount
   useEffect(() => {
     if (!activeWorkspaceId) return
-    ipc.getGithubSyncState(activeWorkspaceId)
-      .then((s) => { setLastSyncedAt(s?.lastSyncedAt ?? null) })
-      .catch(() => { /* not yet synced */ })
+    ipc
+      .getGithubSyncState(activeWorkspaceId)
+      .then((s) => {
+        setLastSyncedAt(s?.lastSyncedAt ?? null)
+      })
+      .catch(() => {
+        /* not yet synced */
+      })
   }, [activeWorkspaceId])
 
-  const updateConfig = useCallback(async (patch: Partial<WorkspaceConfig>) => {
-    if (!workspace) return
-    const merged = { ...config, ...patch }
-    try {
-      const updated = await ipc.updateWorkspaceConfig(workspace.id, JSON.stringify(merged))
-      await updateWorkspace(workspace.id, { config: updated.config })
-      setMessage({ type: 'success', text: 'GitHub settings saved' })
-    } catch {
-      setMessage({ type: 'error', text: 'Failed to save GitHub settings' })
-    }
-  }, [workspace, config, updateWorkspace])
+  const updateConfig = useCallback(
+    async (patch: Partial<WorkspaceConfig>) => {
+      if (!workspace) return
+      const merged = { ...config, ...patch }
+      try {
+        const updated = await ipc.updateWorkspaceConfig(workspace.id, JSON.stringify(merged))
+        await updateWorkspace(workspace.id, { config: updated.config })
+        setMessage({ type: 'success', text: 'GitHub settings saved' })
+      } catch {
+        setMessage({ type: 'error', text: 'Failed to save GitHub settings' })
+      }
+    },
+    [workspace, config, updateWorkspace],
+  )
 
   const handleSyncNow = useCallback(async () => {
     if (!workspace) return
@@ -52,7 +60,7 @@ export function GithubTab() {
       setLastSyncedAt(new Date().toISOString())
       setMessage({
         type: 'success',
-        text: `Synced: ${result.tasksCreated} task(s) created, ${result.issuesFetched} issue(s) fetched`,
+        text: `Synced: ${String(result.tasksCreated)} task(s) created, ${String(result.issuesFetched)} issue(s) fetched`,
       })
     } catch (err) {
       setMessage({
@@ -91,14 +99,19 @@ export function GithubTab() {
         </div>
       )}
 
-      <SettingSection title="GitHub Issues Sync" description="Pull open GitHub issues as tasks and push status back when tasks complete">
+      <SettingSection
+        title="GitHub Issues Sync"
+        description="Pull open GitHub issues as tasks and push status back when tasks complete"
+      >
         <div className="space-y-4">
           <SettingRow label="Enable Sync" description="Automatically sync every 5 minutes">
             <button
               type="button"
               role="switch"
               aria-checked={config.githubSyncEnabled ?? false}
-              onClick={() => { void updateConfig({ githubSyncEnabled: !(config.githubSyncEnabled ?? false) }) }}
+              onClick={() => {
+                void updateConfig({ githubSyncEnabled: !(config.githubSyncEnabled ?? false) })
+              }}
               className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-accent/20 ${
                 (config.githubSyncEnabled ?? false) ? 'bg-accent' : 'bg-border-default'
               }`}
@@ -115,17 +128,24 @@ export function GithubTab() {
             <input
               type="text"
               value={config.githubRepo ?? ''}
-              onChange={(e) => { void updateConfig({ githubRepo: e.target.value }) }}
+              onChange={(e) => {
+                void updateConfig({ githubRepo: e.target.value })
+              }}
               placeholder="owner/repo"
               className="w-48 rounded-lg border border-border-default bg-surface px-3 py-2 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
             />
           </SettingRow>
 
-          <SettingRow label="Label Filter" description="Only sync issues with this label (leave blank for all)">
+          <SettingRow
+            label="Label Filter"
+            description="Only sync issues with this label (leave blank for all)"
+          >
             <input
               type="text"
               value={config.githubLabelFilter ?? ''}
-              onChange={(e) => { void updateConfig({ githubLabelFilter: e.target.value }) }}
+              onChange={(e) => {
+                void updateConfig({ githubLabelFilter: e.target.value })
+              }}
               placeholder="e.g. bento"
               className="w-48 rounded-lg border border-border-default bg-surface px-3 py-2 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
             />
@@ -138,35 +158,53 @@ export function GithubTab() {
           <SettingRow label="Inbox Column" description="New issues are created in this column">
             <select
               value={config.githubInboxColumnId ?? ''}
-              onChange={(e) => { void updateConfig({ githubInboxColumnId: e.target.value }) }}
+              onChange={(e) => {
+                void updateConfig({ githubInboxColumnId: e.target.value })
+              }}
               className="rounded-lg border border-border-default bg-surface px-3 py-2 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
             >
               {columnOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
               ))}
             </select>
           </SettingRow>
 
-          <SettingRow label="Done Column" description="Tasks here trigger a 'resolved' comment on the linked issue">
+          <SettingRow
+            label="Done Column"
+            description="Tasks here trigger a 'resolved' comment on the linked issue"
+          >
             <select
               value={config.githubDoneColumnId ?? ''}
-              onChange={(e) => { void updateConfig({ githubDoneColumnId: e.target.value }) }}
+              onChange={(e) => {
+                void updateConfig({ githubDoneColumnId: e.target.value })
+              }}
               className="rounded-lg border border-border-default bg-surface px-3 py-2 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
             >
               {columnOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
               ))}
             </select>
           </SettingRow>
 
-          <SettingRow label="PR Column" description="Tasks here with a PR URL post a link comment on the issue">
+          <SettingRow
+            label="PR Column"
+            description="Tasks here with a PR URL post a link comment on the issue"
+          >
             <select
               value={config.githubPrColumnId ?? ''}
-              onChange={(e) => { void updateConfig({ githubPrColumnId: e.target.value }) }}
+              onChange={(e) => {
+                void updateConfig({ githubPrColumnId: e.target.value })
+              }}
               className="rounded-lg border border-border-default bg-surface px-3 py-2 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
             >
               {columnOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
               ))}
             </select>
           </SettingRow>
@@ -177,7 +215,9 @@ export function GithubTab() {
         <div className="flex items-center gap-4">
           <button
             type="button"
-            onClick={() => { void handleSyncNow() }}
+            onClick={() => {
+              void handleSyncNow()
+            }}
             disabled={isSyncing || !config.githubRepo}
             className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:opacity-50"
           >
@@ -189,7 +229,9 @@ export function GithubTab() {
             </span>
           )}
           {!config.githubRepo && (
-            <span className="text-xs text-text-secondary">Set a repository above to enable sync</span>
+            <span className="text-xs text-text-secondary">
+              Set a repository above to enable sync
+            </span>
           )}
         </div>
       </SettingSection>

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -121,6 +121,8 @@ let mockTasks: Task[] = [
     prLastFetched: null,
     prHeadSha: null,
     checklist: null,
+    estimatedHours: null,
+    actualHours: 0,
     notifyStakeholders: null,
     notificationSentAt: null,
     triggerOverrides: null,
@@ -296,6 +298,8 @@ const mockCommands: Record<string, CommandHandler> = {
       prLastFetched: null,
       prHeadSha: null,
       checklist: null,
+      estimatedHours: null,
+      actualHours: 0,
       notifyStakeholders: null,
       notificationSentAt: null,
       triggerOverrides: null,
@@ -326,6 +330,10 @@ const mockCommands: Record<string, CommandHandler> = {
       existing.pipelineTriggeredAt =
         (args?.pipelineTriggeredAt as string | null) ?? existing.pipelineTriggeredAt
       existing.pipelineError = (args?.pipelineError as string | null) ?? existing.pipelineError
+      if (Object.prototype.hasOwnProperty.call(args ?? {}, 'estimatedHours')) {
+        existing.estimatedHours = args?.estimatedHours as number | null
+      }
+      existing.actualHours = (args?.actualHours as number) ?? existing.actualHours
       existing.position = (args?.position as number) ?? existing.position
       existing.updatedAt = new Date().toISOString()
       return existing
@@ -823,6 +831,8 @@ export function resetMockData() {
       prLastFetched: new Date().toISOString(),
       prHeadSha: 'abc123',
       checklist: null,
+      estimatedHours: 2,
+      actualHours: 1.25,
       notifyStakeholders: null,
       notificationSentAt: null,
       triggerOverrides: null,
@@ -868,6 +878,8 @@ export function resetMockData() {
       prLastFetched: new Date().toISOString(),
       prHeadSha: 'def456',
       checklist: null,
+      estimatedHours: 1,
+      actualHours: 2.5,
       notifyStakeholders: null,
       notificationSentAt: null,
       triggerOverrides: null,
@@ -913,6 +925,8 @@ export function resetMockData() {
       prLastFetched: new Date().toISOString(),
       prHeadSha: 'ghi789',
       checklist: null,
+      estimatedHours: null,
+      actualHours: 0,
       notifyStakeholders: null,
       notificationSentAt: null,
       triggerOverrides: null,

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -55,6 +55,8 @@ const createMockTask = (overrides: Partial<Task> = {}): Task => ({
   prLastFetched: null,
   prHeadSha: null,
   checklist: null,
+  estimatedHours: null,
+  actualHours: 0,
   notifyStakeholders: null,
   notificationSentAt: null,
   triggerOverrides: null,

--- a/src/test/mocks/tauri.ts
+++ b/src/test/mocks/tauri.ts
@@ -76,6 +76,8 @@ export const mockTask = (overrides: Partial<Task> = {}): Task => ({
   prLastFetched: null,
   prHeadSha: null,
   checklist: null,
+  estimatedHours: null,
+  actualHours: 0,
   notifyStakeholders: null,
   notificationSentAt: null,
   triggerOverrides: null,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -100,6 +100,8 @@ export interface Task {
   branch_name: string | null
   files_touched: string
   checklist: string | null
+  estimated_hours: number | null
+  actual_hours: number
   pipeline_state: string
   pipeline_triggered_at: string | null
   pipeline_error: string | null

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -52,6 +52,8 @@ export type Task = {
   prHeadSha: string | null
   // Task checklist (JSON array of TaskChecklistItem)
   checklist: string | null
+  estimatedHours: number | null
+  actualHours: number
   // Notification fields
   notifyStakeholders: string | null  // JSON array of stakeholder names/emails
   notificationSentAt: string | null


### PR DESCRIPTION
## Description

Add estimated_hours and actual_hours columns to tasks. Show side-by-side on task detail view. Auto-compute actual_hours from agent_session timestamps. Show warning if actual >2x estimated. Acceptance: estimate field editable, actual auto-computed, warning UI works, cargo check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/task-time-tracking-estimated-vs-actual-hours` → `staging/2026-05-01-bento-ya-recovery`

## Commits

```
4a54cf2 Clean up task time tracking UI lint
7c6eaa2 Fix task estimate cancel behavior
36e98a4 Add task time tracking
```

## Changes

```
src-tauri/src/commands/task.rs                     |  14 +-
 .../src/db/migrations/034_task_time_tracking.sql   |   2 +
 src-tauri/src/db/mod.rs                            |  32 ++++-
 src-tauri/src/db/models.rs                         |   2 +
 src-tauri/src/db/schema.rs                         |   2 +
 src-tauri/src/db/task.rs                           |  95 ++++++++------
 src-tauri/src/llm/context.rs                       |   2 +
 src-tauri/src/pipeline/mod.rs                      |   2 +
 src-tauri/src/pipeline/template.rs                 |   2 +
 src/components/kanban/task-card-expanded.test.tsx  |  64 +++++++++
 src/components/kanban/task-card-expanded.tsx       | 145 ++++++++++++++++++++-
 src/components/panel/pipeline-dashboard.test.ts    |   2 +
 src/components/settings/tabs/github-tab.tsx        | 102 ++++++++++-----
 src/lib/browser-mock.ts                            |  14 ++
 src/stores/task-store.test.ts                      |   2 +
 src/test/mocks/tauri.ts                            |   2 +
 src/types/events.ts                                |   2 +
 src/types/task.ts                                  |   2 +
 18 files changed, 408 insertions(+), 80 deletions(-)
```