### PR TITLE
Add workspace-level batch management UI

### DIFF
--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -1619,6 +1619,130 @@ pub async fn remove_task_worktree(
     Ok(updated)
 }
 
+// ─── Batch Management Commands ───────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchSummary {
+    pub batch_id: String,
+    pub task_count: i64,
+    pub failed_count: i64,
+    pub tasks: Vec<Task>,
+    pub created_at: String,
+}
+
+/// List all batches for a workspace grouped by batch_id, newest first.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn list_batches(
+    state: State<'_, AppState>,
+    workspace_id: String,
+) -> Result<Vec<BatchSummary>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT DISTINCT batch_id FROM tasks \
+             WHERE workspace_id = ?1 AND batch_id IS NOT NULL \
+             ORDER BY batch_id DESC",
+        )
+        .map_err(AppError::from)?;
+
+    let batch_ids: Vec<String> = stmt
+        .query_map(rusqlite::params![workspace_id], |row| row.get(0))
+        .map_err(AppError::from)?
+        .collect::<Result<_, _>>()
+        .map_err(AppError::from)?;
+
+    let mut summaries = Vec::new();
+    for batch_id in batch_ids {
+        let tasks = db::list_tasks_by_batch_id(&conn, &workspace_id, &batch_id)?;
+        if tasks.is_empty() {
+            continue;
+        }
+        let task_count = tasks.len() as i64;
+        let failed_count = tasks
+            .iter()
+            .filter(|t| t.pipeline_error.is_some())
+            .count() as i64;
+        let created_at = tasks
+            .first()
+            .map(|t| t.created_at.clone())
+            .unwrap_or_default();
+
+        summaries.push(BatchSummary {
+            batch_id,
+            task_count,
+            failed_count,
+            tasks,
+            created_at,
+        });
+    }
+
+    Ok(summaries)
+}
+
+/// Force-create the batch staging PR even if not all tasks have PRs yet.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn force_merge_batch(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    batch_id: String,
+) -> Result<Option<String>, AppError> {
+    let repo_path = {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        db::get_workspace(&conn, &workspace_id)?.repo_path
+    };
+
+    tokio::task::spawn_blocking(move || {
+        pipeline::triggers::force_create_batch_pr(&repo_path, &batch_id, "main")
+    })
+    .await
+    .map_err(|e| AppError::CommandError(e.to_string()))?
+    .map_err(AppError::CommandError)
+}
+
+/// Retry all failed tasks in a batch by re-firing their column triggers.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn retry_batch(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    workspace_id: String,
+    batch_id: String,
+) -> Result<Vec<Task>, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    let tasks = db::list_tasks_by_batch_id(&conn, &workspace_id, &batch_id)?;
+    let failed: Vec<Task> = tasks
+        .into_iter()
+        .filter(|t| t.pipeline_error.is_some())
+        .collect();
+
+    let mut retried = Vec::new();
+    for task in &failed {
+        let column = db::get_column(&conn, &task.column_id)?;
+        let cleared = db::update_task_pipeline_state(&conn, &task.id, "idle", None, None)?;
+        match pipeline::fire_trigger(&conn, &app, &cleared, &column) {
+            Ok(fired) => retried.push(fired),
+            Err(e) => log::warn!("[retry_batch] Failed to retry task {}: {}", task.id, e),
+        }
+    }
+
+    if !retried.is_empty() {
+        pipeline::emit_tasks_changed(&app, &workspace_id, "batch_retry");
+    }
+
+    Ok(retried)
+}
+
 #[cfg(test)]
 mod tests {
     use super::validate_template_labels;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -159,6 +159,10 @@ pub fn run() {
             commands::task::queue_backlog,
             commands::task::create_task_worktree,
             commands::task::remove_task_worktree,
+            // Batch management
+            commands::task::list_batches,
+            commands::task::force_merge_batch,
+            commands::task::retry_batch,
             // Git commands
             commands::git::create_task_branch,
             commands::git::switch_branch,

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -1309,6 +1309,18 @@ fn open_batch_pr_exists(
     Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
+/// Force-create a batch staging PR without checking if all tasks have PRs.
+/// Used by the batch management UI to manually merge incomplete batches.
+pub fn force_create_batch_pr(
+    repo_path: &str,
+    batch_id: &str,
+    base_branch: &str,
+) -> Result<Option<String>, String> {
+    let normalized = normalize_batch_id(batch_id).unwrap_or_else(|| batch_id.to_string());
+    let staging_branch = staging_branch_for_batch(&normalized);
+    maybe_create_batch_pr(repo_path, &normalized, base_branch, &staging_branch)
+}
+
 fn maybe_create_batch_pr(
     repo_path: &str,
     batch_id: &str,

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -11,6 +11,7 @@ import { GitTab } from './tabs/git-tab'
 import { GithubTab } from './tabs/github-tab'
 import { ShortcutsTab } from './tabs/shortcuts-tab'
 import { UpdatesTab } from './tabs/updates-tab'
+import { BatchesTab } from './tabs/batches-tab'
 
 // SVG Icons for settings tabs
 const icons: Record<string, React.ReactNode> = {
@@ -61,6 +62,11 @@ const icons: Record<string, React.ReactNode> = {
       <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H3.989a.75.75 0 0 0-.75.75v4.242a.75.75 0 0 0 1.5 0v-2.43l.31.31a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39Zm1.23-3.723a.75.75 0 0 0 .219-.53V2.929a.75.75 0 0 0-1.5 0V5.36l-.31-.31A7 7 0 0 0 3.239 8.188a.75.75 0 1 0 1.448.389A5.5 5.5 0 0 1 13.89 6.11l.311.31h-2.432a.75.75 0 0 0 0 1.5h4.243a.75.75 0 0 0 .53-.219Z" clipRule="evenodd" />
     </svg>
   ),
+  batches: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+      <path fillRule="evenodd" d="M2 4.25A2.25 2.25 0 0 1 4.25 2h2.5A2.25 2.25 0 0 1 9 4.25v2.5A2.25 2.25 0 0 1 6.75 9h-2.5A2.25 2.25 0 0 1 2 6.75v-2.5Zm0 9A2.25 2.25 0 0 1 4.25 11h2.5A2.25 2.25 0 0 1 9 13.25v2.5A2.25 2.25 0 0 1 6.75 18h-2.5A2.25 2.25 0 0 1 2 15.75v-2.5Zm9-9A2.25 2.25 0 0 1 13.25 2h2.5A2.25 2.25 0 0 1 18 4.25v2.5A2.25 2.25 0 0 1 15.75 9h-2.5A2.25 2.25 0 0 1 11 6.75v-2.5Zm0 9A2.25 2.25 0 0 1 13.25 11h2.5A2.25 2.25 0 0 1 18 13.25v2.5A2.25 2.25 0 0 1 15.75 18h-2.5A2.25 2.25 0 0 1 11 15.75v-2.5Z" clipRule="evenodd" />
+    </svg>
+  ),
 }
 
 const TABS = [
@@ -71,6 +77,7 @@ const TABS = [
   { id: 'board', label: 'Board' },
   { id: 'voice', label: 'Voice' },
   { id: 'github', label: 'GitHub' },
+  { id: 'batches', label: 'Batches' },
   { id: 'updates', label: 'Updates' },
   { id: 'advanced', label: 'Advanced' },
 ] as const
@@ -97,6 +104,8 @@ export function SettingsPanel() {
         return <VoiceTab />
       case 'github':
         return <GithubTab />
+      case 'batches':
+        return <BatchesTab />
       case 'updates':
         return <UpdatesTab />
       case 'advanced':

--- a/src/components/settings/tabs/batches-tab.tsx
+++ b/src/components/settings/tabs/batches-tab.tsx
@@ -1,0 +1,277 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { BatchSummary, Task } from '@/types'
+import * as ipc from '@/lib/ipc'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+
+// ─── BatchesTab ──────────────────────────────────────────────────────────────
+
+export function BatchesTab() {
+  const workspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
+  const [batches, setBatches] = useState<BatchSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [merging, setMerging] = useState<string | null>(null)
+  const [retrying, setRetrying] = useState<string | null>(null)
+  const [message, setMessage] = useState<{ text: string; kind: 'success' | 'error' } | null>(null)
+
+  const load = useCallback(async () => {
+    if (!workspaceId) return
+    setLoading(true)
+    try {
+      const result = await ipc.listBatches(workspaceId)
+      setBatches(result)
+    } catch (err) {
+      console.error('Failed to load batches:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [workspaceId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const handleForceMerge = useCallback(
+    (batchId: string) => {
+      if (!workspaceId) return
+      setMerging(batchId)
+      setMessage(null)
+      void (async () => {
+        try {
+          const prUrl = await ipc.forceMergeBatch(workspaceId, batchId)
+          setMessage({
+            text: prUrl
+              ? `PR created: ${prUrl}`
+              : 'Batch PR already exists or staging branch has no commits.',
+            kind: 'success',
+          })
+          void load()
+        } catch (err) {
+          setMessage({ text: String(err), kind: 'error' })
+        } finally {
+          setMerging(null)
+        }
+      })()
+    },
+    [workspaceId, load],
+  )
+
+  const handleRetry = useCallback(
+    (batchId: string) => {
+      if (!workspaceId) return
+      setRetrying(batchId)
+      setMessage(null)
+      void (async () => {
+        try {
+          const retried = await ipc.retryBatch(workspaceId, batchId)
+          setMessage({ text: `Retried ${String(retried.length)} task(s).`, kind: 'success' })
+          void load()
+        } catch (err) {
+          setMessage({ text: String(err), kind: 'error' })
+        } finally {
+          setRetrying(null)
+        }
+      })()
+    },
+    [workspaceId, load],
+  )
+
+  const handleRefresh = useCallback(() => {
+    void load()
+  }, [load])
+
+  if (!workspaceId) {
+    return <div className="text-sm text-text-secondary">No workspace selected.</div>
+  }
+
+  if (loading) {
+    return <div className="text-sm text-text-secondary">Loading batches...</div>
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-text-secondary">
+          Batches group related tasks queued together for staging-branch PR workflows.
+        </p>
+        <button
+          onClick={handleRefresh}
+          className="rounded px-2 py-1 text-xs text-text-secondary hover:bg-surface hover:text-text-primary transition-colors"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {message && (
+        <div
+          className={`rounded-lg p-3 text-sm ${
+            message.kind === 'success'
+              ? 'bg-green-500/10 text-green-400'
+              : 'bg-red-500/10 text-red-400'
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      {batches.length === 0 ? (
+        <div className="rounded-lg border border-border-default bg-surface/50 p-6 text-center text-sm text-text-secondary">
+          No batches found for this workspace.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {batches.map((batch) => (
+            <BatchCard
+              key={batch.batchId}
+              batch={batch}
+              isMerging={merging === batch.batchId}
+              isRetrying={retrying === batch.batchId}
+              onForceMerge={handleForceMerge}
+              onRetry={handleRetry}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── BatchCard ───────────────────────────────────────────────────────────────
+
+type BatchCardProps = {
+  batch: BatchSummary
+  isMerging: boolean
+  isRetrying: boolean
+  onForceMerge: (batchId: string) => void
+  onRetry: (batchId: string) => void
+}
+
+function BatchCard({ batch, isMerging, isRetrying, onForceMerge, onRetry }: BatchCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const succeededCount = batch.tasks.filter(
+    (t) => t.prNumber != null && !t.pipelineError,
+  ).length
+  const pendingCount = Math.max(0, batch.taskCount - succeededCount - batch.failedCount)
+  const allComplete = succeededCount === batch.taskCount
+
+  const handleToggleExpand = () => {
+    setExpanded((v) => !v)
+  }
+
+  const handleForceMergeClick = () => {
+    onForceMerge(batch.batchId)
+  }
+
+  const handleRetryClick = () => {
+    onRetry(batch.batchId)
+  }
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface/30">
+      {/* Header row */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button
+          onClick={handleToggleExpand}
+          className="shrink-0 text-text-secondary hover:text-text-primary transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className={`h-4 w-4 transition-transform ${expanded ? 'rotate-90' : ''}`}
+          >
+            <path
+              fillRule="evenodd"
+              d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+
+        <div className="min-w-0 flex-1">
+          <code className="text-xs font-mono text-text-primary">{batch.batchId}</code>
+          <div className="mt-0.5 flex items-center gap-3 text-xs text-text-secondary">
+            <span>
+              {batch.taskCount} task{batch.taskCount !== 1 ? 's' : ''}
+            </span>
+            <span className="text-green-400">
+              {succeededCount} PR{succeededCount !== 1 ? 's' : ''}
+            </span>
+            {batch.failedCount > 0 && (
+              <span className="text-red-400">{batch.failedCount} failed</span>
+            )}
+            {pendingCount > 0 && (
+              <span className="text-yellow-400">{pendingCount} pending</span>
+            )}
+            {allComplete && <span className="text-green-400 font-medium">complete</span>}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          {batch.failedCount > 0 && (
+            <button
+              onClick={handleRetryClick}
+              disabled={isRetrying}
+              className="rounded px-2.5 py-1 text-xs font-medium text-yellow-400 border border-yellow-400/30 hover:bg-yellow-400/10 disabled:opacity-50 transition-colors"
+            >
+              {isRetrying ? 'Retrying...' : `Retry ${String(batch.failedCount)} failed`}
+            </button>
+          )}
+          <button
+            onClick={handleForceMergeClick}
+            disabled={isMerging}
+            className="rounded px-2.5 py-1 text-xs font-medium text-accent border border-accent/30 hover:bg-accent/10 disabled:opacity-50 transition-colors"
+          >
+            {isMerging ? 'Merging...' : 'Force Merge'}
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded task list */}
+      {expanded && (
+        <div className="border-t border-border-default px-4 py-2 space-y-1.5">
+          {batch.tasks.map((task) => (
+            <div key={task.id} className="flex items-center gap-2 py-1 text-sm">
+              <StatusDot task={task} />
+              <span className="flex-1 truncate text-text-primary">{task.title}</span>
+              {task.prNumber && (
+                <span className="text-xs text-text-secondary">PR #{task.prNumber}</span>
+              )}
+              {task.pipelineError && (
+                <span
+                  className="max-w-[200px] truncate text-xs text-red-400"
+                  title={task.pipelineError}
+                >
+                  {task.pipelineError}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatusDot({ task }: { task: Task }) {
+  if (task.pipelineError) {
+    return <span className="h-2 w-2 shrink-0 rounded-full bg-red-400" title="Failed" />
+  }
+  if (task.prNumber) {
+    return <span className="h-2 w-2 shrink-0 rounded-full bg-green-400" title="PR created" />
+  }
+  if (task.pipelineState !== 'idle') {
+    return (
+      <span
+        className="h-2 w-2 shrink-0 rounded-full bg-blue-400 animate-pulse"
+        title="Running"
+      />
+    )
+  }
+  return (
+    <span
+      className="h-2 w-2 shrink-0 rounded-full bg-surface border border-border-default"
+      title="Queued"
+    />
+  )
+}

--- a/src/lib/ipc/pipeline.ts
+++ b/src/lib/ipc/pipeline.ts
@@ -1,5 +1,5 @@
 import { invoke, listen, type EventCallback, type UnlistenFn } from './invoke'
-import type { Task } from '@/types'
+import type { Task, BatchSummary } from '@/types'
 
 // ─── Column metrics ────────────────────────────────────────────────────────
 
@@ -65,6 +65,20 @@ export async function cancelBacklogQueue(taskIds: string[]): Promise<void> {
       invoke('update_task_agent_status', { taskId, agentStatus: null, queuedAt: null })
     )
   )
+}
+
+// ─── Batch Management ────────────────────────────────────────────────────────
+
+export async function listBatches(workspaceId: string): Promise<BatchSummary[]> {
+  return invoke<BatchSummary[]>('list_batches', { workspaceId })
+}
+
+export async function forceMergeBatch(workspaceId: string, batchId: string): Promise<string | null> {
+  return invoke<string | null>('force_merge_batch', { workspaceId, batchId })
+}
+
+export async function retryBatch(workspaceId: string, batchId: string): Promise<Task[]> {
+  return invoke<Task[]>('retry_batch', { workspaceId, batchId })
 }
 
 // ─── Pipeline event listeners ───────────────────────────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,7 @@ export type {
   ActionType,
   CliType,
 } from './column'
-export type { Task, TaskChecklistItem, PipelineState, ReviewStatus, PrCiStatus, PrReviewDecision, PrMergeable } from './task'
+export type { Task, TaskChecklistItem, PipelineState, ReviewStatus, PrCiStatus, PrReviewDecision, PrMergeable, BatchSummary } from './task'
 export type { TaskTemplate } from './task-template'
 export type { AgentSession, AgentStatus, AgentMode, AgentMessage } from './agent'
 export type { Script, ScriptStep, BashStep, AgentStep, CheckStep, StepType } from './script'

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -119,3 +119,11 @@ export type SiegeEvent = {
   maxIterations: number
   message: string
 }
+
+export type BatchSummary = {
+  batchId: string
+  taskCount: number
+  failedCount: number
+  tasks: Task[]
+  createdAt: string
+}


### PR DESCRIPTION
## Summary

Adds a **Batches** tab in the settings panel that lists all batches in the active workspace, with per-task status indicators and two actions:

- **Force Merge** — call ``force_create_batch_pr`` to open the staging->main batch PR even if not every task has reached PR state yet (useful when one task is permanently stuck).
- **Retry N failed** — re-fire column triggers for any tasks in the batch with a ``pipeline_error``, after clearing their pipeline state back to ``idle``.

### Backend

- ``commands::task::list_batches`` — groups tasks by ``batch_id`` for a workspace, returns ``BatchSummary { batchId, taskCount, failedCount, tasks, createdAt }``
- ``commands::task::force_merge_batch`` — wraps ``pipeline::triggers::force_create_batch_pr``
- ``commands::task::retry_batch`` — re-fires triggers for all failed tasks in a batch
- ``pipeline::triggers::force_create_batch_pr`` — new ``pub`` helper that normalizes ``batch_id``, derives the staging branch, and calls the existing private ``maybe_create_batch_pr``

### Frontend

- New ``src/components/settings/tabs/batches-tab.tsx`` (BatchesTab + BatchCard + StatusDot)
- New ``BatchSummary`` type + IPC bindings (``listBatches``, ``forceMergeBatch``, ``retryBatch``)
- Wired into ``settings-panel.tsx`` between the GitHub and Updates tabs

Salvaged from the abandoned ``bentoya/workspace-level-batch-id-management-ui`` branch. The original branch was too stale to rebase (it predated github_sync, the updater plugin, window-state, label CRUD, archive, and templates), so the work was re-applied cleanly on top of current main.

## Test plan

- [ ] ``pnpm tauri dev`` then open Settings -> Batches in a workspace with at least one batch
- [ ] Verify task counts and per-task status (pending/running/PR-created/failed) render correctly
- [ ] Click **Force Merge** on a batch with no existing staging PR; confirm a PR URL appears in the success toast
- [ ] Click **Retry N failed** on a batch with a failed task; confirm the task pipeline state resets to ``idle`` and the trigger re-fires
- [ ] Confirm Refresh button re-fetches without flicker