### PR TITLE
Token usage warning banner at 80% of model limit

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -1,4 +1,6 @@
-use crate::db::{self, AppState, ColumnCost, DailyCost, TaskCost, UsageRecord, UsageSummary};
+use crate::db::{
+    self, AppState, ColumnCost, DailyCost, ModelUsageSummary, TaskCost, UsageRecord, UsageSummary,
+};
 use crate::error::AppError;
 use tauri::State;
 
@@ -72,6 +74,21 @@ pub fn get_workspace_usage_summary(
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     db::get_workspace_usage_summary(&conn, &workspace_id).map_err(AppError::from)
+}
+
+#[tauri::command]
+pub fn get_workspace_model_usage_between(
+    state: State<AppState>,
+    workspace_id: String,
+    start_at: String,
+    end_at: String,
+) -> Result<Vec<ModelUsageSummary>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    db::get_workspace_model_usage_between(&conn, &workspace_id, &start_at, &end_at)
+        .map_err(AppError::from)
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -310,6 +310,18 @@ pub struct UsageSummary {
     pub record_count: i64,
 }
 
+/// Usage aggregated by provider/model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelUsageSummary {
+    pub provider: String,
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cost_usd: f64,
+    pub record_count: i64,
+}
+
 /// Daily cost aggregation for time-series charts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/db/usage.rs
+++ b/src-tauri/src/db/usage.rs
@@ -1,6 +1,8 @@
 use rusqlite::{params, Connection, Result as SqlResult};
 
-use super::models::{ColumnCost, DailyCost, TaskCost, UsageRecord, UsageSummary};
+use super::models::{
+    ColumnCost, DailyCost, ModelUsageSummary, TaskCost, UsageRecord, UsageSummary,
+};
 use super::{new_id, now};
 
 pub const PROVIDER_ANTHROPIC: &str = "anthropic";
@@ -119,6 +121,39 @@ pub fn get_workspace_usage_summary(
     )
 }
 
