### PR TITLE
Task duplication via context menu

### DIFF
--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -2,6 +2,7 @@ use crate::db::{self, AppState, Task};
 use crate::error::AppError;
 use crate::pipeline;
 use serde::{Deserialize, Serialize};
+use rusqlite::params;
 use std::collections::HashSet;
 use std::process::Command;
 use tauri::{AppHandle, State};
@@ -69,6 +70,154 @@ pub async fn create_task(
     pipeline::emit_tasks_changed(&app, &workspace_id, "task_created");
 
     Ok(task)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn duplicate_task(app: AppHandle, state: State<'_, AppState>, id: String) -> Result<Task, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    let source_task = db::get_task(&conn, &id)?;
+
+    let new_id = db::new_id();
+    let ts = db::now();
+    let new_title = if source_task.title.ends_with(" (Copy)") {
+        source_task.title.clone()
+    } else {
+        format!("{} (Copy)", source_task.title)
+    };
+    let duplicate_position = source_task.position + 1;
+
+    // Insert the duplicate immediately after the original task.
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    tx.execute(
+        "UPDATE tasks SET position = position + 1 WHERE column_id = ?1 AND position >= ?2",
+        params![source_task.column_id, duplicate_position],
+    )
+    .map_err(AppError::from)?;
+
+    tx.execute(
+        "INSERT INTO tasks (
+            id,
+            workspace_id,
+            column_id,
+            title,
+            description,
+            position,
+            priority,
+            agent_mode,
+            branch_name,
+            files_touched,
+            checklist,
+            pipeline_state,
+            pipeline_triggered_at,
+            pipeline_error,
+            agent_session_id,
+            last_script_exit_code,
+            review_status,
+            pr_number,
+            pr_url,
+            siege_iteration,
+            siege_active,
+            siege_max_iterations,
+            siege_last_checked,
+            pr_mergeable,
+            pr_ci_status,
+            pr_review_decision,
+            pr_comment_count,
+            pr_is_draft,
+            pr_labels,
+            pr_last_fetched,
+            pr_head_sha,
+            notify_stakeholders,
+            notification_sent_at,
+            trigger_overrides,
+            trigger_prompt,
+            last_output,
+            dependencies,
+            blocked,
+            created_at,
+            updated_at,
+            agent_status,
+            queued_at,
+            retry_count,
+            model,
+            worktree_path,
+            batch_id,
+            github_issue_number,
+            github_issue_commented,
+            github_issue_pr_linked
+        ) SELECT
+            ?1,
+            workspace_id,
+            column_id,
+            ?2,
+            description,
+            ?3,
+            priority,
+            agent_mode,
+            branch_name,
+            files_touched,
+            checklist,
+            'idle',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            siege_max_iterations,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            pr_labels,
+            NULL,
+            NULL,
+            notify_stakeholders,
+            NULL,
+            trigger_overrides,
+            trigger_prompt,
+            NULL,
+            dependencies,
+            blocked,
+            ?4,
+            ?4,
+            NULL,
+            NULL,
+            0,
+            model,
+            NULL,
+            batch_id,
+            NULL,
+            0,
+            0
+        FROM tasks WHERE id = ?5",
+        params![
+            new_id,
+            new_title,
+            duplicate_position,
+            ts,
+            source_task.id,
+        ],
+    )
+    .map_err(AppError::from)?;
+
+    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    pipeline::emit_tasks_changed(&app, &source_task.workspace_id, "task_duplicated");
+    Ok(db::get_task(&conn, &new_id)?)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -82,10 +82,9 @@ pub fn duplicate_task(
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
-    let source_task = db::get_task(&conn, &id)?;
-    let task = db::duplicate_task(&conn, &source_task.id)?;
+    let task = db::duplicate_task(&conn, &id)?;
 
-    pipeline::emit_tasks_changed(&app, &source_task.workspace_id, "task_duplicated");
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_duplicated");
     Ok(task)
 }
 

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -2,7 +2,6 @@ use crate::db::{self, AppState, Task};
 use crate::error::AppError;
 use crate::pipeline;
 use serde::{Deserialize, Serialize};
-use rusqlite::params;
 use std::collections::HashSet;
 use std::process::Command;
 use tauri::{AppHandle, State};
@@ -73,151 +72,21 @@ pub async fn create_task(
 }
 
 #[tauri::command(rename_all = "camelCase")]
-pub fn duplicate_task(app: AppHandle, state: State<'_, AppState>, id: String) -> Result<Task, AppError> {
+pub fn duplicate_task(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<Task, AppError> {
     let conn = state
         .db
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
     let source_task = db::get_task(&conn, &id)?;
-
-    let new_id = db::new_id();
-    let ts = db::now();
-    let new_title = if source_task.title.ends_with(" (Copy)") {
-        source_task.title.clone()
-    } else {
-        format!("{} (Copy)", source_task.title)
-    };
-    let duplicate_position = source_task.position + 1;
-
-    // Insert the duplicate immediately after the original task.
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-
-    tx.execute(
-        "UPDATE tasks SET position = position + 1 WHERE column_id = ?1 AND position >= ?2",
-        params![source_task.column_id, duplicate_position],
-    )
-    .map_err(AppError::from)?;
-
-    tx.execute(
-        "INSERT INTO tasks (
-            id,
-            workspace_id,
-            column_id,
-            title,
-            description,
-            position,
-            priority,
-            agent_mode,
-            branch_name,
-            files_touched,
-            checklist,
-            pipeline_state,
-            pipeline_triggered_at,
-            pipeline_error,
-            agent_session_id,
-            last_script_exit_code,
-            review_status,
-            pr_number,
-            pr_url,
-            siege_iteration,
-            siege_active,
-            siege_max_iterations,
-            siege_last_checked,
-            pr_mergeable,
-            pr_ci_status,
-            pr_review_decision,
-            pr_comment_count,
-            pr_is_draft,
-            pr_labels,
-            pr_last_fetched,
-            pr_head_sha,
-            notify_stakeholders,
-            notification_sent_at,
-            trigger_overrides,
-            trigger_prompt,
-            last_output,
-            dependencies,
-            blocked,
-            created_at,
-            updated_at,
-            agent_status,
-            queued_at,
-            retry_count,
-            model,
-            worktree_path,
-            batch_id,
-            github_issue_number,
-            github_issue_commented,
-            github_issue_pr_linked
-        ) SELECT
-            ?1,
-            workspace_id,
-            column_id,
-            ?2,
-            description,
-            ?3,
-            priority,
-            agent_mode,
-            branch_name,
-            files_touched,
-            checklist,
-            'idle',
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            0,
-            0,
-            siege_max_iterations,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            0,
-            0,
-            pr_labels,
-            NULL,
-            NULL,
-            notify_stakeholders,
-            NULL,
-            trigger_overrides,
-            trigger_prompt,
-            NULL,
-            dependencies,
-            blocked,
-            ?4,
-            ?4,
-            NULL,
-            NULL,
-            0,
-            model,
-            NULL,
-            batch_id,
-            NULL,
-            0,
-            0
-        FROM tasks WHERE id = ?5",
-        params![
-            new_id,
-            new_title,
-            duplicate_position,
-            ts,
-            source_task.id,
-        ],
-    )
-    .map_err(AppError::from)?;
-
-    tx.commit().map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let task = db::duplicate_task(&conn, &source_task.id)?;
 
     pipeline::emit_tasks_changed(&app, &source_task.workspace_id, "task_duplicated");
-    Ok(db::get_task(&conn, &new_id)?)
+    Ok(task)
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -94,6 +94,130 @@ pub fn insert_task(
     get_task(conn, &id)
 }
 
+/// Duplicate a task immediately after the source task in the same column.
+pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
+    let source_task = get_task(conn, id)?;
+    let new_id = new_id();
+    let ts = now();
+    let new_title = format!("{} (copy)", source_task.title);
+    let duplicate_position = source_task.position + 1;
+
+    let tx = conn.unchecked_transaction()?;
+
+    tx.execute(
+        "UPDATE tasks SET position = position + 1 WHERE column_id = ?1 AND position >= ?2",
+        params![source_task.column_id, duplicate_position],
+    )?;
+
+    tx.execute(
+        "INSERT INTO tasks (
+            id,
+            workspace_id,
+            column_id,
+            title,
+            description,
+            position,
+            priority,
+            agent_mode,
+            branch_name,
+            files_touched,
+            checklist,
+            pipeline_state,
+            pipeline_triggered_at,
+            pipeline_error,
+            agent_session_id,
+            last_script_exit_code,
+            review_status,
+            pr_number,
+            pr_url,
+            siege_iteration,
+            siege_active,
+            siege_max_iterations,
+            siege_last_checked,
+            pr_mergeable,
+            pr_ci_status,
+            pr_review_decision,
+            pr_comment_count,
+            pr_is_draft,
+            pr_labels,
+            pr_last_fetched,
+            pr_head_sha,
+            notify_stakeholders,
+            notification_sent_at,
+            trigger_overrides,
+            trigger_prompt,
+            last_output,
+            dependencies,
+            blocked,
+            created_at,
+            updated_at,
+            agent_status,
+            queued_at,
+            retry_count,
+            model,
+            worktree_path,
+            batch_id,
+            github_issue_number,
+            github_issue_commented,
+            github_issue_pr_linked
+        ) SELECT
+            ?1,
+            workspace_id,
+            column_id,
+            ?2,
+            description,
+            ?3,
+            priority,
+            agent_mode,
+            branch_name,
+            files_touched,
+            checklist,
+            'idle',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            siege_max_iterations,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            pr_labels,
+            NULL,
+            NULL,
+            notify_stakeholders,
+            NULL,
+            trigger_overrides,
+            trigger_prompt,
+            NULL,
+            dependencies,
+            blocked,
+            ?4,
+            ?4,
+            NULL,
+            NULL,
+            0,
+            model,
+            NULL,
+            batch_id,
+            NULL,
+            0,
+            0
+        FROM tasks WHERE id = ?5",
+        params![new_id, new_title, duplicate_position, ts, source_task.id],
+    )?;
+
+    tx.commit()?;
+    get_task(conn, &new_id)
+}
+
 /// Move a task to the end of a column, resetting its pipeline state to idle.
 pub fn append_task_to_column(conn: &Connection, task_id: &str, column_id: &str) -> SqlResult<Task> {
     let max_pos: i64 = conn
@@ -464,4 +588,70 @@ pub fn clear_task_notification_sent(conn: &Connection, id: &str) -> SqlResult<Ta
         params![ts, id],
     )?;
     get_task(conn, id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    #[test]
+    fn duplicate_task_copies_metadata_after_source_without_agent_session() {
+        let conn = db::init_test().unwrap();
+        let workspace = db::insert_workspace(&conn, "Test", "/tmp/test").unwrap();
+        let column = db::insert_column(&conn, &workspace.id, "Backlog", 0).unwrap();
+        let source = insert_task(
+            &conn,
+            &workspace.id,
+            &column.id,
+            "Original",
+            Some("details"),
+        )
+        .unwrap();
+        let after = insert_task(&conn, &workspace.id, &column.id, "After", None).unwrap();
+        let session = db::insert_agent_session(&conn, &source.id, "codex", Some("/tmp")).unwrap();
+
+        db::update_task_agent_session(&conn, &source.id, Some(&session.id)).unwrap();
+        conn.execute(
+            "UPDATE tasks SET pr_labels = ?1, checklist = ?2, trigger_overrides = ?3, trigger_prompt = ?4, dependencies = ?5, blocked = 1 WHERE id = ?6",
+            params![
+                r#"["bug","ui"]"#,
+                r#"[{"id":"one","text":"Check","checked":false}]"#,
+                r#"{"skip_triggers":true}"#,
+                "custom prompt",
+                r#"[{"taskId":"dep"}]"#,
+                source.id,
+            ],
+        )
+        .unwrap();
+
+        let duplicated = duplicate_task(&conn, &source.id).unwrap();
+        let shifted = get_task(&conn, &after.id).unwrap();
+
+        assert_ne!(duplicated.id, source.id);
+        assert_eq!(duplicated.title, "Original (copy)");
+        assert_eq!(duplicated.description.as_deref(), Some("details"));
+        assert_eq!(duplicated.workspace_id, workspace.id);
+        assert_eq!(duplicated.column_id, column.id);
+        assert_eq!(duplicated.position, source.position + 1);
+        assert_eq!(shifted.position, source.position + 2);
+        assert_eq!(duplicated.pr_labels, r#"["bug","ui"]"#);
+        assert_eq!(
+            duplicated.checklist.as_deref(),
+            Some(r#"[{"id":"one","text":"Check","checked":false}]"#)
+        );
+        assert_eq!(
+            duplicated.trigger_overrides.as_deref(),
+            Some(r#"{"skip_triggers":true}"#)
+        );
+        assert_eq!(duplicated.trigger_prompt.as_deref(), Some("custom prompt"));
+        assert_eq!(
+            duplicated.dependencies.as_deref(),
+            Some(r#"[{"taskId":"dep"}]"#)
+        );
+        assert!(duplicated.blocked);
+        assert!(duplicated.agent_session_id.is_none());
+        assert_eq!(duplicated.pipeline_state, "idle");
+        assert!(duplicated.worktree_path.is_none());
+    }
 }

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -105,8 +105,8 @@ pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
     let tx = conn.unchecked_transaction()?;
 
     tx.execute(
-        "UPDATE tasks SET position = position + 1 WHERE column_id = ?1 AND position >= ?2",
-        params![source_task.column_id, duplicate_position],
+        "UPDATE tasks SET position = position + 1, updated_at = ?3 WHERE column_id = ?1 AND position >= ?2",
+        params![source_task.column_id, duplicate_position, ts],
     )?;
 
     tx.execute(
@@ -189,7 +189,7 @@ pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
             NULL,
             0,
             0,
-            pr_labels,
+            '[]',
             NULL,
             NULL,
             notify_stakeholders,
@@ -638,7 +638,7 @@ mod tests {
         assert_eq!(duplicated.column_id, column.id);
         assert_eq!(duplicated.position, source.position + 1);
         assert_eq!(shifted.position, source.position + 2);
-        assert_eq!(duplicated.pr_labels, r#"["bug","ui"]"#);
+        assert_eq!(duplicated.pr_labels, "[]");
         assert_eq!(
             duplicated.checklist.as_deref(),
             Some(r#"[{"id":"one","text":"Check","checked":false}]"#)

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -169,8 +169,8 @@ pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
             ?3,
             priority,
             agent_mode,
-            branch_name,
-            files_touched,
+            NULL,
+            '[]',
             checklist,
             'idle',
             NULL,
@@ -206,7 +206,7 @@ pub fn duplicate_task(conn: &Connection, id: &str) -> SqlResult<Task> {
             0,
             model,
             NULL,
-            batch_id,
+            NULL,
             NULL,
             0,
             0
@@ -613,13 +613,16 @@ mod tests {
 
         db::update_task_agent_session(&conn, &source.id, Some(&session.id)).unwrap();
         conn.execute(
-            "UPDATE tasks SET pr_labels = ?1, checklist = ?2, trigger_overrides = ?3, trigger_prompt = ?4, dependencies = ?5, blocked = 1 WHERE id = ?6",
+            "UPDATE tasks SET pr_labels = ?1, checklist = ?2, trigger_overrides = ?3, trigger_prompt = ?4, dependencies = ?5, blocked = 1, branch_name = ?6, files_touched = ?7, batch_id = ?8 WHERE id = ?9",
             params![
                 r#"["bug","ui"]"#,
                 r#"[{"id":"one","text":"Check","checked":false}]"#,
                 r#"{"skip_triggers":true}"#,
                 "custom prompt",
                 r#"[{"taskId":"dep"}]"#,
+                "bentoya/source-branch",
+                r#"["src/main.rs"]"#,
+                "batch-source",
                 source.id,
             ],
         )
@@ -651,6 +654,9 @@ mod tests {
         );
         assert!(duplicated.blocked);
         assert!(duplicated.agent_session_id.is_none());
+        assert!(duplicated.branch_name.is_none());
+        assert_eq!(duplicated.files_touched, "[]");
+        assert!(duplicated.batch_id.is_none());
         assert_eq!(duplicated.pipeline_state, "idle");
         assert!(duplicated.worktree_path.is_none());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ pub fn run() {
             commands::task::get_task,
             commands::task::list_tasks,
             commands::task::update_task,
+            commands::task::duplicate_task,
             commands::task::update_task_triggers,
             commands::task::move_task,
             commands::task::bulk_update_tasks,

--- a/src/lib/ipc/task.ts
+++ b/src/lib/ipc/task.ts
@@ -51,6 +51,10 @@ export async function reorderTasks(columnId: string, taskIds: string[]): Promise
   return invoke<Task[]>('reorder_tasks', { columnId, taskIds })
 }
 
+export async function duplicateTask(id: string): Promise<Task> {
+  return invoke<Task>('duplicate_task', { id })
+}
+
 export async function deleteTask(id: string): Promise<void> {
   return invoke('delete_task', { id })
 }

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -16,6 +16,7 @@ vi.mock('./workspace-store', () => ({
 vi.mock('@/lib/ipc', () => ({
   getTasks: vi.fn(),
   createTask: vi.fn(),
+  duplicateTask: vi.fn(),
   deleteTask: vi.fn(),
   bulkUpdateTasks: vi.fn(),
   moveTask: vi.fn(),
@@ -378,30 +379,25 @@ describe('task-store', () => {
       })
     })
 
-    it('should create a copy of the task with "(Copy)" suffix', async () => {
+    it('should duplicate task', async () => {
       const duplicatedTask = createMockTask({
         id: 'task-dup',
         title: 'Original Task (Copy)',
         description: 'Some description',
       })
-      mockIpc.createTask.mockResolvedValueOnce(duplicatedTask)
+      mockIpc.duplicateTask.mockResolvedValueOnce(duplicatedTask)
       refreshWorkspace.mockResolvedValueOnce(undefined)
 
       const result = await useTaskStore.getState().duplicate('task-1')
 
       expect(result).toEqual(duplicatedTask)
-      expect(mockIpc.createTask).toHaveBeenCalledWith(
-        'ws-1',
-        'col-1',
-        'Original Task (Copy)',
-        'Some description',
-      )
+      expect(mockIpc.duplicateTask).toHaveBeenCalledWith('task-1')
       expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
     })
 
     it('should add duplicated task to store', async () => {
       const duplicatedTask = createMockTask({ id: 'task-dup', title: 'Original Task (Copy)' })
-      mockIpc.createTask.mockResolvedValueOnce(duplicatedTask)
+      mockIpc.duplicateTask.mockResolvedValueOnce(duplicatedTask)
 
       await useTaskStore.getState().duplicate('task-1')
 
@@ -410,23 +406,11 @@ describe('task-store', () => {
       expect(state.tasks).toContainEqual(duplicatedTask)
     })
 
-    it('should not add extra "(Copy)" if title already ends with it', async () => {
-      useTaskStore.setState({
-        tasks: [createMockTask({ id: 'task-1', title: 'Already Copied (Copy)' })],
-      })
-      const duplicatedTask = createMockTask({ id: 'task-dup', title: 'Already Copied (Copy)' })
-      mockIpc.createTask.mockResolvedValueOnce(duplicatedTask)
-
-      await useTaskStore.getState().duplicate('task-1')
-
-      expect(mockIpc.createTask).toHaveBeenCalledWith('ws-1', 'col-1', 'Already Copied (Copy)', '')
-    })
-
     it('should return null for non-existent task', async () => {
       const result = await useTaskStore.getState().duplicate('non-existent')
 
       expect(result).toBeNull()
-      expect(mockIpc.createTask).not.toHaveBeenCalled()
+      expect(mockIpc.duplicateTask).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -382,7 +382,7 @@ describe('task-store', () => {
     it('should duplicate task', async () => {
       const duplicatedTask = createMockTask({
         id: 'task-dup',
-        title: 'Original Task (Copy)',
+        title: 'Original Task (copy)',
         description: 'Some description',
       })
       mockIpc.duplicateTask.mockResolvedValueOnce(duplicatedTask)
@@ -396,7 +396,7 @@ describe('task-store', () => {
     })
 
     it('should add duplicated task to store', async () => {
-      const duplicatedTask = createMockTask({ id: 'task-dup', title: 'Original Task (Copy)' })
+      const duplicatedTask = createMockTask({ id: 'task-dup', title: 'Original Task (copy)' })
       mockIpc.duplicateTask.mockResolvedValueOnce(duplicatedTask)
 
       await useTaskStore.getState().duplicate('task-1')
@@ -404,6 +404,34 @@ describe('task-store', () => {
       const state = useTaskStore.getState()
       expect(state.tasks).toHaveLength(2)
       expect(state.tasks).toContainEqual(duplicatedTask)
+    })
+
+    it('should shift following tasks in the same column', async () => {
+      useTaskStore.setState({
+        tasks: [
+          createMockTask({ id: 'task-1', columnId: 'col-1', position: 0 }),
+          createMockTask({ id: 'task-2', columnId: 'col-1', position: 1 }),
+          createMockTask({ id: 'task-3', columnId: 'col-2', position: 1 }),
+        ],
+      })
+      const duplicatedTask = createMockTask({
+        id: 'task-dup',
+        columnId: 'col-1',
+        position: 1,
+        title: 'Original Task (copy)',
+      })
+      mockIpc.duplicateTask.mockResolvedValueOnce(duplicatedTask)
+
+      await useTaskStore.getState().duplicate('task-1')
+
+      const tasks = useTaskStore.getState().tasks
+      expect(tasks.find((task) => task.id === 'task-2')?.position).toBe(2)
+      expect(tasks.find((task) => task.id === 'task-3')?.position).toBe(1)
+      expect(useTaskStore.getState().getByColumn('col-1').map((task) => task.id)).toEqual([
+        'task-1',
+        'task-dup',
+        'task-2',
+      ])
     })
 
     it('should return null for non-existent task', async () => {

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -169,7 +169,16 @@ export const useTaskStore = create<TaskState>()(
         const original = get().tasks.find((t) => t.id === id)
         if (!original) return null
         const task = await ipc.duplicateTask(original.id)
-        set((s) => ({ tasks: [...s.tasks, task] }))
+        set((s) => ({
+          tasks: [
+            ...s.tasks.map((existing) =>
+              existing.columnId === task.columnId && existing.position >= task.position
+                ? { ...existing, position: existing.position + 1 }
+                : existing,
+            ),
+            task,
+          ],
+        }))
         await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
         return task
       },

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -168,15 +168,7 @@ export const useTaskStore = create<TaskState>()(
       duplicate: async (id) => {
         const original = get().tasks.find((t) => t.id === id)
         if (!original) return null
-        const newTitle = original.title.endsWith(' (Copy)')
-          ? original.title
-          : `${original.title} (Copy)`
-        const task = await ipc.createTask(
-          original.workspaceId,
-          original.columnId,
-          newTitle,
-          original.description,
-        )
+        const task = await ipc.duplicateTask(original.id)
         set((s) => ({ tasks: [...s.tasks, task] }))
         await useWorkspaceStore.getState().refreshWorkspace(original.workspaceId)
         return task


### PR DESCRIPTION
## Description

Right-click on task → Duplicate. Creates a copy with title suffixed " (copy)", same description/labels, in the same column, position right after original. Add Tauri command duplicate_task. Acceptance: duplicate works, deep copy of metadata, no shared agent_session reference, npm run type-check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/task-duplication-via-context-menu` → `staging/2026-05-01-bento-ya-recovery`

## Commits

```
2dfe551 Polish task duplication state handling
ad1bfbc Fix duplicated task runtime state
1ab9879 Add task duplication command
5b2ca05 Implement backend task duplication and wire IPC/store flow
```

## Changes

```
src-tauri/src/commands/task.rs |  17 ++++
 src-tauri/src/db/task.rs       | 196 +++++++++++++++++++++++++++++++++++++++++
 src-tauri/src/lib.rs           |   1 +
 src/lib/ipc/task.ts            |   4 +
 src/stores/task-store.test.ts  |  46 ++++++----
 src/stores/task-store.ts       |  21 ++---
 6 files changed, 258 insertions(+), 27 deletions(-)
```