### PR TITLE
Cost dashboard — per-task and per-workspace LLM spend

### DIFF
--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -23,6 +23,7 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { useChecklistStore } from '@/stores/checklist-store'
 import { Tooltip } from '@/components/shared/tooltip'
 import type { Workspace } from '@/types'
+import { CostBadge, MetricsDashboard } from '@/components/usage'
 import { AddWorkspaceDialog } from './add-workspace-dialog'
 import { useTabBarNavigation } from './use-tab-bar-navigation'
 
@@ -241,6 +242,7 @@ export function TabBar() {
 
   const [draggingId, setDraggingId] = useState<string | null>(null)
   const [showAddDialog, setShowAddDialog] = useState(false)
+  const [showDashboard, setShowDashboard] = useState(false)
 
   const sortedWorkspaces = [...workspaces].sort((a, b) => a.tabOrder - b.tabOrder)
   const workspaceIds = sortedWorkspaces.map((w) => w.id)
@@ -322,7 +324,7 @@ export function TabBar() {
           </DndContext>
         </div>
 
-        {/* Right: add workspace + checklist + settings */}
+        {/* Right: add workspace + checklist + cost + settings */}
         <div className="ml-auto flex items-center gap-1">
           <AddTabButton
             onClick={() => {
@@ -330,16 +332,28 @@ export function TabBar() {
             }}
           />
           <ChecklistButton />
+          {activeWorkspaceId && (
+            <CostBadge
+              workspaceId={activeWorkspaceId}
+              onOpenDashboard={() => { setShowDashboard(true) }}
+            />
+          )}
           <SettingsButton />
         </div>
       </header>
 
-      {/* Add workspace dialog - simple placeholder for now */}
       {showAddDialog && (
         <AddWorkspaceDialog
           onClose={() => {
             setShowAddDialog(false)
           }}
+        />
+      )}
+
+      {showDashboard && activeWorkspaceId && (
+        <MetricsDashboard
+          workspaceId={activeWorkspaceId}
+          onClose={() => { setShowDashboard(false) }}
         />
       )}
     </>

--- a/src/components/usage/cost-badge.tsx
+++ b/src/components/usage/cost-badge.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { useWorkspaceUsage } from '@/hooks/use-workspace-usage'
-import { formatUsageCost, formatUsageTokens } from '@/lib/usage'
+import { formatUsageCost, formatUsageTokens, shortModelName } from '@/lib/usage'
 
 type Props = {
   workspaceId: string
@@ -115,7 +115,7 @@ export function CostBadge({ workspaceId, onOpenDashboard }: Props) {
                         >
                           <div className="flex items-center gap-2">
                             <span className="font-mono text-text-secondary">
-                              {record.model.split('/').pop()}
+                              {shortModelName(record.model)}
                             </span>
                           </div>
                           <div className="flex items-center gap-3">

--- a/src/components/usage/metrics-dashboard.tsx
+++ b/src/components/usage/metrics-dashboard.tsx
@@ -63,6 +63,7 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const [columnCosts, setColumnCosts] = useState<ColumnCost[]>([])
   const [taskCosts, setTaskCosts] = useState<TaskCost[]>([])
   const [workspaceCosts, setWorkspaceCosts] = useState<WorkspaceCost[]>([])
+  const [workspaceCostsLoading, setWorkspaceCostsLoading] = useState(false)
   const [activeTab, setActiveTab] = useState<ActiveTab>('overview')
 
   useEffect(() => {
@@ -73,6 +74,8 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
 
   useEffect(() => {
     if (allWorkspaces.length === 0) return
+    let cancelled = false
+    setWorkspaceCostsLoading(true)
     void Promise.all(
       allWorkspaces.map(async (ws) => {
         const s = await getWorkspaceUsageSummary(ws.id)
@@ -86,8 +89,14 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
         } satisfies WorkspaceCost
       }),
     ).then((costs) => {
+      if (cancelled) return
       setWorkspaceCosts(costs.sort((a, b) => b.totalCostUsd - a.totalCostUsd))
+    }).catch(() => {
+      // non-critical: workspace cost summaries will just remain empty
+    }).finally(() => {
+      if (!cancelled) setWorkspaceCostsLoading(false)
     })
+    return () => { cancelled = true }
   }, [allWorkspaces])
 
   const modelStats = useMemo((): ModelStats[] => {
@@ -403,7 +412,9 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
               {activeTab === 'workspace' && (
                 <div className="rounded-xl border border-border-default bg-bg p-4">
                   <h3 className="mb-4 font-semibold text-text-primary">Cost by Workspace</h3>
-                  {workspaceCosts.length === 0 ? (
+                  {workspaceCostsLoading ? (
+                    <p className="text-sm text-text-secondary">Loading workspace costs...</p>
+                  ) : workspaceCosts.length === 0 ? (
                     <p className="text-sm text-text-secondary">No workspace data available</p>
                   ) : (
                     <div className="space-y-3">

--- a/src/components/usage/metrics-dashboard.tsx
+++ b/src/components/usage/metrics-dashboard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { motion } from 'motion/react'
 import { useWorkspaceUsage } from '@/hooks/use-workspace-usage'
+import { useWorkspaceStore } from '@/stores/workspace-store'
 import { formatUsageCost, formatUsageDate, formatUsageTokens } from '@/lib/usage'
 import {
   type ColumnCost,
@@ -9,6 +10,7 @@ import {
   getWorkspaceColumnCosts,
   getWorkspaceDailyCosts,
   getWorkspaceTaskCosts,
+  getWorkspaceUsageSummary,
 } from '@/lib/ipc/usage'
 
 type Props = {
@@ -24,7 +26,16 @@ type ModelStats = {
   count: number
 }
 
-type ActiveTab = 'overview' | 'model' | 'column' | 'task'
+type WorkspaceCost = {
+  workspaceId: string
+  workspaceName: string
+  totalCostUsd: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  recordCount: number
+}
+
+type ActiveTab = 'overview' | 'model' | 'column' | 'task' | 'workspace'
 
 const DAYS = 30
 const TOP_TASKS_LIMIT = 10
@@ -35,6 +46,7 @@ const TABS: { id: ActiveTab; label: string }[] = [
   { id: 'model', label: 'By Model' },
   { id: 'column', label: 'By Column' },
   { id: 'task', label: 'By Task' },
+  { id: 'workspace', label: 'All Workspaces' },
 ]
 
 function shortModelName(model: string): string {
@@ -45,10 +57,12 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const { summary, records, isLoading, error } = useWorkspaceUsage(workspaceId, {
     limit: 1000,
   })
+  const allWorkspaces = useWorkspaceStore((s) => s.workspaces)
 
   const [dailyCosts, setDailyCosts] = useState<DailyCost[]>([])
   const [columnCosts, setColumnCosts] = useState<ColumnCost[]>([])
   const [taskCosts, setTaskCosts] = useState<TaskCost[]>([])
+  const [workspaceCosts, setWorkspaceCosts] = useState<WorkspaceCost[]>([])
   const [activeTab, setActiveTab] = useState<ActiveTab>('overview')
 
   useEffect(() => {
@@ -56,6 +70,25 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
     void getWorkspaceColumnCosts(workspaceId).then(setColumnCosts)
     void getWorkspaceTaskCosts(workspaceId, TOP_TASKS_LIMIT).then(setTaskCosts)
   }, [workspaceId])
+
+  useEffect(() => {
+    if (allWorkspaces.length === 0) return
+    void Promise.all(
+      allWorkspaces.map(async (ws) => {
+        const s = await getWorkspaceUsageSummary(ws.id)
+        return {
+          workspaceId: ws.id,
+          workspaceName: ws.name,
+          totalCostUsd: s.totalCostUsd,
+          totalInputTokens: s.totalInputTokens,
+          totalOutputTokens: s.totalOutputTokens,
+          recordCount: s.recordCount,
+        } satisfies WorkspaceCost
+      }),
+    ).then((costs) => {
+      setWorkspaceCosts(costs.sort((a, b) => b.totalCostUsd - a.totalCostUsd))
+    })
+  }, [allWorkspaces])
 
   const modelStats = useMemo((): ModelStats[] => {
     const map = new Map<string, ModelStats>()
@@ -80,6 +113,7 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const maxColumnCost = Math.max(...columnCosts.map((c) => c.costUsd), 0.01)
   const maxTaskCost = Math.max(...taskCosts.map((t) => t.costUsd), 0.01)
   const maxModelCost = Math.max(...modelStats.map((m) => m.cost), 0.01)
+  const maxWorkspaceCost = Math.max(...workspaceCosts.map((w) => w.totalCostUsd), 0.01)
 
   const exportCsv = useCallback(() => {
     const csvField = (v: string) => (v.includes(',') || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v)
@@ -358,6 +392,43 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
                           <div className="flex gap-4 text-xs text-text-secondary">
                             <span>In: {formatUsageTokens(task.inputTokens)}</span>
                             <span>Out: {formatUsageTokens(task.outputTokens)}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {activeTab === 'workspace' && (
+                <div className="rounded-xl border border-border-default bg-bg p-4">
+                  <h3 className="mb-4 font-semibold text-text-primary">Cost by Workspace</h3>
+                  {workspaceCosts.length === 0 ? (
+                    <p className="text-sm text-text-secondary">No workspace data available</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {workspaceCosts.map((ws) => (
+                        <div key={ws.workspaceId} className="space-y-1">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className={`font-medium ${ws.workspaceId === workspaceId ? 'text-accent' : 'text-text-primary'}`}>
+                              {ws.workspaceName}
+                              {ws.workspaceId === workspaceId && (
+                                <span className="ml-1.5 text-xs text-text-secondary font-normal">(current)</span>
+                              )}
+                            </span>
+                            <span className="text-text-secondary shrink-0 ml-2">
+                              {formatUsageCost(ws.totalCostUsd)} ({ws.recordCount} calls)
+                            </span>
+                          </div>
+                          <div className="h-2 rounded-full bg-surface">
+                            <div
+                              className="h-full rounded-full bg-emerald-500"
+                              style={{ width: `${String((ws.totalCostUsd / maxWorkspaceCost) * 100)}%` }}
+                            />
+                          </div>
+                          <div className="flex gap-4 text-xs text-text-secondary">
+                            <span>In: {formatUsageTokens(ws.totalInputTokens)}</span>
+                            <span>Out: {formatUsageTokens(ws.totalOutputTokens)}</span>
                           </div>
                         </div>
                       ))}

--- a/src/components/usage/metrics-dashboard.tsx
+++ b/src/components/usage/metrics-dashboard.tsx
@@ -2,11 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { motion } from 'motion/react'
 import { useWorkspaceUsage } from '@/hooks/use-workspace-usage'
 import { useWorkspaceStore } from '@/stores/workspace-store'
-import { formatUsageCost, formatUsageDate, formatUsageTokens } from '@/lib/usage'
+import { formatUsageCost, formatUsageDate, formatUsageTokens, shortModelName } from '@/lib/usage'
 import {
   type ColumnCost,
   type DailyCost,
   type TaskCost,
+  type UsageSummary,
   getWorkspaceColumnCosts,
   getWorkspaceDailyCosts,
   getWorkspaceTaskCosts,
@@ -26,14 +27,7 @@ type ModelStats = {
   count: number
 }
 
-type WorkspaceCost = {
-  workspaceId: string
-  workspaceName: string
-  totalCostUsd: number
-  totalInputTokens: number
-  totalOutputTokens: number
-  recordCount: number
-}
+type WorkspaceCost = UsageSummary & { workspaceId: string; workspaceName: string }
 
 type ActiveTab = 'overview' | 'model' | 'column' | 'task' | 'workspace'
 
@@ -49,15 +43,11 @@ const TABS: { id: ActiveTab; label: string }[] = [
   { id: 'workspace', label: 'All Workspaces' },
 ]
 
-function shortModelName(model: string): string {
-  return model.split('/').pop() ?? model
-}
-
 export function MetricsDashboard({ workspaceId, onClose }: Props) {
   const { summary, records, isLoading, error } = useWorkspaceUsage(workspaceId, {
     limit: 1000,
   })
-  const allWorkspaces = useWorkspaceStore((s) => s.workspaces)
+  const workspacesKey = useWorkspaceStore((s) => s.workspaces.map((w) => w.id).join(','))
 
   const [dailyCosts, setDailyCosts] = useState<DailyCost[]>([])
   const [columnCosts, setColumnCosts] = useState<ColumnCost[]>([])
@@ -73,20 +63,14 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
   }, [workspaceId])
 
   useEffect(() => {
-    if (allWorkspaces.length === 0) return
+    const workspaces = useWorkspaceStore.getState().workspaces
+    if (workspaces.length === 0) return
     let cancelled = false
     setWorkspaceCostsLoading(true)
     void Promise.all(
-      allWorkspaces.map(async (ws) => {
+      workspaces.map(async (ws) => {
         const s = await getWorkspaceUsageSummary(ws.id)
-        return {
-          workspaceId: ws.id,
-          workspaceName: ws.name,
-          totalCostUsd: s.totalCostUsd,
-          totalInputTokens: s.totalInputTokens,
-          totalOutputTokens: s.totalOutputTokens,
-          recordCount: s.recordCount,
-        } satisfies WorkspaceCost
+        return { workspaceId: ws.id, workspaceName: ws.name, ...s } satisfies WorkspaceCost
       }),
     ).then((costs) => {
       if (cancelled) return
@@ -97,7 +81,7 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
       if (!cancelled) setWorkspaceCostsLoading(false)
     })
     return () => { cancelled = true }
-  }, [allWorkspaces])
+  }, [workspacesKey])
 
   const modelStats = useMemo((): ModelStats[] => {
     const map = new Map<string, ModelStats>()

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -1,3 +1,7 @@
+export function shortModelName(model: string): string {
+  return model.split('/').pop() ?? model
+}
+
 export function formatUsageCost(usd: number): string {
   if (usd < 0.01) return '<$0.01'
   return `$${usd.toFixed(2)}`


### PR DESCRIPTION
## Description

Build a dashboard panel showing LLM spend grouped by task, column, and workspace using the existing usage table. Add a new route/panel in the React frontend that queries `usage` rows joined with tasks. Show: total spend, spend per workspace, top 10 most expensive tasks, daily trend chart. Acceptance: panel renders without errors, data accurate against DB queries, npx tsc --noEmit passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/cost-dashboard-per-task-and-per-workspace-llm-spen` → `staging/2026-05-01-bento-ya-recovery`

## Commits

```
f6c6f6c Refactor usage components: extract shortModelName, fix WorkspaceCost type, stabilize effect deps
0af370b Fix race condition, error handling, and loading state in workspace costs effect
add4dcb Add cost dashboard panel with per-workspace and per-task LLM spend
```

## Changes

```
src/components/layout/tab-bar.tsx          | 18 ++++++-
 src/components/usage/cost-badge.tsx        |  4 +-
 src/components/usage/metrics-dashboard.tsx | 78 +++++++++++++++++++++++++++---
 src/lib/usage.ts                           |  4 ++
 4 files changed, 94 insertions(+), 10 deletions(-)
```