+pub fn get_workspace_model_usage_between(
+    conn: &Connection,
+    workspace_id: &str,
+    start_at: &str,
+    end_at: &str,
+) -> SqlResult<Vec<ModelUsageSummary>> {
+    let mut stmt = conn.prepare(
+        "SELECT provider,
+                model,
+                COALESCE(SUM(input_tokens), 0) as input_tokens,
+                COALESCE(SUM(output_tokens), 0) as output_tokens,
+                COALESCE(SUM(cost_usd), 0.0) as cost_usd,
+                COUNT(*) as record_count
+         FROM usage_records
+         WHERE workspace_id = ?1
+           AND datetime(created_at) >= datetime(?2)
+           AND datetime(created_at) < datetime(?3)
+         GROUP BY provider, model
+         ORDER BY cost_usd DESC",
+    )?;
+    let rows = stmt.query_map(params![workspace_id, start_at, end_at], |row| {
+        Ok(ModelUsageSummary {
+            provider: row.get(0)?,
+            model: row.get(1)?,
+            input_tokens: row.get(2)?,
+            output_tokens: row.get(3)?,
+            cost_usd: row.get(4)?,
+            record_count: row.get(5)?,
+        })
+    })?;
+    rows.collect()
+}
+
 pub fn get_task_usage_summary(conn: &Connection, task_id: &str) -> SqlResult<UsageSummary> {
     conn.query_row(
         "SELECT COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cost_usd), 0.0), COUNT(*) FROM usage_records WHERE task_id = ?1",
@@ -234,6 +269,29 @@ pub fn delete_workspace_usage(conn: &Connection, workspace_id: &str) -> SqlResul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
+
+    fn setup_usage_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE usage_records (
+                id TEXT PRIMARY KEY NOT NULL,
+                workspace_id TEXT NOT NULL,
+                task_id TEXT,
+                session_id TEXT,
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cost_usd REAL NOT NULL DEFAULT 0.0,
+                column_name TEXT,
+                duration_seconds INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn
+    }
 
     #[test]
     fn test_estimate_cost_opus() {
@@ -263,5 +321,39 @@ mod tests {
     fn test_estimate_cost_zero_tokens() {
         let cost = estimate_cost("claude-opus-4-20250514", 0, 0);
         assert!((cost - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_get_workspace_model_usage_between_groups_current_window() {
+        let conn = setup_usage_conn();
+        conn.execute(
+            "INSERT INTO usage_records
+             (id, workspace_id, provider, model, input_tokens, output_tokens, cost_usd, created_at)
+             VALUES
+             ('1', 'ws-1', 'anthropic', 'sonnet', 100, 50, 0.25, '2026-05-01T00:00:00+00:00'),
+             ('2', 'ws-1', 'anthropic', 'sonnet', 200, 75, 0.50, '2026-05-01T04:00:00+00:00'),
+             ('3', 'ws-1', 'anthropic', 'opus', 1000, 500, 4.00, '2026-05-01T05:00:00+00:00'),
+             ('4', 'ws-1', 'anthropic', 'sonnet', 999, 999, 9.99, '2026-05-02T00:00:00+00:00'),
+             ('5', 'ws-2', 'anthropic', 'sonnet', 999, 999, 9.99, '2026-05-01T04:00:00Z')",
+            [],
+        )
+        .unwrap();
+
+        let summaries = get_workspace_model_usage_between(
+            &conn,
+            "ws-1",
+            "2026-05-01T00:00:00.000Z",
+            "2026-05-02T00:00:00.000Z",
+        )
+        .unwrap();
+
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].model, "opus");
+        assert_eq!(summaries[0].cost_usd, 4.0);
+        assert_eq!(summaries[1].model, "sonnet");
+        assert_eq!(summaries[1].input_tokens, 300);
+        assert_eq!(summaries[1].output_tokens, 125);
+        assert_eq!(summaries[1].record_count, 2);
+        assert!((summaries[1].cost_usd - 0.75).abs() < 0.001);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -208,6 +208,7 @@ pub fn run() {
             commands::usage::get_workspace_usage,
             commands::usage::get_task_usage,
             commands::usage::get_workspace_usage_summary,
+            commands::usage::get_workspace_model_usage_between,
             commands::usage::get_task_usage_summary,
             commands::usage::clear_workspace_usage,
             commands::usage::get_workspace_daily_costs,

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -26,6 +26,7 @@ import { useUIStore } from '@/stores/ui-store'
 import { CardPositionContext, useCardPositionProvider } from '@/hooks/use-card-positions'
 import { DepDragContext } from '@/hooks/use-dep-drag-context'
 import { BulkTaskToolbar } from '@/components/kanban/bulk-task-toolbar'
+import { UsageBudgetBanner } from '@/components/usage/usage-budget-banner'
 
 export function Board() {
   const panelDock = useUIStore((s) => s.panelDock)
@@ -218,6 +219,7 @@ export function Board() {
         <div className="flex h-full" data-board-container>
           {/* Board + orchestrator panel (left side, shrinks when task panel open) */}
           <div className="flex flex-1 flex-col overflow-hidden">
+            {activeWorkspaceId && <UsageBudgetBanner workspaceId={activeWorkspaceId} />}
             <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
               <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
                 {sortedColumns.map((col) => (

--- a/src/components/settings/tabs/agent-tab.tsx
+++ b/src/components/settings/tabs/agent-tab.tsx
@@ -5,6 +5,7 @@ import { detectSingleCli, checkCliUpdate, type DetectedCli, type CliUpdateInfo }
 import { useModels } from '@/hooks/use-models'
 import { SettingSection, SettingRow, SettingInput, SettingSlider } from '@/components/shared/setting-components'
 import { Dropdown } from '@/components/shared/dropdown'
+import { getModelBudgetKey } from '@/lib/usage-budget'
 
 const PROVIDER_INFO: Record<string, { name: string; description: string; cliId: string }> = {
   anthropic: {
@@ -79,6 +80,22 @@ export function AgentTab() {
   const availableModels = allModels
     .filter((m) => enabledProviderIds.has(m.provider) && !disabledModelIds.has(m.id))
     .map((m) => m.id)
+  const budgetModels = allModels
+    .filter((m) => enabledProviderIds.has(m.provider) && !disabledModelIds.has(m.id))
+    .sort((a, b) => a.displayName.localeCompare(b.displayName))
+
+  const updateDailyBudget = (budgetKey: string, value: string) => {
+    const parsed = Number.parseFloat(value)
+    const nextBudgets = { ...(model.dailyBudgetsUsd ?? {}) }
+
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      Reflect.deleteProperty(nextBudgets, budgetKey)
+    } else {
+      nextBudgets[budgetKey] = parsed
+    }
+
+    updateGlobal('model', { ...model, dailyBudgetsUsd: nextBudgets })
+  }
 
   // Toggle provider enabled state
   const handleToggleProvider = (providerId: string, enabled: boolean) => {
@@ -584,6 +601,55 @@ export function AgentTab() {
           </SettingRow>
 
         </div>
+      </SettingSection>
+
+      <SettingSection
+        title="Daily Model Budgets"
+        description="Show a board warning when today's usage for a model reaches 80% of its budget."
+        border
+      >
+        {budgetModels.length === 0 ? (
+          <p className="rounded-lg border border-border-default px-3 py-4 text-sm text-text-secondary">
+            Enable a provider and model to set daily budgets.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {budgetModels.map((entry) => {
+              const budgetKey = getModelBudgetKey(entry.id, entry.provider)
+              const budget = model.dailyBudgetsUsd?.[budgetKey]
+              const providerName = model.providers.find((provider) => provider.id === entry.provider)?.name ?? entry.provider
+
+              return (
+                <div
+                  key={budgetKey}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-border-default bg-surface/50 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-text-primary">
+                      {entry.displayName}
+                    </div>
+                    <div className="truncate text-xs text-text-secondary">
+                      {providerName} · {entry.id}
+                    </div>
+                  </div>
+                  <label className="flex shrink-0 items-center gap-2">
+                    <span className="text-xs text-text-secondary">$</span>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={budget === undefined ? '' : String(budget)}
+                      onChange={(event) => { updateDailyBudget(budgetKey, event.target.value) }}
+                      placeholder="0.00"
+                      className="w-24 rounded-lg border border-border-default bg-surface px-2 py-1.5 text-right text-sm tabular-nums text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                      aria-label={`${entry.displayName} daily budget`}
+                    />
+                  </label>
+                </div>
+              )
+            })}
+          </div>
+        )}
       </SettingSection>
     </div>
   )

--- a/src/components/settings/tabs/agent-tab.tsx
+++ b/src/components/settings/tabs/agent-tab.tsx
@@ -86,7 +86,7 @@ export function AgentTab() {
 
   const updateDailyBudget = (budgetKey: string, value: string) => {
     const parsed = Number.parseFloat(value)
-    const nextBudgets = { ...(model.dailyBudgetsUsd ?? {}) }
+    const nextBudgets = { ...model.dailyBudgetsUsd }
 
     if (!Number.isFinite(parsed) || parsed <= 0) {
       Reflect.deleteProperty(nextBudgets, budgetKey)
@@ -616,7 +616,7 @@ export function AgentTab() {
           <div className="space-y-2">
             {budgetModels.map((entry) => {
               const budgetKey = getModelBudgetKey(entry.id, entry.provider)
-              const budget = model.dailyBudgetsUsd?.[budgetKey]
+              const budget = model.dailyBudgetsUsd[budgetKey]
               const providerName = model.providers.find((provider) => provider.id === entry.provider)?.name ?? entry.provider
 
               return (

--- a/src/components/settings/tabs/github-tab.tsx
+++ b/src/components/settings/tabs/github-tab.tsx
@@ -52,7 +52,7 @@ export function GithubTab() {
       setLastSyncedAt(new Date().toISOString())
       setMessage({
         type: 'success',
-        text: `Synced: ${result.tasksCreated} task(s) created, ${result.issuesFetched} issue(s) fetched`,
+        text: `Synced: ${String(result.tasksCreated)} task(s) created, ${String(result.issuesFetched)} issue(s) fetched`,
       })
     } catch (err) {
       setMessage({

--- a/src/components/usage/usage-budget-banner.tsx
+++ b/src/components/usage/usage-budget-banner.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useSettingsStore } from '@/stores/settings-store'
-import { getWorkspaceUsage, type UsageRecord } from '@/lib/ipc/usage'
+import { getWorkspaceModelUsageBetween, type ModelUsageSummary } from '@/lib/ipc/usage'
 import { formatUsageCost, formatUsageTokens } from '@/lib/usage-format'
 import {
   buildUsageDismissKey,
-  findDailyUsageBudgetWarnings,
+  findUsageBudgetWarnings,
+  localDayBounds,
   todayLocalDateKey,
 } from '@/lib/usage-budget'
 
@@ -18,7 +19,8 @@ export function UsageBudgetBanner({ workspaceId }: Props) {
   const budgetsUsd = useSettingsStore((s) => s.global.model.dailyBudgetsUsd ?? {})
   const openSettings = useSettingsStore((s) => s.openSettings)
   const setActiveTab = useSettingsStore((s) => s.setActiveTab)
-  const [records, setRecords] = useState<UsageRecord[]>([])
+  const [usage, setUsage] = useState<ModelUsageSummary[]>([])
+  const [dateKey, setDateKey] = useState(() => todayLocalDateKey())
   const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(() => new Set())
 
   const hasBudgets = useMemo(
@@ -27,25 +29,36 @@ export function UsageBudgetBanner({ workspaceId }: Props) {
   )
 
   useEffect(() => {
-    setRecords([])
+    setUsage([])
+    setDateKey(todayLocalDateKey())
     setDismissedKeys(new Set())
   }, [workspaceId])
 
   useEffect(() => {
     if (!hasBudgets) {
-      setRecords([])
+      setUsage([])
       return
     }
 
     let cancelled = false
 
     const loadUsage = () => {
-      void getWorkspaceUsage(workspaceId, 2000)
+      const now = new Date()
+      const nextDateKey = todayLocalDateKey(now)
+      const { startAt, endAt } = localDayBounds(now)
+
+      void getWorkspaceModelUsageBetween(workspaceId, startAt, endAt)
         .then((usageRecords) => {
-          if (!cancelled) setRecords(usageRecords)
+          if (!cancelled) {
+            setDateKey(nextDateKey)
+            setUsage(usageRecords)
+          }
         })
         .catch(() => {
-          if (!cancelled) setRecords([])
+          if (!cancelled) {
+            setDateKey(nextDateKey)
+            setUsage([])
+          }
         })
     }
 
@@ -58,9 +71,8 @@ export function UsageBudgetBanner({ workspaceId }: Props) {
     }
   }, [hasBudgets, workspaceId])
 
-  const dateKey = todayLocalDateKey()
   const warning = useMemo(() => {
-    const warnings = findDailyUsageBudgetWarnings(records, budgetsUsd)
+    const warnings = findUsageBudgetWarnings(usage, budgetsUsd)
     return warnings.find((candidate) => {
       const dismissKey = buildUsageDismissKey(workspaceId, dateKey, candidate.key)
       if (dismissedKeys.has(dismissKey)) return false
@@ -71,7 +83,7 @@ export function UsageBudgetBanner({ workspaceId }: Props) {
         return true
       }
     })
-  }, [budgetsUsd, dateKey, dismissedKeys, records, workspaceId])
+  }, [budgetsUsd, dateKey, dismissedKeys, usage, workspaceId])
 
   if (!warning) return null
 
@@ -83,8 +95,17 @@ export function UsageBudgetBanner({ workspaceId }: Props) {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-3">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-red-500/20 text-red-200">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
-              <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.19-1.458-1.516-2.625L8.485 2.495ZM10 5.75a.75.75 0 0 1 .75.75v3.25a.75.75 0 0 1-1.5 0V6.5A.75.75 0 0 1 10 5.75Zm0 7.75a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="h-5 w-5"
+            >
+              <path
+                fillRule="evenodd"
+                d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.19-1.458-1.516-2.625L8.485 2.495ZM10 5.75a.75.75 0 0 1 .75.75v3.25a.75.75 0 0 1-1.5 0V6.5A.75.75 0 0 1 10 5.75Zm0 7.75a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                clipRule="evenodd"
+              />
             </svg>
           </div>
           <div className="min-w-0">
@@ -92,7 +113,8 @@ export function UsageBudgetBanner({ workspaceId }: Props) {
               {warning.displayName} daily budget at {String(percentage)}%
             </p>
             <p className="text-xs text-red-100/85">
-              {formatUsageCost(warning.costUsd)} of {formatUsageCost(warning.budgetUsd)} today · {formatUsageTokens(warning.totalTokens)} tokens
+              {formatUsageCost(warning.costUsd)} of {formatUsageCost(warning.budgetUsd)} today ·{' '}
+              {formatUsageTokens(warning.totalTokens)} tokens
             </p>
           </div>
         </div>
@@ -122,7 +144,12 @@ export function UsageBudgetBanner({ workspaceId }: Props) {
             aria-label="Dismiss usage budget warning"
             style={{ cursor: 'pointer' }}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="h-5 w-5"
+            >
               <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
             </svg>
           </button>

--- a/src/components/usage/usage-budget-banner.tsx
+++ b/src/components/usage/usage-budget-banner.tsx
@@ -16,7 +16,7 @@ type Props = {
 const USAGE_REFRESH_INTERVAL_MS = 60_000
 
 export function UsageBudgetBanner({ workspaceId }: Props) {
-  const budgetsUsd = useSettingsStore((s) => s.global.model.dailyBudgetsUsd ?? {})
+  const budgetsUsd = useSettingsStore((s) => s.global.model.dailyBudgetsUsd)
   const openSettings = useSettingsStore((s) => s.openSettings)
   const setActiveTab = useSettingsStore((s) => s.setActiveTab)
   const [usage, setUsage] = useState<ModelUsageSummary[]>([])

--- a/src/components/usage/usage-budget-banner.tsx
+++ b/src/components/usage/usage-budget-banner.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useSettingsStore } from '@/stores/settings-store'
+import { getWorkspaceUsage, type UsageRecord } from '@/lib/ipc/usage'
+import { formatUsageCost, formatUsageTokens } from '@/lib/usage-format'
+import {
+  buildUsageDismissKey,
+  findDailyUsageBudgetWarnings,
+  todayLocalDateKey,
+} from '@/lib/usage-budget'
+
+type Props = {
+  workspaceId: string
+}
+
+const USAGE_REFRESH_INTERVAL_MS = 60_000
+
+export function UsageBudgetBanner({ workspaceId }: Props) {
+  const budgetsUsd = useSettingsStore((s) => s.global.model.dailyBudgetsUsd ?? {})
+  const openSettings = useSettingsStore((s) => s.openSettings)
+  const setActiveTab = useSettingsStore((s) => s.setActiveTab)
+  const [records, setRecords] = useState<UsageRecord[]>([])
+  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(() => new Set())
+
+  const hasBudgets = useMemo(
+    () => Object.values(budgetsUsd).some((budget) => Number.isFinite(budget) && budget > 0),
+    [budgetsUsd],
+  )
+
+  useEffect(() => {
+    setRecords([])
+    setDismissedKeys(new Set())
+  }, [workspaceId])
+
+  useEffect(() => {
+    if (!hasBudgets) {
+      setRecords([])
+      return
+    }
+
+    let cancelled = false
+
+    const loadUsage = () => {
+      void getWorkspaceUsage(workspaceId, 2000)
+        .then((usageRecords) => {
+          if (!cancelled) setRecords(usageRecords)
+        })
+        .catch(() => {
+          if (!cancelled) setRecords([])
+        })
+    }
+
+    loadUsage()
+    const interval = window.setInterval(loadUsage, USAGE_REFRESH_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
+  }, [hasBudgets, workspaceId])
+
+  const dateKey = todayLocalDateKey()
+  const warning = useMemo(() => {
+    const warnings = findDailyUsageBudgetWarnings(records, budgetsUsd)
+    return warnings.find((candidate) => {
+      const dismissKey = buildUsageDismissKey(workspaceId, dateKey, candidate.key)
+      if (dismissedKeys.has(dismissKey)) return false
+
+      try {
+        return localStorage.getItem(dismissKey) !== 'true'
+      } catch {
+        return true
+      }
+    })
+  }, [budgetsUsd, dateKey, dismissedKeys, records, workspaceId])
+
+  if (!warning) return null
+
+  const dismissKey = buildUsageDismissKey(workspaceId, dateKey, warning.key)
+  const percentage = Math.round(warning.percentage * 100)
+
+  return (
+    <div className="sticky top-0 z-30 border-b border-red-500/30 bg-red-950/95 px-4 py-3 text-red-50 shadow-lg">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-red-500/20 text-red-200">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+              <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.19-1.458-1.516-2.625L8.485 2.495ZM10 5.75a.75.75 0 0 1 .75.75v3.25a.75.75 0 0 1-1.5 0V6.5A.75.75 0 0 1 10 5.75Zm0 7.75a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">
+              {warning.displayName} daily budget at {String(percentage)}%
+            </p>
+            <p className="text-xs text-red-100/85">
+              {formatUsageCost(warning.costUsd)} of {formatUsageCost(warning.budgetUsd)} today · {formatUsageTokens(warning.totalTokens)} tokens
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setActiveTab('agent')
+              openSettings()
+            }}
+            className="rounded border border-red-200/30 px-2.5 py-1.5 text-xs font-medium text-red-50 transition-colors hover:bg-red-500/20"
+            style={{ cursor: 'pointer' }}
+          >
+            Settings
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              try {
+                localStorage.setItem(dismissKey, 'true')
+              } catch {
+                // Ignore storage failures; local state still hides this banner.
+              }
+              setDismissedKeys((current) => new Set(current).add(dismissKey))
+            }}
+            className="rounded p-1.5 text-red-100/80 transition-colors hover:bg-red-500/20 hover:text-red-50"
+            aria-label="Dismiss usage budget warning"
+            style={{ cursor: 'pointer' }}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+              <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -524,6 +524,7 @@ const mockCommands: Record<string, CommandHandler> = {
     totalCostUsd: 0,
     recordCount: 0,
   }),
+  get_workspace_model_usage_between: () => [],
   get_task_usage_summary: () => ({
     totalInputTokens: 0,
     totalOutputTokens: 0,

--- a/src/lib/ipc/usage.ts
+++ b/src/lib/ipc/usage.ts
@@ -24,6 +24,15 @@ export type UsageSummary = {
   recordCount: number
 }
 
+export type ModelUsageSummary = {
+  provider: string
+  model: string
+  inputTokens: number
+  outputTokens: number
+  costUsd: number
+  recordCount: number
+}
+
 export async function recordUsage(
   workspaceId: string,
   provider: string,
@@ -61,10 +70,20 @@ export async function getTaskUsage(taskId: string): Promise<UsageRecord[]> {
   return invoke<UsageRecord[]>('get_task_usage', { taskId })
 }
 
-export async function getWorkspaceUsageSummary(
-  workspaceId: string,
-): Promise<UsageSummary> {
+export async function getWorkspaceUsageSummary(workspaceId: string): Promise<UsageSummary> {
   return invoke<UsageSummary>('get_workspace_usage_summary', { workspaceId })
+}
+
+export async function getWorkspaceModelUsageBetween(
+  workspaceId: string,
+  startAt: string,
+  endAt: string,
+): Promise<ModelUsageSummary[]> {
+  return invoke<ModelUsageSummary[]>('get_workspace_model_usage_between', {
+    workspaceId,
+    startAt,
+    endAt,
+  })
 }
 
 export async function getTaskUsageSummary(taskId: string): Promise<UsageSummary> {

--- a/src/lib/usage-budget.test.ts
+++ b/src/lib/usage-budget.test.ts
@@ -1,28 +1,21 @@
 import { describe, expect, it } from 'vitest'
-import type { UsageRecord } from '@/lib/ipc/usage'
+import type { ModelUsageSummary } from '@/lib/ipc/usage'
 import {
   buildUsageDismissKey,
-  findDailyUsageBudgetWarnings,
   findUsageBudgetWarnings,
   getModelBudgetKey,
   localDayBounds,
   todayLocalDateKey,
 } from './usage-budget'
 
-function usageRecord(overrides: Partial<UsageRecord>): UsageRecord {
+function modelUsage(overrides: Partial<ModelUsageSummary>): ModelUsageSummary {
   return {
-    id: 'usage-1',
-    workspaceId: 'ws-1',
-    taskId: null,
-    sessionId: null,
     provider: 'anthropic',
     model: 'sonnet',
     inputTokens: 100,
     outputTokens: 50,
     costUsd: 0.8,
-    columnName: null,
-    durationSeconds: 0,
-    createdAt: '2026-05-01T12:00:00Z',
+    recordCount: 1,
     ...overrides,
   }
 }
@@ -48,18 +41,16 @@ describe('usage-budget', () => {
 
   it('aggregates aliases and returns warnings at the 80 percent threshold', () => {
     const key = getModelBudgetKey('claude-sonnet-4-6-20260217', 'anthropic')
-    const warnings = findDailyUsageBudgetWarnings(
+    const warnings = findUsageBudgetWarnings(
       [
-        usageRecord({ id: 'usage-1', model: 'sonnet', costUsd: 0.35 }),
-        usageRecord({
-          id: 'usage-2',
+        modelUsage({ model: 'sonnet', costUsd: 0.35 }),
+        modelUsage({
           model: 'claude-sonnet-4-6-20260217',
           costUsd: 0.45,
           inputTokens: 200,
         }),
       ],
       { [key]: 1 },
-      new Date(2026, 4, 1, 12),
     )
 
     expect(warnings).toHaveLength(1)
@@ -74,15 +65,14 @@ describe('usage-budget', () => {
     })
   })
 
-  it('ignores prior-day records and models without positive budgets', () => {
+  it('ignores models without positive budgets', () => {
     const key = getModelBudgetKey('sonnet', 'anthropic')
-    const warnings = findDailyUsageBudgetWarnings(
+    const warnings = findUsageBudgetWarnings(
       [
-        usageRecord({ id: 'usage-1', costUsd: 10, createdAt: '2026-04-30T23:00:00Z' }),
-        usageRecord({ id: 'usage-2', model: 'haiku', costUsd: 10 }),
+        modelUsage({ costUsd: 10 }),
+        modelUsage({ model: 'haiku', costUsd: 10 }),
       ],
-      { [key]: 1, [getModelBudgetKey('haiku', 'anthropic')]: 0 },
-      new Date(2026, 4, 1, 12),
+      { [key]: 0, [getModelBudgetKey('haiku', 'anthropic')]: 0 },
     )
 
     expect(warnings).toEqual([])
@@ -92,14 +82,12 @@ describe('usage-budget', () => {
     const key = getModelBudgetKey('sonnet', 'anthropic')
     const warnings = findUsageBudgetWarnings(
       [
-        {
-          provider: 'anthropic',
-          model: 'sonnet',
+        modelUsage({
           costUsd: 8,
           inputTokens: 1000,
           outputTokens: 2000,
           recordCount: 2500,
-        },
+        }),
       ],
       { [key]: 10 },
     )

--- a/src/lib/usage-budget.test.ts
+++ b/src/lib/usage-budget.test.ts
@@ -3,7 +3,9 @@ import type { UsageRecord } from '@/lib/ipc/usage'
 import {
   buildUsageDismissKey,
   findDailyUsageBudgetWarnings,
+  findUsageBudgetWarnings,
   getModelBudgetKey,
+  localDayBounds,
   todayLocalDateKey,
 } from './usage-budget'
 
@@ -28,6 +30,14 @@ function usageRecord(overrides: Partial<UsageRecord>): UsageRecord {
 describe('usage-budget', () => {
   it('uses a stable local date key', () => {
     expect(todayLocalDateKey(new Date(2026, 4, 1, 9))).toBe('2026-05-01')
+  })
+
+  it('builds local day UTC bounds for IPC aggregation', () => {
+    const bounds = localDayBounds(new Date(2026, 4, 1, 9))
+
+    expect(new Date(bounds.startAt).getHours()).toBe(0)
+    expect(new Date(bounds.endAt).getHours()).toBe(0)
+    expect(new Date(bounds.endAt).getTime() - new Date(bounds.startAt).getTime()).toBe(86_400_000)
   })
 
   it('builds a workspace and model scoped dismiss key', () => {
@@ -76,5 +86,30 @@ describe('usage-budget', () => {
     )
 
     expect(warnings).toEqual([])
+  })
+
+  it('uses pre-aggregated model summaries without a row limit', () => {
+    const key = getModelBudgetKey('sonnet', 'anthropic')
+    const warnings = findUsageBudgetWarnings(
+      [
+        {
+          provider: 'anthropic',
+          model: 'sonnet',
+          costUsd: 8,
+          inputTokens: 1000,
+          outputTokens: 2000,
+          recordCount: 2500,
+        },
+      ],
+      { [key]: 10 },
+    )
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatchObject({
+      key,
+      costUsd: 8,
+      budgetUsd: 10,
+      percentage: 0.8,
+    })
   })
 })

--- a/src/lib/usage-budget.test.ts
+++ b/src/lib/usage-budget.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import type { UsageRecord } from '@/lib/ipc/usage'
+import {
+  buildUsageDismissKey,
+  findDailyUsageBudgetWarnings,
+  getModelBudgetKey,
+  todayLocalDateKey,
+} from './usage-budget'
+
+function usageRecord(overrides: Partial<UsageRecord>): UsageRecord {
+  return {
+    id: 'usage-1',
+    workspaceId: 'ws-1',
+    taskId: null,
+    sessionId: null,
+    provider: 'anthropic',
+    model: 'sonnet',
+    inputTokens: 100,
+    outputTokens: 50,
+    costUsd: 0.8,
+    columnName: null,
+    durationSeconds: 0,
+    createdAt: '2026-05-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('usage-budget', () => {
+  it('uses a stable local date key', () => {
+    expect(todayLocalDateKey(new Date(2026, 4, 1, 9))).toBe('2026-05-01')
+  })
+
+  it('builds a workspace and model scoped dismiss key', () => {
+    expect(buildUsageDismissKey('ws-1', '2026-05-01', 'anthropic:sonnet')).toBe(
+      'usage-budget-warning-dismissed:ws-1:2026-05-01:anthropic:sonnet',
+    )
+  })
+
+  it('aggregates aliases and returns warnings at the 80 percent threshold', () => {
+    const key = getModelBudgetKey('claude-sonnet-4-6-20260217', 'anthropic')
+    const warnings = findDailyUsageBudgetWarnings(
+      [
+        usageRecord({ id: 'usage-1', model: 'sonnet', costUsd: 0.35 }),
+        usageRecord({
+          id: 'usage-2',
+          model: 'claude-sonnet-4-6-20260217',
+          costUsd: 0.45,
+          inputTokens: 200,
+        }),
+      ],
+      { [key]: 1 },
+      new Date(2026, 4, 1, 12),
+    )
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatchObject({
+      key,
+      displayName: 'Claude Sonnet 4.6',
+      costUsd: 0.8,
+      budgetUsd: 1,
+      inputTokens: 300,
+      outputTokens: 100,
+      totalTokens: 400,
+    })
+  })
+
+  it('ignores prior-day records and models without positive budgets', () => {
+    const key = getModelBudgetKey('sonnet', 'anthropic')
+    const warnings = findDailyUsageBudgetWarnings(
+      [
+        usageRecord({ id: 'usage-1', costUsd: 10, createdAt: '2026-04-30T23:00:00Z' }),
+        usageRecord({ id: 'usage-2', model: 'haiku', costUsd: 10 }),
+      ],
+      { [key]: 1, [getModelBudgetKey('haiku', 'anthropic')]: 0 },
+      new Date(2026, 4, 1, 12),
+    )
+
+    expect(warnings).toEqual([])
+  })
+})

--- a/src/lib/usage-budget.ts
+++ b/src/lib/usage-budget.ts
@@ -1,5 +1,5 @@
 import { canonicalModelUsageKey, getModelMetadata } from '@/lib/model-metadata'
-import type { UsageRecord } from '@/lib/ipc/usage'
+import type { ModelUsageSummary, UsageRecord } from '@/lib/ipc/usage'
 
 export const USAGE_BUDGET_WARNING_THRESHOLD = 0.8
 
@@ -23,11 +23,28 @@ export function todayLocalDateKey(date = new Date()): string {
   return `${year}-${month}-${day}`
 }
 
+export function localDayBounds(date = new Date()): { startAt: string; endAt: string } {
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+
+  const end = new Date(start)
+  end.setDate(end.getDate() + 1)
+
+  return {
+    startAt: start.toISOString(),
+    endAt: end.toISOString(),
+  }
+}
+
 export function getModelBudgetKey(modelId: string, provider = 'unknown'): string {
   return canonicalModelUsageKey(modelId, provider)
 }
 
-export function buildUsageDismissKey(workspaceId: string, dateKey: string, warningKey: string): string {
+export function buildUsageDismissKey(
+  workspaceId: string,
+  dateKey: string,
+  warningKey: string,
+): string {
   return `usage-budget-warning-dismissed:${workspaceId}:${dateKey}:${warningKey}`
 }
 
@@ -36,23 +53,32 @@ export function findDailyUsageBudgetWarnings(
   budgetsUsd: Record<string, number> | undefined,
   date = new Date(),
 ): UsageBudgetWarning[] {
-  const enabledBudgets = Object.entries(budgetsUsd ?? {})
-    .filter(([, budget]) => Number.isFinite(budget) && budget > 0)
+  const dateKey = todayLocalDateKey(date)
+  return findUsageBudgetWarnings(
+    records.filter((record) => todayLocalDateKey(new Date(record.createdAt)) === dateKey),
+    budgetsUsd,
+  )
+}
+
+export function findUsageBudgetWarnings(
+  usage: Array<ModelUsageSummary | UsageRecord>,
+  budgetsUsd: Record<string, number> | undefined,
+): UsageBudgetWarning[] {
+  const enabledBudgets = Object.entries(budgetsUsd ?? {}).filter(
+    ([, budget]) => Number.isFinite(budget) && budget > 0,
+  )
 
   if (enabledBudgets.length === 0) return []
 
-  const dateKey = todayLocalDateKey(date)
   const budgetByKey = Object.fromEntries(enabledBudgets)
   const statsByKey = new Map<string, UsageBudgetWarning>()
 
-  for (const record of records) {
-    if (todayLocalDateKey(new Date(record.createdAt)) !== dateKey) continue
-
-    const key = getModelBudgetKey(record.model, record.provider)
+  for (const entry of usage) {
+    const key = getModelBudgetKey(entry.model, entry.provider)
     const budgetUsd = budgetByKey[key]
     if (!budgetUsd) continue
 
-    const metadata = getModelMetadata(record.model, record.provider)
+    const metadata = getModelMetadata(entry.model, entry.provider)
     const existing = statsByKey.get(key) ?? {
       key,
       provider: metadata.provider,
@@ -66,10 +92,10 @@ export function findDailyUsageBudgetWarnings(
       percentage: 0,
     }
 
-    existing.inputTokens += record.inputTokens
-    existing.outputTokens += record.outputTokens
-    existing.totalTokens += record.inputTokens + record.outputTokens
-    existing.costUsd += record.costUsd
+    existing.inputTokens += entry.inputTokens
+    existing.outputTokens += entry.outputTokens
+    existing.totalTokens += entry.inputTokens + entry.outputTokens
+    existing.costUsd += entry.costUsd
     existing.percentage = existing.costUsd / budgetUsd
     statsByKey.set(key, existing)
   }

--- a/src/lib/usage-budget.ts
+++ b/src/lib/usage-budget.ts
@@ -1,5 +1,5 @@
 import { canonicalModelUsageKey, getModelMetadata } from '@/lib/model-metadata'
-import type { ModelUsageSummary, UsageRecord } from '@/lib/ipc/usage'
+import type { ModelUsageSummary } from '@/lib/ipc/usage'
 
 export const USAGE_BUDGET_WARNING_THRESHOLD = 0.8
 
@@ -17,7 +17,7 @@ export type UsageBudgetWarning = {
 }
 
 export function todayLocalDateKey(date = new Date()): string {
-  const year = date.getFullYear()
+  const year = String(date.getFullYear())
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
   return `${year}-${month}-${day}`
@@ -48,20 +48,8 @@ export function buildUsageDismissKey(
   return `usage-budget-warning-dismissed:${workspaceId}:${dateKey}:${warningKey}`
 }
 
-export function findDailyUsageBudgetWarnings(
-  records: UsageRecord[],
-  budgetsUsd: Record<string, number> | undefined,
-  date = new Date(),
-): UsageBudgetWarning[] {
-  const dateKey = todayLocalDateKey(date)
-  return findUsageBudgetWarnings(
-    records.filter((record) => todayLocalDateKey(new Date(record.createdAt)) === dateKey),
-    budgetsUsd,
-  )
-}
-
 export function findUsageBudgetWarnings(
-  usage: Array<ModelUsageSummary | UsageRecord>,
+  usage: ModelUsageSummary[],
   budgetsUsd: Record<string, number> | undefined,
 ): UsageBudgetWarning[] {
   const enabledBudgets = Object.entries(budgetsUsd ?? {}).filter(

--- a/src/lib/usage-budget.ts
+++ b/src/lib/usage-budget.ts
@@ -1,0 +1,80 @@
+import { canonicalModelUsageKey, getModelMetadata } from '@/lib/model-metadata'
+import type { UsageRecord } from '@/lib/ipc/usage'
+
+export const USAGE_BUDGET_WARNING_THRESHOLD = 0.8
+
+export type UsageBudgetWarning = {
+  key: string
+  provider: string
+  model: string
+  displayName: string
+  inputTokens: number
+  outputTokens: number
+  totalTokens: number
+  costUsd: number
+  budgetUsd: number
+  percentage: number
+}
+
+export function todayLocalDateKey(date = new Date()): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function getModelBudgetKey(modelId: string, provider = 'unknown'): string {
+  return canonicalModelUsageKey(modelId, provider)
+}
+
+export function buildUsageDismissKey(workspaceId: string, dateKey: string, warningKey: string): string {
+  return `usage-budget-warning-dismissed:${workspaceId}:${dateKey}:${warningKey}`
+}
+
+export function findDailyUsageBudgetWarnings(
+  records: UsageRecord[],
+  budgetsUsd: Record<string, number> | undefined,
+  date = new Date(),
+): UsageBudgetWarning[] {
+  const enabledBudgets = Object.entries(budgetsUsd ?? {})
+    .filter(([, budget]) => Number.isFinite(budget) && budget > 0)
+
+  if (enabledBudgets.length === 0) return []
+
+  const dateKey = todayLocalDateKey(date)
+  const budgetByKey = Object.fromEntries(enabledBudgets)
+  const statsByKey = new Map<string, UsageBudgetWarning>()
+
+  for (const record of records) {
+    if (todayLocalDateKey(new Date(record.createdAt)) !== dateKey) continue
+
+    const key = getModelBudgetKey(record.model, record.provider)
+    const budgetUsd = budgetByKey[key]
+    if (!budgetUsd) continue
+
+    const metadata = getModelMetadata(record.model, record.provider)
+    const existing = statsByKey.get(key) ?? {
+      key,
+      provider: metadata.provider,
+      model: metadata.id,
+      displayName: metadata.displayName,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      budgetUsd,
+      percentage: 0,
+    }
+
+    existing.inputTokens += record.inputTokens
+    existing.outputTokens += record.outputTokens
+    existing.totalTokens += record.inputTokens + record.outputTokens
+    existing.costUsd += record.costUsd
+    existing.percentage = existing.costUsd / budgetUsd
+    statsByKey.set(key, existing)
+  }
+
+  return Array.from(statsByKey.values())
+    .filter((warning) => warning.percentage >= USAGE_BUDGET_WARNING_THRESHOLD)
+    .sort((a, b) => b.percentage - a.percentage)
+}

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -22,6 +22,56 @@ type SettingsState = {
   resetToDefaults: () => void
 }
 
+type PersistedSettings = Omit<
+  Partial<Settings>,
+  | 'agent'
+  | 'model'
+  | 'voice'
+  | 'git'
+  | 'appearance'
+  | 'cards'
+  | 'terminal'
+  | 'panel'
+  | 'gestures'
+  | 'advanced'
+  | 'workspaceDefaults'
+> & {
+  agent?: Partial<Settings['agent']>
+  model?: Partial<Settings['model']>
+  voice?: Partial<Settings['voice']>
+  git?: Partial<Settings['git']>
+  appearance?: Partial<Settings['appearance']>
+  cards?: Partial<Settings['cards']>
+  terminal?: Partial<Settings['terminal']>
+  panel?: Partial<Settings['panel']>
+  gestures?: Partial<Settings['gestures']>
+  advanced?: Partial<Settings['advanced']>
+  workspaceDefaults?: Partial<Settings['workspaceDefaults']>
+}
+
+type PersistedSettingsState = {
+  global?: PersistedSettings
+  workspaceOverrides?: SettingsState['workspaceOverrides']
+}
+
+function mergeSettings(settings: PersistedSettings | undefined): Settings {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...settings,
+    agent: { ...DEFAULT_SETTINGS.agent, ...settings?.agent },
+    model: { ...DEFAULT_SETTINGS.model, ...settings?.model },
+    voice: { ...DEFAULT_SETTINGS.voice, ...settings?.voice },
+    git: { ...DEFAULT_SETTINGS.git, ...settings?.git },
+    appearance: { ...DEFAULT_SETTINGS.appearance, ...settings?.appearance },
+    cards: { ...DEFAULT_SETTINGS.cards, ...settings?.cards },
+    terminal: { ...DEFAULT_SETTINGS.terminal, ...settings?.terminal },
+    panel: { ...DEFAULT_SETTINGS.panel, ...settings?.panel },
+    gestures: { ...DEFAULT_SETTINGS.gestures, ...settings?.gestures },
+    advanced: { ...DEFAULT_SETTINGS.advanced, ...settings?.advanced },
+    workspaceDefaults: { ...DEFAULT_SETTINGS.workspaceDefaults, ...settings?.workspaceDefaults },
+  }
+}
+
 export const useSettingsStore = create<SettingsState>()(
   devtools(
     persist(
@@ -100,6 +150,15 @@ export const useSettingsStore = create<SettingsState>()(
           global: state.global,
           workspaceOverrides: state.workspaceOverrides,
         }),
+        merge: (persistedState, currentState) => {
+          const persisted = persistedState as PersistedSettingsState | undefined
+          return {
+            ...currentState,
+            ...persisted,
+            global: mergeSettings(persisted?.global),
+            workspaceOverrides: persisted?.workspaceOverrides ?? currentState.workspaceOverrides,
+          }
+        },
       },
     ),
     { name: 'settings-store' },

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -31,6 +31,8 @@ export type ModelConfig = {
   providers: ProviderConfig[]
   /** Model IDs that are disabled (hidden from orchestrator dropdown) */
   disabledModels: string[]
+  /** Daily USD budget per canonical provider:model key */
+  dailyBudgetsUsd: Record<string, number>
 }
 
 export type McpServer = {
@@ -170,6 +172,7 @@ export const DEFAULT_SETTINGS: Settings = {
   model: {
     showCostEstimates: true,
     disabledModels: [],
+    dailyBudgetsUsd: {},
     providers: [
       {
         id: 'anthropic',


### PR DESCRIPTION
## Description

Track token usage per model per day. When daily usage hits 80% of a configured budget, show a sticky banner at top of board with red warning + cost/total. Add settings for daily budget per model. Acceptance: banner shows at threshold, dismissible, settings persist, npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/token-usage-warning-banner-at-80-of-model-limit` → `staging/2026-05-01-bento-ya-recovery`

## Commits

```
75c7707 Tighten usage budget quality fixes
da3295d Fix daily usage budget aggregation
499e149 Add daily model usage budget warning
```

## Changes

```
src-tauri/src/commands/usage.rs              |  19 +++-
 src-tauri/src/db/models.rs                   |  12 ++
 src-tauri/src/db/usage.rs                    |  94 +++++++++++++++-
 src-tauri/src/lib.rs                         |   1 +
 src/components/layout/board.tsx              |   2 +
 src/components/settings/tabs/agent-tab.tsx   |  66 +++++++++++
 src/components/settings/tabs/github-tab.tsx  |   2 +-
 src/components/usage/usage-budget-banner.tsx | 160 +++++++++++++++++++++++++++
 src/lib/browser-mock.ts                      |   1 +
 src/lib/ipc/usage.ts                         |  25 ++++-
 src/lib/usage-budget.test.ts                 | 103 +++++++++++++++++
 src/lib/usage-budget.ts                      |  94 ++++++++++++++++
 src/stores/settings-store.ts                 |  59 ++++++++++
 src/types/settings.ts                        |   3 +
 14 files changed, 635 insertions(+), 6 deletions(-)
```