### PR TITLE
Window state persistence — remember size, position, zoom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-shell",
  "tauri-plugin-webdriver-automation",
+ "tauri-plugin-window-state",
  "thiserror 1.0.69",
  "tokio",
  "uuid",
@@ -4907,6 +4908,21 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-window-state = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "shell:allow-open",
     "dialog:allow-open",
-    "fs:allow-read"
+    "fs:allow-read",
+    "window-state:default",
+    "core:webview:allow-set-webview-zoom"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,8 @@ use chat::registry::{new_shared_session_registry, start_idle_sweep};
 use commands::voice::RecorderState;
 use db::AppState;
 use tauri::Manager;
+#[cfg(desktop)]
+use tauri_plugin_window_state::StateFlags;
 #[cfg(feature = "voice")]
 use whisper::AudioRecorder;
 
@@ -79,7 +81,16 @@ pub fn run() {
     }
 
     #[cfg(desktop)]
-    let builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
+    let builder = builder.plugin(
+        tauri_plugin_window_state::Builder::default()
+            .with_state_flags(
+                StateFlags::SIZE
+                    | StateFlags::POSITION
+                    | StateFlags::MAXIMIZED
+                    | StateFlags::FULLSCREEN,
+            )
+            .build(),
+    );
 
     builder
         .on_window_event(move |_window, event| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,9 @@ pub fn run() {
         builder = builder.manage(recorder_state);
     }
 
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
+
     builder
         .on_window_event(move |_window, event| {
             if let tauri::WindowEvent::Destroyed = event {

--- a/src/components/settings/tabs/github-tab.tsx
+++ b/src/components/settings/tabs/github-tab.tsx
@@ -52,7 +52,7 @@ export function GithubTab() {
       setLastSyncedAt(new Date().toISOString())
       setMessage({
         type: 'success',
-        text: `Synced: ${result.tasksCreated} task(s) created, ${result.issuesFetched} issue(s) fetched`,
+        text: `Synced: ${String(result.tasksCreated)} task(s) created, ${String(result.issuesFetched)} issue(s) fetched`,
       })
     } catch (err) {
       setMessage({

--- a/src/lib/window-state.test.ts
+++ b/src/lib/window-state.test.ts
@@ -14,7 +14,8 @@ type TauriWindow = Window & { __TAURI_INTERNALS__?: unknown }
 describe('window zoom state', () => {
   beforeEach(() => {
     window.localStorage.clear()
-    setZoom.mockClear()
+    setZoom.mockReset()
+    setZoom.mockResolvedValue(undefined)
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
       value: {},
@@ -32,6 +33,12 @@ describe('window zoom state', () => {
     await initializeWindowZoomState()
 
     expect(setZoom).toHaveBeenCalledWith(1.25)
+  })
+
+  it('does not reset zoom when no persisted zoom exists', async () => {
+    await initializeWindowZoomState()
+
+    expect(setZoom).not.toHaveBeenCalled()
   })
 
   it('persists app zoom keyboard shortcuts', async () => {
@@ -70,5 +77,71 @@ describe('window zoom state', () => {
       expect(setZoom).toHaveBeenLastCalledWith(1)
     })
     expect(window.localStorage.getItem('bento-window-zoom')).toBe('1')
+  })
+
+  it('serializes rapid zoom shortcuts so stale writes cannot win', async () => {
+    const resolveZoom: Array<() => void> = []
+    setZoom.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveZoom.push(resolve)
+        }),
+    )
+
+    await initializeWindowZoomState()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: '=',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: '=',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(setZoom).toHaveBeenCalledTimes(1)
+    })
+    expect(setZoom).toHaveBeenCalledWith(1.1)
+
+    expect(resolveZoom[0]).toBeDefined()
+    resolveZoom[0]?.()
+    await vi.waitFor(() => {
+      expect(setZoom).toHaveBeenCalledTimes(2)
+    })
+    expect(setZoom).toHaveBeenLastCalledWith(1.2)
+
+    expect(resolveZoom[1]).toBeDefined()
+    resolveZoom[1]?.()
+    await vi.waitFor(() => {
+      expect(window.localStorage.getItem('bento-window-zoom')).toBe('1.2')
+    })
+  })
+
+  it('keeps only one shortcut listener when initialized again', async () => {
+    await initializeWindowZoomState()
+    await initializeWindowZoomState()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: '=',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(setZoom).toHaveBeenCalledTimes(1)
+    })
+    expect(setZoom).toHaveBeenCalledWith(1.1)
   })
 })

--- a/src/lib/window-state.test.ts
+++ b/src/lib/window-state.test.ts
@@ -11,6 +11,16 @@ vi.mock('@tauri-apps/api/webview', () => ({
 
 type TauriWindow = Window & { __TAURI_INTERNALS__?: unknown }
 
+const ZOOM_KEY = 'bento-window-zoom'
+
+const zoomInEvent = () =>
+  new KeyboardEvent('keydown', {
+    key: '=',
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  })
+
 describe('window zoom state', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -28,7 +38,7 @@ describe('window zoom state', () => {
   })
 
   it('restores persisted zoom on startup', async () => {
-    window.localStorage.setItem('bento-window-zoom', '1.25')
+    window.localStorage.setItem(ZOOM_KEY, '1.25')
 
     await initializeWindowZoomState()
 
@@ -44,24 +54,18 @@ describe('window zoom state', () => {
   it('persists app zoom keyboard shortcuts', async () => {
     await initializeWindowZoomState()
 
-    const event = new KeyboardEvent('keydown', {
-      key: '=',
-      metaKey: true,
-      bubbles: true,
-      cancelable: true,
-    })
-
+    const event = zoomInEvent()
     window.dispatchEvent(event)
 
     await vi.waitFor(() => {
       expect(setZoom).toHaveBeenCalledWith(1.1)
     })
     expect(event.defaultPrevented).toBe(true)
-    expect(window.localStorage.getItem('bento-window-zoom')).toBe('1.1')
+    expect(window.localStorage.getItem(ZOOM_KEY)).toBe('1.1')
   })
 
   it('resets app zoom with the standard shortcut', async () => {
-    window.localStorage.setItem('bento-window-zoom', '1.4')
+    window.localStorage.setItem(ZOOM_KEY, '1.4')
     await initializeWindowZoomState()
 
     window.dispatchEvent(
@@ -76,7 +80,7 @@ describe('window zoom state', () => {
     await vi.waitFor(() => {
       expect(setZoom).toHaveBeenLastCalledWith(1)
     })
-    expect(window.localStorage.getItem('bento-window-zoom')).toBe('1')
+    expect(window.localStorage.getItem(ZOOM_KEY)).toBe('1')
   })
 
   it('serializes rapid zoom shortcuts so stale writes cannot win', async () => {
@@ -90,22 +94,8 @@ describe('window zoom state', () => {
 
     await initializeWindowZoomState()
 
-    window.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: '=',
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
-    window.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: '=',
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
+    window.dispatchEvent(zoomInEvent())
+    window.dispatchEvent(zoomInEvent())
 
     await vi.waitFor(() => {
       expect(setZoom).toHaveBeenCalledTimes(1)
@@ -122,7 +112,7 @@ describe('window zoom state', () => {
     expect(resolveZoom[1]).toBeDefined()
     resolveZoom[1]?.()
     await vi.waitFor(() => {
-      expect(window.localStorage.getItem('bento-window-zoom')).toBe('1.2')
+      expect(window.localStorage.getItem(ZOOM_KEY)).toBe('1.2')
     })
   })
 
@@ -130,14 +120,7 @@ describe('window zoom state', () => {
     await initializeWindowZoomState()
     await initializeWindowZoomState()
 
-    window.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: '=',
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
+    window.dispatchEvent(zoomInEvent())
 
     await vi.waitFor(() => {
       expect(setZoom).toHaveBeenCalledTimes(1)

--- a/src/lib/window-state.test.ts
+++ b/src/lib/window-state.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initializeWindowZoomState } from './window-state'
+
+const setZoom = vi.hoisted(() => vi.fn(() => Promise.resolve()))
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    setZoom,
+  }),
+}))
+
+type TauriWindow = Window & { __TAURI_INTERNALS__?: unknown }
+
+describe('window zoom state', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setZoom.mockClear()
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+  })
+
+  afterEach(() => {
+    window.dispatchEvent(new Event('pagehide'))
+    Reflect.deleteProperty(window as TauriWindow, '__TAURI_INTERNALS__')
+  })
+
+  it('restores persisted zoom on startup', async () => {
+    window.localStorage.setItem('bento-window-zoom', '1.25')
+
+    await initializeWindowZoomState()
+
+    expect(setZoom).toHaveBeenCalledWith(1.25)
+  })
+
+  it('persists app zoom keyboard shortcuts', async () => {
+    await initializeWindowZoomState()
+
+    const event = new KeyboardEvent('keydown', {
+      key: '=',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    window.dispatchEvent(event)
+
+    await vi.waitFor(() => {
+      expect(setZoom).toHaveBeenCalledWith(1.1)
+    })
+    expect(event.defaultPrevented).toBe(true)
+    expect(window.localStorage.getItem('bento-window-zoom')).toBe('1.1')
+  })
+
+  it('resets app zoom with the standard shortcut', async () => {
+    window.localStorage.setItem('bento-window-zoom', '1.4')
+    await initializeWindowZoomState()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: '0',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(setZoom).toHaveBeenLastCalledWith(1)
+    })
+    expect(window.localStorage.getItem('bento-window-zoom')).toBe('1')
+  })
+})

--- a/src/lib/window-state.ts
+++ b/src/lib/window-state.ts
@@ -16,9 +16,12 @@ const inRange = (value: number): number => {
 const hasTauriInternals = (): boolean =>
   typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
+let cleanupWindowZoomState: (() => void) | null = null
+
 const readPersistedZoom = (): number | null => {
   try {
     const raw = window.localStorage.getItem(WINDOW_ZOOM_KEY)
+    if (raw === null || raw.trim() === '') return null
     const parsed = Number(raw)
     if (!Number.isFinite(parsed)) return null
     return inRange(parsed)
@@ -59,13 +62,24 @@ export async function initializeWindowZoomState(): Promise<void> {
     return
   }
 
+  cleanupWindowZoomState?.()
+  cleanupWindowZoomState = null
+
   const webview = getCurrentWebview()
   let currentZoom = readPersistedZoom() ?? 1
+  let zoomQueue = Promise.resolve()
 
-  const applyZoom = async (zoom: number): Promise<void> => {
-    currentZoom = inRange(zoom)
-    await webview.setZoom(currentZoom)
-    writePersistedZoom(currentZoom)
+  const applyZoom = (zoom: number): Promise<void> => {
+    const nextZoom = inRange(zoom)
+    currentZoom = nextZoom
+
+    const setAndPersist = async (): Promise<void> => {
+      await webview.setZoom(nextZoom)
+      writePersistedZoom(nextZoom)
+    }
+
+    zoomQueue = zoomQueue.then(setAndPersist, setAndPersist)
+    return zoomQueue
   }
 
   const persistedZoom = readPersistedZoom()
@@ -85,8 +99,14 @@ export async function initializeWindowZoomState(): Promise<void> {
 
   const cleanup = (): void => {
     window.removeEventListener('keydown', handleKeyDown)
+    window.removeEventListener('pagehide', cleanup)
+    window.removeEventListener('beforeunload', cleanup)
+    if (cleanupWindowZoomState === cleanup) {
+      cleanupWindowZoomState = null
+    }
   }
 
-  window.addEventListener('pagehide', cleanup, { once: true })
-  window.addEventListener('beforeunload', cleanup, { once: true })
+  cleanupWindowZoomState = cleanup
+  window.addEventListener('pagehide', cleanup)
+  window.addEventListener('beforeunload', cleanup)
 }

--- a/src/lib/window-state.ts
+++ b/src/lib/window-state.ts
@@ -1,0 +1,67 @@
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { getCurrentWebview } from '@tauri-apps/api/webview'
+
+const WINDOW_ZOOM_KEY = 'bento-window-zoom'
+const MIN_ZOOM = 0.2
+const MAX_ZOOM = 5
+
+const inRange = (value: number): number => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 1
+  }
+  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, value))
+}
+
+const hasTauriInternals = (): boolean =>
+  typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+
+const readPersistedZoom = (): number | null => {
+  try {
+    const raw = window.localStorage.getItem(WINDOW_ZOOM_KEY)
+    const parsed = Number(raw)
+    if (!Number.isFinite(parsed)) return null
+    return inRange(parsed)
+  } catch {
+    return null
+  }
+}
+
+const writePersistedZoom = (zoom: number): void => {
+  try {
+    window.localStorage.setItem(WINDOW_ZOOM_KEY, String(inRange(zoom)))
+  } catch {
+    // Ignore localStorage failures in restricted environments.
+  }
+}
+
+export async function initializeWindowZoomState(): Promise<void> {
+  if (typeof window === 'undefined' || !hasTauriInternals()) {
+    return
+  }
+
+  const webview = getCurrentWebview()
+  const windowApi = getCurrentWindow()
+
+  const persistedZoom = readPersistedZoom()
+  if (persistedZoom !== null) {
+    await webview.setZoom(persistedZoom).catch(() => undefined)
+  }
+
+  try {
+    const unlisten = await windowApi.onScaleChanged(({ payload }) => {
+      const scale = Number((payload as { scaleFactor?: unknown }).scaleFactor)
+      if (Number.isFinite(scale)) {
+        writePersistedZoom(scale)
+      }
+    })
+    window.addEventListener('pagehide', () => {
+      void unlisten()
+    })
+    window.addEventListener('beforeunload', () => {
+      void unlisten()
+    })
+  } catch {
+    // Ignore environments where scale-change tracking is unsupported.
+  }
+}
+

--- a/src/lib/window-state.ts
+++ b/src/lib/window-state.ts
@@ -5,7 +5,7 @@ const MIN_ZOOM = 0.2
 const MAX_ZOOM = 5
 const ZOOM_STEP = 0.1
 
-const inRange = (value: number): number => {
+const normalizeZoom = (value: number): number => {
   if (!Number.isFinite(value) || value <= 0) {
     return 1
   }
@@ -24,7 +24,7 @@ const readPersistedZoom = (): number | null => {
     if (raw === null || raw.trim() === '') return null
     const parsed = Number(raw)
     if (!Number.isFinite(parsed)) return null
-    return inRange(parsed)
+    return normalizeZoom(parsed)
   } catch {
     return null
   }
@@ -32,7 +32,7 @@ const readPersistedZoom = (): number | null => {
 
 const writePersistedZoom = (zoom: number): void => {
   try {
-    window.localStorage.setItem(WINDOW_ZOOM_KEY, String(inRange(zoom)))
+    window.localStorage.setItem(WINDOW_ZOOM_KEY, String(normalizeZoom(zoom)))
   } catch {
     // Ignore localStorage failures in restricted environments.
   }
@@ -66,11 +66,12 @@ export async function initializeWindowZoomState(): Promise<void> {
   cleanupWindowZoomState = null
 
   const webview = getCurrentWebview()
-  let currentZoom = readPersistedZoom() ?? 1
+  const persistedZoom = readPersistedZoom()
+  let currentZoom = persistedZoom ?? 1
   let zoomQueue = Promise.resolve()
 
   const applyZoom = (zoom: number): Promise<void> => {
-    const nextZoom = inRange(zoom)
+    const nextZoom = normalizeZoom(zoom)
     currentZoom = nextZoom
 
     const setAndPersist = async (): Promise<void> => {
@@ -82,7 +83,6 @@ export async function initializeWindowZoomState(): Promise<void> {
     return zoomQueue
   }
 
-  const persistedZoom = readPersistedZoom()
   if (persistedZoom !== null) {
     await applyZoom(persistedZoom).catch(() => undefined)
   }

--- a/src/lib/window-state.ts
+++ b/src/lib/window-state.ts
@@ -1,15 +1,16 @@
-import { getCurrentWindow } from '@tauri-apps/api/window'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 
 const WINDOW_ZOOM_KEY = 'bento-window-zoom'
 const MIN_ZOOM = 0.2
 const MAX_ZOOM = 5
+const ZOOM_STEP = 0.1
 
 const inRange = (value: number): number => {
   if (!Number.isFinite(value) || value <= 0) {
     return 1
   }
-  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, value))
+  const clamped = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, value))
+  return Math.round(clamped * 100) / 100
 }
 
 const hasTauriInternals = (): boolean =>
@@ -34,34 +35,58 @@ const writePersistedZoom = (zoom: number): void => {
   }
 }
 
+const getShortcutZoom = (event: KeyboardEvent, currentZoom: number): number | null => {
+  if (!(event.metaKey || event.ctrlKey) || event.altKey) {
+    return null
+  }
+
+  switch (event.key) {
+    case '+':
+    case '=':
+      return currentZoom + ZOOM_STEP
+    case '-':
+    case '_':
+      return currentZoom - ZOOM_STEP
+    case '0':
+      return 1
+    default:
+      return null
+  }
+}
+
 export async function initializeWindowZoomState(): Promise<void> {
   if (typeof window === 'undefined' || !hasTauriInternals()) {
     return
   }
 
   const webview = getCurrentWebview()
-  const windowApi = getCurrentWindow()
+  let currentZoom = readPersistedZoom() ?? 1
+
+  const applyZoom = async (zoom: number): Promise<void> => {
+    currentZoom = inRange(zoom)
+    await webview.setZoom(currentZoom)
+    writePersistedZoom(currentZoom)
+  }
 
   const persistedZoom = readPersistedZoom()
   if (persistedZoom !== null) {
-    await webview.setZoom(persistedZoom).catch(() => undefined)
+    await applyZoom(persistedZoom).catch(() => undefined)
   }
 
-  try {
-    const unlisten = await windowApi.onScaleChanged(({ payload }) => {
-      const scale = Number((payload as { scaleFactor?: unknown }).scaleFactor)
-      if (Number.isFinite(scale)) {
-        writePersistedZoom(scale)
-      }
-    })
-    window.addEventListener('pagehide', () => {
-      void unlisten()
-    })
-    window.addEventListener('beforeunload', () => {
-      void unlisten()
-    })
-  } catch {
-    // Ignore environments where scale-change tracking is unsupported.
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    const nextZoom = getShortcutZoom(event, currentZoom)
+    if (nextZoom === null) return
+
+    event.preventDefault()
+    void applyZoom(nextZoom).catch(() => undefined)
   }
+
+  window.addEventListener('keydown', handleKeyDown)
+
+  const cleanup = (): void => {
+    window.removeEventListener('keydown', handleKeyDown)
+  }
+
+  window.addEventListener('pagehide', cleanup, { once: true })
+  window.addEventListener('beforeunload', cleanup, { once: true })
 }
-

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,12 @@ import App from './app'
 import './index.css'
 import { initializeAppearance } from './lib/appearance'
 import { initializeTheme } from './lib/theme'
+import { initializeWindowZoomState } from './lib/window-state'
 
 // Apply saved theme and appearance settings before render
 initializeTheme()
 initializeAppearance()
+void initializeWindowZoomState()
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Description

Persist Tauri window state across launches: size, position, maximized state, zoom level. Use tauri-plugin-window-state or implement custom via app config. Acceptance: resize+move window, restart app, window restores to last position. cargo check passes.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/window-state-persistence-remember-size-position-zo` → `staging/2026-05-01-final-cleanup`

## Commits

```
806c990 Reduce DRY violations in window-state test
81a06a4 Clean up window state quality issues
28014a2 Fix window zoom persistence edge cases
b1bec4f Persist window geometry and zoom state
aca6159 Persist window state and restore zoom on startup
```

## Changes

```
Cargo.lock                                  |  16 ++++
 src-tauri/Cargo.toml                        |   1 +
 src-tauri/capabilities/default.json         |   4 +-
 src-tauri/src/lib.rs                        |  14 +++
 src/components/settings/tabs/github-tab.tsx |   2 +-
 src/lib/window-state.test.ts                | 130 ++++++++++++++++++++++++++++
 src/lib/window-state.ts                     | 112 ++++++++++++++++++++++++
 src/main.tsx                                |   2 +
 8 files changed, 279 insertions(+), 2 deletions(-)
```