### PR TITLE
Tauri auto-update integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +307,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tauri-plugin-webdriver-automation",
  "thiserror 1.0.69",
  "tokio",
@@ -922,6 +932,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1237,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2416,7 +2448,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2588,6 +2623,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2858,6 +2899,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,6 +3062,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,7 +3118,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3266,6 +3333,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3538,6 +3611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,15 +3748,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3782,6 +3869,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,6 +3888,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4262,7 +4388,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4694,6 +4820,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4891,6 +5028,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -5841,6 +6011,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6640,6 +6819,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6740,6 +6929,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.1",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-updater = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,8 +11,8 @@ pub mod pipeline;
 pub mod script;
 pub mod siege;
 pub mod task;
-pub mod updater;
 pub mod terminal;
+pub mod updater;
 pub mod usage;
 #[cfg(feature = "voice")]
 pub mod voice;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod pipeline;
 pub mod script;
 pub mod siege;
 pub mod task;
+pub mod updater;
 pub mod terminal;
 pub mod usage;
 #[cfg(feature = "voice")]

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -43,12 +43,13 @@ pub async fn install_update(app: AppHandle) -> Result<(), AppError> {
         .await
         .map_err(|e| AppError::CommandError(e.to_string()))?;
 
-    if let Some(update) = update {
-        update
-            .download_and_install(|_, _| {}, || {})
-            .await
-            .map_err(|e| AppError::CommandError(e.to_string()))?;
-    }
+    let update = update
+        .ok_or_else(|| AppError::CommandError("No update available".to_string()))?;
+
+    update
+        .download_and_install(|_, _| {}, || {})
+        .await
+        .map_err(|e| AppError::CommandError(e.to_string()))?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,0 +1,54 @@
+use serde::Serialize;
+use tauri::AppHandle;
+use tauri_plugin_updater::UpdaterExt;
+
+use crate::error::AppError;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    pub version: String,
+    pub body: Option<String>,
+    pub date: Option<String>,
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn check_for_update(app: AppHandle) -> Result<Option<UpdateInfo>, AppError> {
+    let updater = app
+        .updater_builder()
+        .build()
+        .map_err(|e| AppError::CommandError(e.to_string()))?;
+
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| AppError::CommandError(e.to_string()))?;
+
+    Ok(update.map(|u| UpdateInfo {
+        version: u.version,
+        body: u.body,
+        date: u.date.map(|d| d.to_string()),
+    }))
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn install_update(app: AppHandle) -> Result<(), AppError> {
+    let updater = app
+        .updater_builder()
+        .build()
+        .map_err(|e| AppError::CommandError(e.to_string()))?;
+
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| AppError::CommandError(e.to_string()))?;
+
+    if let Some(update) = update {
+        update
+            .download_and_install(|_, _| {}, || {})
+            .await
+            .map_err(|e| AppError::CommandError(e.to_string()))?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -14,15 +14,8 @@ pub struct UpdateInfo {
 
 #[tauri::command(rename_all = "camelCase")]
 pub async fn check_for_update(app: AppHandle) -> Result<Option<UpdateInfo>, AppError> {
-    let updater = app
-        .updater_builder()
-        .build()
-        .map_err(|e| AppError::CommandError(e.to_string()))?;
-
-    let update = updater
-        .check()
-        .await
-        .map_err(|e| AppError::CommandError(e.to_string()))?;
+    let updater = app.updater_builder().build()?;
+    let update = updater.check().await?;
 
     Ok(update.map(|u| UpdateInfo {
         version: u.version,
@@ -33,23 +26,12 @@ pub async fn check_for_update(app: AppHandle) -> Result<Option<UpdateInfo>, AppE
 
 #[tauri::command(rename_all = "camelCase")]
 pub async fn install_update(app: AppHandle) -> Result<(), AppError> {
-    let updater = app
-        .updater_builder()
-        .build()
-        .map_err(|e| AppError::CommandError(e.to_string()))?;
+    let updater = app.updater_builder().build()?;
+    let update = updater.check().await?;
+    let update =
+        update.ok_or_else(|| AppError::CommandError("No update available".to_string()))?;
 
-    let update = updater
-        .check()
-        .await
-        .map_err(|e| AppError::CommandError(e.to_string()))?;
-
-    let update = update
-        .ok_or_else(|| AppError::CommandError("No update available".to_string()))?;
-
-    update
-        .download_and_install(|_, _| {}, || {})
-        .await
-        .map_err(|e| AppError::CommandError(e.to_string()))?;
+    update.download_and_install(|_, _| {}, || {}).await?;
 
     Ok(())
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -16,6 +16,12 @@ pub enum AppError {
     CommandError(String),
 }
 
+impl From<tauri_plugin_updater::Error> for AppError {
+    fn from(err: tauri_plugin_updater::Error) -> Self {
+        AppError::CommandError(err.to_string())
+    }
+}
+
 impl From<rusqlite::Error> for AppError {
     fn from(err: rusqlite::Error) -> Self {
         match err {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(state)
         .manage(session_registry);
 
@@ -255,6 +256,9 @@ pub fn run() {
             // Dynamic model discovery
             models::get_available_models,
             models::refresh_models,
+            // Updater commands
+            commands::updater::check_for_update,
+            commands::updater::install_update,
         ])
         .setup(|app| {
             // Start HTTP API server for external MCP control

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,6 +23,14 @@
       "csp": "default-src 'self' blob: data: media:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.anthropic.com https://*.openai.com"
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "",
+      "endpoints": [
+        "https://github.com/hamming-ai/bento-ya/releases/latest/download/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { AnimatePresence } from 'motion/react'
+import { AnimatePresence, motion } from 'motion/react'
 import { initializeTheme } from '@/lib/theme'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -17,6 +17,7 @@ import { ChecklistPanel } from '@/components/checklist/checklist-panel'
 import { AboutModal } from '@/components/about/about-modal'
 import { CommandPalette } from '@/components/command-palette/command-palette'
 import { SkeletonLoader } from '@/components/shared/skeleton-loader'
+import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
 
 function App() {
   const loaded = useWorkspaceStore((s) => s.loaded)
@@ -26,6 +27,9 @@ function App() {
   const [error, setError] = useState<string | null>(null)
   const [showAbout, setShowAbout] = useState(false)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
+  const [pendingUpdate, setPendingUpdate] = useState<UpdateInfo | null>(null)
+  const [updateDismissed, setUpdateDismissed] = useState(false)
+  const [installing, setInstalling] = useState(false)
 
   // Keyboard shortcuts
   const toggleAbout = useCallback(() => { setShowAbout((prev) => !prev) }, [])
@@ -36,6 +40,22 @@ function App() {
     { key: 'k', meta: true, handler: toggleCommandPalette },
     { key: ',', meta: true, handler: openSettings },
   ])
+
+  // Check for updates on launch (non-blocking, silent on failure)
+  useEffect(() => {
+    checkForUpdate().then((info) => {
+      if (info) setPendingUpdate(info)
+    }).catch(() => { /* ignore update check failures silently */ })
+  }, [])
+
+  const handleInstallUpdate = useCallback(async () => {
+    setInstalling(true)
+    try {
+      await installUpdate()
+    } catch {
+      setInstalling(false)
+    }
+  }, [])
 
   // Auto-detect CLI paths on startup
   useAutoDetectClis()
@@ -73,6 +93,43 @@ function App() {
 
       {/* Tab bar */}
       <TabBar />
+
+      {/* Update available banner */}
+      <AnimatePresence>
+        {pendingUpdate && !updateDismissed && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="flex items-center justify-between bg-accent/10 border-b border-accent/20 px-4 py-2 text-sm">
+              <span className="text-text-primary">
+                Update available: <span className="font-medium">v{pendingUpdate.version}</span>
+              </span>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => { void handleInstallUpdate() }}
+                  disabled={installing}
+                  className="rounded px-2.5 py-1 text-xs font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+                >
+                  {installing ? 'Installing…' : 'Install & Restart'}
+                </button>
+                <button
+                  onClick={() => { setUpdateDismissed(true) }}
+                  className="text-text-secondary hover:text-text-primary transition-colors"
+                  aria-label="Dismiss"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                    <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Main content */}
       <main className="flex-1 overflow-hidden">

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -30,6 +30,7 @@ function App() {
   const [pendingUpdate, setPendingUpdate] = useState<UpdateInfo | null>(null)
   const [updateDismissed, setUpdateDismissed] = useState(false)
   const [installing, setInstalling] = useState(false)
+  const [installError, setInstallError] = useState<string | null>(null)
 
   // Keyboard shortcuts
   const toggleAbout = useCallback(() => { setShowAbout((prev) => !prev) }, [])
@@ -50,10 +51,12 @@ function App() {
 
   const handleInstallUpdate = useCallback(async () => {
     setInstalling(true)
+    setInstallError(null)
     try {
       await installUpdate()
-    } catch {
+    } catch (err) {
       setInstalling(false)
+      setInstallError(err instanceof Error ? err.message : 'Update failed')
     }
   }, [])
 
@@ -106,7 +109,10 @@ function App() {
           >
             <div className="flex items-center justify-between bg-accent/10 border-b border-accent/20 px-4 py-2 text-sm">
               <span className="text-text-primary">
-                Update available: <span className="font-medium">v{pendingUpdate.version}</span>
+                {installError
+                  ? <span className="text-error">{installError}</span>
+                  : <>Update available: <span className="font-medium">v{pendingUpdate.version}</span></>
+                }
               </span>
               <div className="flex items-center gap-3">
                 <button
@@ -114,7 +120,7 @@ function App() {
                   disabled={installing}
                   className="rounded px-2.5 py-1 text-xs font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
                 >
-                  {installing ? 'Installing…' : 'Install & Restart'}
+                  {installing ? 'Installing…' : installError ? 'Retry' : 'Install & Restart'}
                 </button>
                 <button
                   onClick={() => { setUpdateDismissed(true) }}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { usePrStatusPolling } from '@/hooks/use-pr-status-polling'
 import { useTaskSync } from '@/hooks/use-task-sync'
 import { useAgentStreamingSync } from '@/hooks/use-agent-streaming-sync'
 import { useAutoDetectClis } from '@/hooks/use-cli-path'
+import { useUpdater } from '@/hooks/use-updater'
 import { Board } from '@/components/layout/board'
 import { WorkspaceSetup } from '@/components/layout/workspace-setup'
 import { OnboardingWizard } from '@/components/onboarding/onboarding-wizard'
@@ -17,7 +18,6 @@ import { ChecklistPanel } from '@/components/checklist/checklist-panel'
 import { AboutModal } from '@/components/about/about-modal'
 import { CommandPalette } from '@/components/command-palette/command-palette'
 import { SkeletonLoader } from '@/components/shared/skeleton-loader'
-import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
 
 function App() {
   const loaded = useWorkspaceStore((s) => s.loaded)
@@ -27,10 +27,14 @@ function App() {
   const [error, setError] = useState<string | null>(null)
   const [showAbout, setShowAbout] = useState(false)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
-  const [pendingUpdate, setPendingUpdate] = useState<UpdateInfo | null>(null)
-  const [updateDismissed, setUpdateDismissed] = useState(false)
-  const [installing, setInstalling] = useState(false)
-  const [installError, setInstallError] = useState<string | null>(null)
+  const {
+    pendingUpdate,
+    dismissed: updateDismissed,
+    installing,
+    error: installError,
+    dismiss: dismissUpdate,
+    install: handleInstallUpdate,
+  } = useUpdater()
 
   // Keyboard shortcuts
   const toggleAbout = useCallback(() => { setShowAbout((prev) => !prev) }, [])
@@ -41,24 +45,6 @@ function App() {
     { key: 'k', meta: true, handler: toggleCommandPalette },
     { key: ',', meta: true, handler: openSettings },
   ])
-
-  // Check for updates on launch (non-blocking, silent on failure)
-  useEffect(() => {
-    checkForUpdate().then((info) => {
-      if (info) setPendingUpdate(info)
-    }).catch(() => { /* ignore update check failures silently */ })
-  }, [])
-
-  const handleInstallUpdate = useCallback(async () => {
-    setInstalling(true)
-    setInstallError(null)
-    try {
-      await installUpdate()
-    } catch (err) {
-      setInstalling(false)
-      setInstallError(err instanceof Error ? err.message : 'Update failed')
-    }
-  }, [])
 
   // Auto-detect CLI paths on startup
   useAutoDetectClis()
@@ -116,14 +102,14 @@ function App() {
               </span>
               <div className="flex items-center gap-3">
                 <button
-                  onClick={() => { void handleInstallUpdate() }}
+                  onClick={handleInstallUpdate}
                   disabled={installing}
                   className="rounded px-2.5 py-1 text-xs font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
                 >
                   {installing ? 'Installing…' : installError ? 'Retry' : 'Install & Restart'}
                 </button>
                 <button
-                  onClick={() => { setUpdateDismissed(true) }}
+                  onClick={dismissUpdate}
                   className="text-text-secondary hover:text-text-primary transition-colors"
                   aria-label="Dismiss"
                 >

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -10,6 +10,7 @@ import { AdvancedTab } from './tabs/advanced-tab'
 import { GitTab } from './tabs/git-tab'
 import { GithubTab } from './tabs/github-tab'
 import { ShortcutsTab } from './tabs/shortcuts-tab'
+import { UpdatesTab } from './tabs/updates-tab'
 
 // SVG Icons for settings tabs
 const icons: Record<string, React.ReactNode> = {
@@ -55,6 +56,11 @@ const icons: Record<string, React.ReactNode> = {
       <path fillRule="evenodd" d="M10 1.944A10.065 10.065 0 0 0 0 12.01c0 4.44 2.865 8.207 6.84 9.537.5.093.683-.217.683-.483 0-.237-.009-.868-.013-1.703-2.782.605-3.369-1.342-3.369-1.342-.454-1.156-1.11-1.463-1.11-1.463-.908-.621.069-.608.069-.608 1.004.071 1.532 1.03 1.532 1.03.891 1.529 2.341 1.088 2.91.832.092-.647.35-1.089.636-1.34-2.22-.253-4.556-1.11-4.556-4.944 0-1.091.39-1.984 1.03-2.682-.103-.253-.447-1.27.097-2.647 0 0 .84-.269 2.75 1.025A9.577 9.577 0 0 1 10 6.836c.85.004 1.705.114 2.504.337 1.909-1.294 2.748-1.025 2.748-1.025.546 1.377.202 2.394.1 2.647.64.698 1.028 1.591 1.028 2.682 0 3.842-2.34 4.688-4.566 4.935.359.309.678.919.678 1.852 0 1.337-.012 2.415-.012 2.742 0 .268.18.58.688.482A10.07 10.07 0 0 0 20 12.01 10.065 10.065 0 0 0 10 1.944Z" clipRule="evenodd" />
     </svg>
   ),
+  updates: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+      <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H3.989a.75.75 0 0 0-.75.75v4.242a.75.75 0 0 0 1.5 0v-2.43l.31.31a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39Zm1.23-3.723a.75.75 0 0 0 .219-.53V2.929a.75.75 0 0 0-1.5 0V5.36l-.31-.31A7 7 0 0 0 3.239 8.188a.75.75 0 1 0 1.448.389A5.5 5.5 0 0 1 13.89 6.11l.311.31h-2.432a.75.75 0 0 0 0 1.5h4.243a.75.75 0 0 0 .53-.219Z" clipRule="evenodd" />
+    </svg>
+  ),
 }
 
 const TABS = [
@@ -65,6 +71,7 @@ const TABS = [
   { id: 'board', label: 'Board' },
   { id: 'voice', label: 'Voice' },
   { id: 'github', label: 'GitHub' },
+  { id: 'updates', label: 'Updates' },
   { id: 'advanced', label: 'Advanced' },
 ] as const
 
@@ -90,6 +97,8 @@ export function SettingsPanel() {
         return <VoiceTab />
       case 'github':
         return <GithubTab />
+      case 'updates':
+        return <UpdatesTab />
       case 'advanced':
         return (
           <div className="space-y-8">

--- a/src/components/settings/tabs/updates-tab.tsx
+++ b/src/components/settings/tabs/updates-tab.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
+
+type CheckState = 'idle' | 'checking' | 'up-to-date' | 'available' | 'installing' | 'error'
+
+export function UpdatesTab() {
+  const [state, setState] = useState<CheckState>('idle')
+  const [update, setUpdate] = useState<UpdateInfo | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleCheck = async () => {
+    setState('checking')
+    setError(null)
+    setUpdate(null)
+    try {
+      const result = await checkForUpdate()
+      if (result) {
+        setUpdate(result)
+        setState('available')
+      } else {
+        setState('up-to-date')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setState('error')
+    }
+  }
+
+  const handleInstall = async () => {
+    setState('installing')
+    setError(null)
+    try {
+      await installUpdate()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setState('error')
+    }
+  }
+
+  const installing = state === 'installing'
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h3 className="mb-4 text-sm font-medium text-text-primary">Application Updates</h3>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-text-primary">Current version</p>
+              <p className="text-xs text-text-secondary font-mono">0.1.0</p>
+            </div>
+            <button
+              onClick={() => { void handleCheck() }}
+              disabled={state === 'checking' || state === 'installing'}
+              className="rounded px-3 py-1.5 text-sm font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {state === 'checking' ? 'Checking…' : 'Check for Updates'}
+            </button>
+          </div>
+
+          {state === 'up-to-date' && (
+            <div className="rounded-md border border-border-default bg-surface px-3 py-2 text-sm text-text-secondary">
+              You're on the latest version.
+            </div>
+          )}
+
+          {state === 'available' && update && (
+            <div className="rounded-md border border-accent/30 bg-accent/5 px-3 py-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-text-primary">
+                    Version {update.version} available
+                  </p>
+                  {update.date && (
+                    <p className="text-xs text-text-secondary">{update.date}</p>
+                  )}
+                </div>
+                <button
+                  onClick={() => { void handleInstall() }}
+                  disabled={installing}
+                  className="rounded px-3 py-1.5 text-sm font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+                >
+                  {installing ? 'Installing…' : 'Install & Restart'}
+                </button>
+              </div>
+              {update.body && (
+                <p className="text-xs text-text-secondary whitespace-pre-wrap">{update.body}</p>
+              )}
+            </div>
+          )}
+
+          {state === 'installing' && (
+            <div className="rounded-md border border-border-default bg-surface px-3 py-2 text-sm text-text-secondary">
+              Downloading and installing update…
+            </div>
+          )}
+
+          {state === 'error' && error && (
+            <div className="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error">
+              {error}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/settings/tabs/updates-tab.tsx
+++ b/src/components/settings/tabs/updates-tab.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { getVersion } from '@tauri-apps/api/app'
 import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
 
 type CheckState = 'idle' | 'checking' | 'up-to-date' | 'available' | 'installing' | 'error'
@@ -7,6 +8,11 @@ export function UpdatesTab() {
   const [state, setState] = useState<CheckState>('idle')
   const [update, setUpdate] = useState<UpdateInfo | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [currentVersion, setCurrentVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    getVersion().then(setCurrentVersion).catch(() => { /* non-critical */ })
+  }, [])
 
   const handleCheck = async () => {
     setState('checking')
@@ -47,7 +53,7 @@ export function UpdatesTab() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-text-primary">Current version</p>
-              <p className="text-xs text-text-secondary font-mono">0.1.0</p>
+              <p className="text-xs text-text-secondary font-mono">{currentVersion ?? '—'}</p>
             </div>
             <button
               onClick={() => { void handleCheck() }}

--- a/src/components/settings/tabs/updates-tab.tsx
+++ b/src/components/settings/tabs/updates-tab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { getVersion } from '@tauri-apps/api/app'
 import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
 
@@ -14,34 +14,33 @@ export function UpdatesTab() {
     getVersion().then(setCurrentVersion).catch(() => { /* non-critical */ })
   }, [])
 
-  const handleCheck = async () => {
+  const handleCheck = useCallback(() => {
     setState('checking')
     setError(null)
     setUpdate(null)
-    try {
-      const result = await checkForUpdate()
-      if (result) {
-        setUpdate(result)
-        setState('available')
-      } else {
-        setState('up-to-date')
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-      setState('error')
-    }
-  }
+    checkForUpdate()
+      .then((result) => {
+        if (result) {
+          setUpdate(result)
+          setState('available')
+        } else {
+          setState('up-to-date')
+        }
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : String(err))
+        setState('error')
+      })
+  }, [])
 
-  const handleInstall = async () => {
+  const handleInstall = useCallback(() => {
     setState('installing')
     setError(null)
-    try {
-      await installUpdate()
-    } catch (err) {
+    installUpdate().catch((err: unknown) => {
       setError(err instanceof Error ? err.message : String(err))
       setState('error')
-    }
-  }
+    })
+  }, [])
 
   const installing = state === 'installing'
 
@@ -56,7 +55,7 @@ export function UpdatesTab() {
               <p className="text-xs text-text-secondary font-mono">{currentVersion ?? '—'}</p>
             </div>
             <button
-              onClick={() => { void handleCheck() }}
+              onClick={handleCheck}
               disabled={state === 'checking' || state === 'installing'}
               className="rounded px-3 py-1.5 text-sm font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
@@ -82,7 +81,7 @@ export function UpdatesTab() {
                   )}
                 </div>
                 <button
-                  onClick={() => { void handleInstall() }}
+                  onClick={handleInstall}
                   disabled={installing}
                   className="rounded px-3 py-1.5 text-sm font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
                 >

--- a/src/hooks/use-updater.ts
+++ b/src/hooks/use-updater.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback, useEffect } from 'react'
+import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
+
+export type UseUpdaterResult = {
+  pendingUpdate: UpdateInfo | null
+  dismissed: boolean
+  installing: boolean
+  error: string | null
+  dismiss: () => void
+  install: () => void
+}
+
+export function useUpdater(): UseUpdaterResult {
+  const [pendingUpdate, setPendingUpdate] = useState<UpdateInfo | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+  const [installing, setInstalling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    checkForUpdate()
+      .then((info) => { if (info) setPendingUpdate(info) })
+      .catch(() => { /* ignore update check failures silently */ })
+  }, [])
+
+  const install = useCallback(() => {
+    setInstalling(true)
+    setError(null)
+    installUpdate()
+      .then(() => { /* app restarts on success */ })
+      .catch((err: unknown) => {
+        setInstalling(false)
+        setError(err instanceof Error ? err.message : 'Update failed')
+      })
+  }, [])
+
+  const dismiss = useCallback(() => { setDismissed(true) }, [])
+
+  return { pendingUpdate, dismissed, installing, error, dismiss, install }
+}

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -17,6 +17,7 @@ export * from './siege'
 export * from './github'
 export * from './terminal'
 export * from './models'
+export * from './updater'
 
 // Re-export listen and types that consumers use directly
 export { listen, type UnlistenFn, type EventCallback } from './invoke'

--- a/src/lib/ipc/updater.ts
+++ b/src/lib/ipc/updater.ts
@@ -1,0 +1,15 @@
+import { invoke } from './invoke'
+
+export type UpdateInfo = {
+  version: string
+  body: string | null
+  date: string | null
+}
+
+export async function checkForUpdate(): Promise<UpdateInfo | null> {
+  return invoke<UpdateInfo | null>('check_for_update')
+}
+
+export async function installUpdate(): Promise<void> {
+  return invoke<void>('install_update')
+}

--- a/src/lib/ipc/updater.ts
+++ b/src/lib/ipc/updater.ts
@@ -11,5 +11,5 @@ export async function checkForUpdate(): Promise<UpdateInfo | null> {
 }
 
 export async function installUpdate(): Promise<void> {
-  return invoke<void>('install_update')
+  await invoke('install_update')
 }


### PR DESCRIPTION
## Description

Wire tauri-plugin-updater. Configure update endpoint (GitHub releases). Show "Update available" toast when new version detected. Add manual "Check for updates" in settings. Acceptance: app checks for updates on launch, can install update, cargo check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/tauri-auto-update-integration` → `staging/2026-05-01-bento-ya-recovery`

## Commits

```
8ef9c77 Refactor auto-update code quality
f17aea4 Fix updater integration issues
a95d681 Add Tauri auto-update integration
```

## Changes

```
Cargo.lock                                   | 205 ++++++++++++++++++++++++++-
 src-tauri/Cargo.toml                         |   1 +
 src-tauri/src/commands/mod.rs                |   1 +
 src-tauri/src/commands/updater.rs            |  37 +++++
 src-tauri/src/error.rs                       |   6 +
 src-tauri/src/lib.rs                         |   4 +
 src-tauri/tauri.conf.json                    |   8 ++
 src/app.tsx                                  |  51 ++++++-
 src/components/settings/settings-panel.tsx   |   9 ++
 src/components/settings/tabs/updates-tab.tsx | 112 +++++++++++++++
 src/hooks/use-updater.ts                     |  39 +++++
 src/lib/ipc/index.ts                         |   1 +
 src/lib/ipc/updater.ts                       |  15 ++
 13 files changed, 486 insertions(+), 3 deletions(-)
```