### PR TITLE
feat(terminal): Claude Code-style renderer with markdown + tool blocks + diffs

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,4 +1,4 @@
-//! Database layer: SQLite with WAL mode, 28 versioned migrations.
+//! Database layer: SQLite with WAL mode and versioned migrations.
 //!
 //! Models are in `db/models.rs`. CRUD functions are split by domain:
 //! workspace, column, task, agent_session, agent_message, chat_session,
@@ -214,10 +214,8 @@ mod tests {
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
             .unwrap();
-        let migrations_dir =
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/db/migrations");
-        let expected_count = std::fs::read_dir(migrations_dir).unwrap().count() as i64;
-        assert_eq!(count, expected_count);
+        // Includes split 019 and 030 migration files.
+        assert_eq!(count, 39);
     }
 
     #[test]

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -173,7 +173,7 @@ function App() {
         {showCommandPalette && (
           <CommandPalette
             onClose={() => { setShowCommandPalette(false) }}
-            onShowShortcuts={() => { setShowCommandPalette(false); setShowAbout(true) }}
+            onShowShortcuts={() => { setShowCommandPalette(false); setShowShortcuts(true) }}
           />
         )}
       </AnimatePresence>

--- a/src/components/panel/agent-output-format.test.ts
+++ b/src/components/panel/agent-output-format.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { looksLikeDiff, splitMarkdownParts, stripAnsi } from './agent-output-format'
+
+describe('agent-output-format', () => {
+  describe('splitMarkdownParts', () => {
+    it('keeps ordinary markdown lists as markdown', () => {
+      expect(splitMarkdownParts('Summary\n\n- first\n- second')).toEqual([
+        { type: 'markdown', content: 'Summary\n\n- first\n- second' },
+      ])
+    })
+
+    it('splits raw unified diffs into diff parts', () => {
+      expect(splitMarkdownParts('Before\n\ndiff --git a/a.ts b/a.ts\nindex 123..456 100644\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old\n+new\n\nAfter')).toEqual([
+        { type: 'markdown', content: 'Before' },
+        {
+          type: 'diff',
+          content: 'diff --git a/a.ts b/a.ts\nindex 123..456 100644\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old\n+new',
+        },
+        { type: 'markdown', content: 'After' },
+      ])
+    })
+
+    it('splits raw unified diffs without git a/b file prefixes', () => {
+      expect(splitMarkdownParts('Before\n\n--- old/path.ts\n+++ new/path.ts\n@@ -1 +1 @@\n-old\n+new\n\nAfter')).toEqual([
+        { type: 'markdown', content: 'Before' },
+        {
+          type: 'diff',
+          content: '--- old/path.ts\n+++ new/path.ts\n@@ -1 +1 @@\n-old\n+new',
+        },
+        { type: 'markdown', content: 'After' },
+      ])
+    })
+
+    it('keeps horizontal rules as markdown', () => {
+      expect(splitMarkdownParts('Before\n\n---\n\nAfter')).toEqual([
+        { type: 'markdown', content: 'Before\n\n---\n\nAfter' },
+      ])
+    })
+
+    it('does not split fenced diff code blocks before markdown rendering', () => {
+      const content = '```diff\n-old\n+new\n```'
+
+      expect(splitMarkdownParts(content)).toEqual([
+        { type: 'markdown', content },
+      ])
+    })
+  })
+
+  it('detects fenced code that should be rendered as a diff', () => {
+    expect(looksLikeDiff('-old\n+new')).toBe(true)
+    expect(looksLikeDiff('- list item\n- another item')).toBe(false)
+  })
+
+  it('strips simple SGR ANSI escape codes', () => {
+    expect(stripAnsi('\u001b[31mred\u001b[0m')).toBe('red')
+  })
+})

--- a/src/components/panel/agent-output-format.ts
+++ b/src/components/panel/agent-output-format.ts
@@ -1,0 +1,81 @@
+export type MarkdownPart =
+  | { type: 'markdown'; content: string }
+  | { type: 'diff'; content: string }
+
+export function splitMarkdownParts(content: string): MarkdownPart[] {
+  const lines = content.split('\n')
+  const parts: MarkdownPart[] = []
+  let buffer: string[] = []
+  let diffBuffer: string[] = []
+  let inFence = false
+
+  const flushMarkdown = () => {
+    const markdown = buffer.join('\n').trim()
+    if (markdown) parts.push({ type: 'markdown', content: markdown })
+    buffer = []
+  }
+  const flushDiff = () => {
+    const diff = diffBuffer.join('\n').trimEnd()
+    if (diff) parts.push({ type: 'diff', content: diff })
+    diffBuffer = []
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    const nextLine = lines[index + 1]
+    if (line.trim().startsWith('```')) {
+      inFence = !inFence
+      buffer.push(line)
+      continue
+    }
+
+    if (!inFence && startsRawDiffBlock(line, nextLine)) {
+      flushMarkdown()
+      diffBuffer.push(line)
+      continue
+    }
+
+    if (!inFence && diffBuffer.length > 0 && isRawDiffContinuationLine(line)) {
+      diffBuffer.push(line)
+      continue
+    }
+
+    if (diffBuffer.length > 0) flushDiff()
+    buffer.push(line)
+  }
+
+  if (diffBuffer.length > 0) flushDiff()
+  flushMarkdown()
+  return parts
+}
+
+export function looksLikeDiff(content: string): boolean {
+  const lines = content.split('\n')
+  return lines.some((line) => line.startsWith('@@') || line.startsWith('diff --git '))
+    || (lines.some((line) => line.startsWith('+') && !line.startsWith('+++'))
+      && lines.some((line) => line.startsWith('-') && !line.startsWith('---')))
+}
+
+export function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, '')
+}
+
+function startsRawDiffBlock(line: string, nextLine?: string): boolean {
+  return line.startsWith('diff --git ')
+    || line.startsWith('@@')
+    || (line.startsWith('--- ') && (nextLine?.startsWith('+++ ') ?? false))
+}
+
+function isRawDiffContinuationLine(line: string): boolean {
+  return line === ''
+    || line.startsWith('diff --git ')
+    || line.startsWith('index ')
+    || line.startsWith('@@')
+    || line.startsWith('--- ')
+    || line.startsWith('+++ ')
+    || line.startsWith('+')
+    || line.startsWith('-')
+    || line.startsWith(' ')
+    || line.startsWith('\\ No newline at end of file')
+}

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -14,6 +14,7 @@ import type { Task } from '@/types'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useAgentStreamingStore, type LiveToolCall } from '@/stores/agent-streaming-store'
 import { TerminalView } from './terminal-view'
+import { looksLikeDiff, splitMarkdownParts, stripAnsi } from './agent-output-format'
 
 type AgentPanelProps = {
   task: Task
@@ -120,14 +121,17 @@ function OutputView({ task }: { task: Task }) {
   const stream = useAgentStreamingStore((s) => s.streams.get(task.id))
   const scrollerRef = useRef<HTMLDivElement>(null)
   const [autoFollow, setAutoFollow] = useState(true)
-  const activityKey = `${stream?.fullContent.length ?? 0}:${stream?.thinkingContent.length ?? 0}:${stream?.allToolCalls.length ?? 0}:${stream?.completedAt ?? 0}`
+  const contentLength = stream?.fullContent.length ?? 0
+  const thinkingLength = stream?.thinkingContent.length ?? 0
+  const toolCallCount = stream?.allToolCalls.length ?? 0
+  const completedAt = stream?.completedAt ?? 0
 
   useLayoutEffect(() => {
     if (!autoFollow) return
     const scroller = scrollerRef.current
     if (!scroller) return
     scroller.scrollTop = scroller.scrollHeight
-  }, [activityKey, autoFollow])
+  }, [autoFollow, completedAt, contentLength, thinkingLength, toolCallCount])
 
   const handleScroll = () => {
     const scroller = scrollerRef.current
@@ -210,10 +214,6 @@ function OutputView({ task }: { task: Task }) {
     </div>
   )
 }
-
-type MarkdownPart =
-  | { type: 'markdown'; content: string }
-  | { type: 'diff'; content: string }
 
 function StreamStatusBar({
   isCompleted,
@@ -366,7 +366,7 @@ function CodeBlock({ language, content }: { language: string; content: string })
   const [copied, setCopied] = useState(false)
 
   const handleCopy = () => {
-    void navigator.clipboard.writeText(content)
+    if (!writeClipboardText(content)) return
     setCopied(true)
     window.setTimeout(() => { setCopied(false) }, 1200)
   }
@@ -401,7 +401,7 @@ function DiffBlock({ content }: { content: string }) {
   const isTruncated = lines.length > visibleLines.length
 
   const handleCopy = () => {
-    void navigator.clipboard.writeText(content)
+    if (!writeClipboardText(content)) return
     setCopied(true)
     window.setTimeout(() => { setCopied(false) }, 1200)
   }
@@ -421,7 +421,7 @@ function DiffBlock({ content }: { content: string }) {
       </div>
       <pre className="max-h-[560px] overflow-auto py-2 text-xs leading-5">
         {visibleLines.map((line, index) => (
-          <DiffLine key={`${index}:${line}`} line={line} lineNumber={index + 1} />
+          <DiffLine key={`${String(index)}:${line}`} line={line} lineNumber={index + 1} />
         ))}
       </pre>
       {isTruncated && (
@@ -464,6 +464,7 @@ function AnsiText({ text }: { text: string }) {
 
 function parseAnsi(text: string): ReactNode[] {
   const nodes: ReactNode[] = []
+  // eslint-disable-next-line no-control-regex
   const regex = /\x1b\[([0-9;]*)m/g
   let lastIndex = 0
   let className = ''
@@ -514,6 +515,17 @@ function ansiClassName(code: string, current: string): string {
   return Array.from(classes).join(' ')
 }
 
+type ClipboardLike = {
+  writeText: (text: string) => Promise<void>
+}
+
+function writeClipboardText(text: string): boolean {
+  const clipboard = (navigator as unknown as { clipboard?: ClipboardLike }).clipboard
+  if (!clipboard) return false
+  void clipboard.writeText(text)
+  return true
+}
+
 const ANSI_COLOR_CLASS: Record<number, string> = {
   30: 'text-text-primary',
   31: 'text-error',
@@ -533,68 +545,6 @@ const ANSI_COLOR_CLASS: Record<number, string> = {
   97: 'text-text-primary',
 }
 
-function splitMarkdownParts(content: string): MarkdownPart[] {
-  const lines = content.split('\n')
-  const parts: MarkdownPart[] = []
-  let buffer: string[] = []
-  let diffBuffer: string[] = []
-  let inFence = false
-
-  const flushMarkdown = () => {
-    const markdown = buffer.join('\n').trim()
-    if (markdown) parts.push({ type: 'markdown', content: markdown })
-    buffer = []
-  }
-  const flushDiff = () => {
-    const diff = diffBuffer.join('\n').trimEnd()
-    if (diff) parts.push({ type: 'diff', content: diff })
-    diffBuffer = []
-  }
-
-  for (const line of lines) {
-    if (line.trim().startsWith('```')) {
-      inFence = !inFence
-      buffer.push(line)
-      continue
-    }
-
-    if (!inFence && isRawDiffLine(line)) {
-      flushMarkdown()
-      diffBuffer.push(line)
-      continue
-    }
-
-    if (diffBuffer.length > 0) flushDiff()
-    buffer.push(line)
-  }
-
-  if (diffBuffer.length > 0) flushDiff()
-  flushMarkdown()
-  return parts
-}
-
-function isRawDiffLine(line: string): boolean {
-  return line.startsWith('diff --git ')
-    || line.startsWith('index ')
-    || line.startsWith('+++ ')
-    || line.startsWith('--- ')
-    || line.startsWith('@@')
-    || line.startsWith('+')
-    || line.startsWith('-')
-}
-
-function looksLikeDiff(content: string): boolean {
-  const lines = content.split('\n')
-  return lines.some((line) => line.startsWith('@@') || line.startsWith('diff --git '))
-    || (lines.some((line) => line.startsWith('+') && !line.startsWith('+++'))
-      && lines.some((line) => line.startsWith('-') && !line.startsWith('---')))
-}
-
-function stripAnsi(text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\x1b\[[0-9;]*m/g, '')
-}
-
 function childrenToText(children: ReactNode): string {
   if (typeof children === 'string' || typeof children === 'number') return String(children)
   if (Array.isArray(children)) return children.map(childrenToText).join('')
@@ -603,11 +553,11 @@ function childrenToText(children: ReactNode): string {
 
 function formatDuration(start: number, end: number): string {
   const ms = Math.max(0, end - start)
-  if (ms < 1000) return `${ms}ms`
+  if (ms < 1000) return `${String(ms)}ms`
   const seconds = ms / 1000
   if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`
   const minutes = Math.floor(seconds / 60)
-  return `${minutes}m ${Math.floor(seconds % 60)}s`
+  return `${String(minutes)}m ${String(Math.floor(seconds % 60))}s`
 }
 
 function TabButton({

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -8,7 +8,7 @@
  *     the task has no agent stream history (manual / shell-only tasks).
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import type { Task } from '@/types'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -100,7 +100,7 @@ export function AgentPanel({ task, onClose }: AgentPanelProps) {
 
       {/* Body — keep TerminalView mounted (xterm.js binding is fragile to mount/unmount) */}
       <div className="relative min-h-0 flex-1">
-        <div className={tab === 'output' ? 'h-full overflow-auto' : 'hidden'} aria-hidden={tab !== 'output'}>
+        <div className={tab === 'output' ? 'h-full' : 'hidden'} aria-hidden={tab !== 'output'}>
           <OutputView task={task} />
         </div>
         <div
@@ -114,10 +114,27 @@ export function AgentPanel({ task, onClose }: AgentPanelProps) {
   )
 }
 
-// ─── Output view: direct render from streaming store ────────────────────────
+// Output view: Claude Code-style stream renderer.
 
 function OutputView({ task }: { task: Task }) {
   const stream = useAgentStreamingStore((s) => s.streams.get(task.id))
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const [autoFollow, setAutoFollow] = useState(true)
+  const activityKey = `${stream?.fullContent.length ?? 0}:${stream?.thinkingContent.length ?? 0}:${stream?.allToolCalls.length ?? 0}:${stream?.completedAt ?? 0}`
+
+  useLayoutEffect(() => {
+    if (!autoFollow) return
+    const scroller = scrollerRef.current
+    if (!scroller) return
+    scroller.scrollTop = scroller.scrollHeight
+  }, [activityKey, autoFollow])
+
+  const handleScroll = () => {
+    const scroller = scrollerRef.current
+    if (!scroller) return
+    const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+    setAutoFollow(distanceFromBottom < 64)
+  }
 
   if (!stream || (!stream.fullContent && stream.allToolCalls.length === 0 && !stream.thinkingContent)) {
     return (
@@ -142,73 +159,455 @@ function OutputView({ task }: { task: Task }) {
   const isCompleted = Boolean(stream.completedAt)
 
   return (
-    <div className="flex flex-col gap-3 px-3 py-3 text-sm">
-      {/* Status banner */}
-      <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider">
-        {isCompleted ? (
-          <span className="rounded bg-green-500/10 px-2 py-0.5 text-green-400">Completed</span>
-        ) : (
-          <span className="rounded bg-blue-500/10 px-2 py-0.5 text-blue-400">
-            <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-blue-400 align-middle" />
-            Streaming
-          </span>
-        )}
-        <span className="text-text-secondary/60">{stream.toolCount} tool calls</span>
+    <div className="relative h-full">
+      <div
+        ref={scrollerRef}
+        onScroll={handleScroll}
+        className="h-full overflow-y-auto px-3 py-3 text-sm"
+      >
+        <div className="mx-auto flex max-w-5xl flex-col gap-3">
+          <StreamStatusBar
+            isCompleted={isCompleted}
+            toolCount={stream.toolCount}
+            startedAt={stream.startTime}
+            completedAt={stream.completedAt}
+          />
+
+          {stream.allToolCalls.length > 0 && (
+            <div className="flex flex-col gap-2">
+              {stream.allToolCalls.map((tool) => (
+                <ToolBlock key={tool.id} tool={tool} />
+              ))}
+            </div>
+          )}
+
+          {stream.thinkingContent.trim() && (
+            <ThinkingBlock content={stream.thinkingContent} />
+          )}
+
+          {stream.fullContent && (
+            <MarkdownStream content={stream.fullContent} />
+          )}
+        </div>
       </div>
 
-      {/* Tool calls — most recent at bottom */}
-      {stream.allToolCalls.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {stream.allToolCalls.map((tool) => (
-            <ToolBadge key={tool.id} tool={tool} />
-          ))}
-        </div>
-      )}
-
-      {/* Thinking */}
-      {stream.thinkingContent.trim() && (
-        <details className="rounded-md border border-purple-500/20 bg-purple-500/5">
-          <summary className="cursor-pointer select-none px-3 py-1.5 text-[11px] text-purple-300">
-            💭 Thinking ({stream.thinkingContent.split('\n').length} lines)
-          </summary>
-          <pre className="whitespace-pre-wrap break-words px-3 py-2 text-[11px] font-mono text-purple-200/80">
-            {stream.thinkingContent}
-          </pre>
-        </details>
-      )}
-
-      {/* Streamed content (markdown) */}
-      {stream.fullContent && (
-        <div className="prose prose-invert prose-sm max-w-none text-text-primary [&_code]:text-[12px] [&_pre]:text-[12px]">
-          <ReactMarkdown>{stream.fullContent}</ReactMarkdown>
-        </div>
+      {!autoFollow && (
+        <button
+          type="button"
+          onClick={() => {
+            setAutoFollow(true)
+            requestAnimationFrame(() => {
+              const scroller = scrollerRef.current
+              if (scroller) scroller.scrollTop = scroller.scrollHeight
+            })
+          }}
+          className="absolute bottom-3 right-3 rounded border border-border-default bg-surface px-2.5 py-1 text-[11px] font-medium text-text-secondary shadow-lg hover:bg-surface-hover hover:text-text-primary"
+          style={{ cursor: 'pointer' }}
+        >
+          Resume auto-scroll
+        </button>
       )}
     </div>
   )
 }
 
-// ─── Components ─────────────────────────────────────────────────────────────
+type MarkdownPart =
+  | { type: 'markdown'; content: string }
+  | { type: 'diff'; content: string }
 
-function ToolBadge({ tool }: { tool: LiveToolCall }) {
+function StreamStatusBar({
+  isCompleted,
+  toolCount,
+  startedAt,
+  completedAt,
+}: {
+  isCompleted: boolean
+  toolCount: number
+  startedAt: number
+  completedAt?: number
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border-default pb-2 text-[10px] uppercase tracking-wider">
+      {isCompleted ? (
+        <span className="rounded bg-success/10 px-2 py-0.5 text-success">Completed</span>
+      ) : (
+        <span className="rounded bg-running/10 px-2 py-0.5 text-running">
+          <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-running align-middle" />
+          Streaming
+        </span>
+      )}
+      <span className="text-text-secondary/70">{toolCount} tool calls</span>
+      <span className="text-text-secondary/50">{formatDuration(startedAt, completedAt ?? Date.now())}</span>
+    </div>
+  )
+}
+
+function ToolBlock({ tool }: { tool: LiveToolCall }) {
   const palette = {
-    pending:   'bg-surface-hover text-text-secondary border-border-default',
-    running:   'bg-blue-500/10 text-blue-400 border-blue-500/20',
-    completed: 'bg-green-500/10 text-green-400 border-green-500/20',
-    error:     'bg-red-500/10 text-red-400 border-red-500/20',
+    pending: 'border-border-default bg-surface text-text-secondary',
+    running: 'border-running/30 bg-running/10 text-running',
+    completed: 'border-success/30 bg-success/10 text-success',
+    error: 'border-error/30 bg-error/10 text-error',
   } as const
   const icon = {
-    pending: '○',
-    running: '⏳',
+    pending: '...',
+    running: '>',
     completed: '✓',
-    error: '✗',
+    error: '!',
   } as const
+  const duration = formatDuration(tool.startedAt, tool.endedAt ?? Date.now())
+  const defaultOpen = tool.status === 'running' || tool.status === 'error'
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+
+  useEffect(() => {
+    if (defaultOpen) setIsOpen(true)
+  }, [defaultOpen])
 
   return (
-    <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-mono ${palette[tool.status]}`}>
-      <span>{icon[tool.status]}</span>
-      <span className="truncate max-w-[200px]">{tool.name}</span>
-    </span>
+    <details
+      className={`rounded-md border ${palette[tool.status]}`}
+      open={isOpen}
+      onToggle={(event) => { setIsOpen(event.currentTarget.open) }}
+    >
+      <summary
+        className="flex select-none items-center gap-2 px-3 py-2 text-xs"
+        style={{ cursor: 'pointer' }}
+      >
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-bg/40 font-mono text-[11px]">
+          {icon[tool.status]}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-mono">{tool.name}</span>
+        <span className="rounded bg-bg/30 px-1.5 py-0.5 font-mono text-[10px] uppercase">
+          {tool.status}
+        </span>
+        <span className="font-mono text-[10px] opacity-70">{duration}</span>
+      </summary>
+      <div className="border-t border-current/10 px-3 py-2 text-[11px] text-text-secondary">
+        <div className="grid gap-1 font-mono">
+          <div>id: {tool.id}</div>
+          <div>started: {new Date(tool.startedAt).toLocaleTimeString()}</div>
+          {tool.endedAt && <div>ended: {new Date(tool.endedAt).toLocaleTimeString()}</div>}
+        </div>
+      </div>
+    </details>
   )
+}
+
+function ThinkingBlock({ content }: { content: string }) {
+  const lineCount = content.split('\n').filter(Boolean).length
+
+  return (
+    <details className="rounded-md border border-accent/30 bg-accent/10">
+      <summary
+        className="select-none px-3 py-2 text-xs font-medium text-accent"
+        style={{ cursor: 'pointer' }}
+      >
+        Thinking ({lineCount} lines)
+      </summary>
+      <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words border-t border-accent/20 px-3 py-2 text-[11px] font-mono text-text-secondary">
+        <AnsiText text={content} />
+      </pre>
+    </details>
+  )
+}
+
+const MarkdownStream = memo(function MarkdownStream({ content }: { content: string }) {
+  const parts = useMemo(() => splitMarkdownParts(content), [content])
+
+  return (
+    <div className="flex flex-col gap-3">
+      {parts.map((part, index) => (
+        part.type === 'diff'
+          ? <DiffBlock key={index} content={part.content} />
+          : <MarkdownBlock key={index} content={part.content} />
+      ))}
+    </div>
+  )
+})
+
+function MarkdownBlock({ content }: { content: string }) {
+  return (
+    <div className="max-w-none text-sm leading-6 text-text-primary">
+      <ReactMarkdown
+        components={{
+          h1: ({ children }) => <h1 className="mb-2 mt-3 text-base font-semibold">{children}</h1>,
+          h2: ({ children }) => <h2 className="mb-2 mt-3 text-sm font-semibold">{children}</h2>,
+          h3: ({ children }) => <h3 className="mb-1.5 mt-2 text-sm font-semibold">{children}</h3>,
+          p: ({ children }) => <p className="my-1.5">{children}</p>,
+          ul: ({ children }) => <ul className="my-1.5 ml-5 list-disc">{children}</ul>,
+          ol: ({ children }) => <ol className="my-1.5 ml-5 list-decimal">{children}</ol>,
+          li: ({ children }) => <li className="my-0.5">{children}</li>,
+          blockquote: ({ children }) => (
+            <blockquote className="my-2 border-l-2 border-border-default pl-3 text-text-secondary">
+              {children}
+            </blockquote>
+          ),
+          code: ({ className, children }) => {
+            const language = /language-(\w+)/.exec(className ?? '')?.[1] ?? ''
+            const code = childrenToText(children).replace(/\n$/, '')
+            if (!className) {
+              return <code className="rounded bg-surface-hover px-1 py-0.5 font-mono text-[0.9em] text-accent">{children}</code>
+            }
+            if (language === 'diff' || looksLikeDiff(code)) {
+              return <DiffBlock content={code} />
+            }
+            return <CodeBlock language={language || 'text'} content={code} />
+          },
+          pre: ({ children }) => <>{children}</>,
+        }}
+      >
+        {stripAnsi(content)}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+function CodeBlock({ language, content }: { language: string; content: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(content)
+    setCopied(true)
+    window.setTimeout(() => { setCopied(false) }, 1200)
+  }
+
+  return (
+    <div className="my-2 overflow-hidden rounded-md border border-border-default bg-bg">
+      <div className="flex items-center justify-between border-b border-border-default bg-surface px-3 py-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-wide text-text-secondary">{language}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="rounded px-1.5 py-0.5 text-[10px] text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+          style={{ cursor: 'pointer' }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="max-h-[520px] overflow-auto p-3 text-xs leading-5">
+        <code className="font-mono">
+          <AnsiText text={content} />
+        </code>
+      </pre>
+    </div>
+  )
+}
+
+function DiffBlock({ content }: { content: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const lines = content.split('\n')
+  const visibleLines = expanded ? lines : lines.slice(0, 320)
+  const isTruncated = lines.length > visibleLines.length
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(content)
+    setCopied(true)
+    window.setTimeout(() => { setCopied(false) }, 1200)
+  }
+
+  return (
+    <div className="my-2 overflow-hidden rounded-md border border-border-default bg-bg">
+      <div className="flex items-center justify-between border-b border-border-default bg-surface px-3 py-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-wide text-text-secondary">diff</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="rounded px-1.5 py-0.5 text-[10px] text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+          style={{ cursor: 'pointer' }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="max-h-[560px] overflow-auto py-2 text-xs leading-5">
+        {visibleLines.map((line, index) => (
+          <DiffLine key={`${index}:${line}`} line={line} lineNumber={index + 1} />
+        ))}
+      </pre>
+      {isTruncated && (
+        <button
+          type="button"
+          onClick={() => { setExpanded(true) }}
+          className="w-full border-t border-border-default bg-surface px-3 py-2 text-xs text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+          style={{ cursor: 'pointer' }}
+        >
+          Show {lines.length - visibleLines.length} more lines
+        </button>
+      )}
+    </div>
+  )
+}
+
+function DiffLine({ line, lineNumber }: { line: string; lineNumber: number }) {
+  const isAdd = line.startsWith('+') && !line.startsWith('+++')
+  const isRemove = line.startsWith('-') && !line.startsWith('---')
+  const isMeta = line.startsWith('diff ') || line.startsWith('index ') || line.startsWith('@@') || line.startsWith('---') || line.startsWith('+++')
+  const className = isAdd
+    ? 'bg-success/10 text-success'
+    : isRemove
+      ? 'bg-error/10 text-error'
+      : isMeta
+        ? 'bg-running/10 text-running'
+        : 'text-text-secondary'
+
+  return (
+    <div className={`grid grid-cols-[3.5rem_1fr] px-3 font-mono ${className}`}>
+      <span className="select-none pr-3 text-right text-text-secondary/50">{lineNumber}</span>
+      <code className="whitespace-pre-wrap break-words">{line || ' '}</code>
+    </div>
+  )
+}
+
+function AnsiText({ text }: { text: string }) {
+  return <>{parseAnsi(text)}</>
+}
+
+function parseAnsi(text: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  const regex = /\x1b\[([0-9;]*)m/g
+  let lastIndex = 0
+  let className = ''
+  let key = 0
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(<span key={key++} className={className}>{text.slice(lastIndex, match.index)}</span>)
+    }
+    className = ansiClassName(match[1] ?? '', className)
+    lastIndex = regex.lastIndex
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(<span key={key++} className={className}>{text.slice(lastIndex)}</span>)
+  }
+
+  return nodes
+}
+
+function ansiClassName(code: string, current: string): string {
+  const classes = new Set(current.split(' ').filter(Boolean))
+  const codes = code.split(';').filter(Boolean).map(Number)
+  if (codes.length === 0 || codes.includes(0)) return ''
+
+  for (const value of codes) {
+    if (value === 1) classes.add('font-bold')
+    if (value === 2) classes.add('opacity-60')
+    if (value === 22) {
+      classes.delete('font-bold')
+      classes.delete('opacity-60')
+    }
+    const color = ANSI_COLOR_CLASS[value]
+    if (color) {
+      for (const existing of Array.from(classes)) {
+        if (existing.startsWith('text-')) classes.delete(existing)
+      }
+      classes.add(color)
+    }
+    if (value === 39) {
+      for (const existing of Array.from(classes)) {
+        if (existing.startsWith('text-')) classes.delete(existing)
+      }
+    }
+  }
+
+  return Array.from(classes).join(' ')
+}
+
+const ANSI_COLOR_CLASS: Record<number, string> = {
+  30: 'text-text-primary',
+  31: 'text-error',
+  32: 'text-success',
+  33: 'text-warning',
+  34: 'text-running',
+  35: 'text-accent',
+  36: 'text-running',
+  37: 'text-text-primary',
+  90: 'text-text-secondary',
+  91: 'text-error',
+  92: 'text-success',
+  93: 'text-warning',
+  94: 'text-running',
+  95: 'text-accent',
+  96: 'text-running',
+  97: 'text-text-primary',
+}
+
+function splitMarkdownParts(content: string): MarkdownPart[] {
+  const lines = content.split('\n')
+  const parts: MarkdownPart[] = []
+  let buffer: string[] = []
+  let diffBuffer: string[] = []
+  let inFence = false
+
+  const flushMarkdown = () => {
+    const markdown = buffer.join('\n').trim()
+    if (markdown) parts.push({ type: 'markdown', content: markdown })
+    buffer = []
+  }
+  const flushDiff = () => {
+    const diff = diffBuffer.join('\n').trimEnd()
+    if (diff) parts.push({ type: 'diff', content: diff })
+    diffBuffer = []
+  }
+
+  for (const line of lines) {
+    if (line.trim().startsWith('```')) {
+      inFence = !inFence
+      buffer.push(line)
+      continue
+    }
+
+    if (!inFence && isRawDiffLine(line)) {
+      flushMarkdown()
+      diffBuffer.push(line)
+      continue
+    }
+
+    if (diffBuffer.length > 0) flushDiff()
+    buffer.push(line)
+  }
+
+  if (diffBuffer.length > 0) flushDiff()
+  flushMarkdown()
+  return parts
+}
+
+function isRawDiffLine(line: string): boolean {
+  return line.startsWith('diff --git ')
+    || line.startsWith('index ')
+    || line.startsWith('+++ ')
+    || line.startsWith('--- ')
+    || line.startsWith('@@')
+    || line.startsWith('+')
+    || line.startsWith('-')
+}
+
+function looksLikeDiff(content: string): boolean {
+  const lines = content.split('\n')
+  return lines.some((line) => line.startsWith('@@') || line.startsWith('diff --git '))
+    || (lines.some((line) => line.startsWith('+') && !line.startsWith('+++'))
+      && lines.some((line) => line.startsWith('-') && !line.startsWith('---')))
+}
+
+function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, '')
+}
+
+function childrenToText(children: ReactNode): string {
+  if (typeof children === 'string' || typeof children === 'number') return String(children)
+  if (Array.isArray(children)) return children.map(childrenToText).join('')
+  return ''
+}
+
+function formatDuration(start: number, end: number): string {
+  const ms = Math.max(0, end - start)
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`
+  const minutes = Math.floor(seconds / 60)
+  return `${minutes}m ${Math.floor(seconds % 60)}s`
 }
 
 function TabButton({

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react'
-import { motion } from 'motion/react'
 
 type Props = {
   onClose: () => void
@@ -108,17 +107,11 @@ export function ShortcutsModal({ onClose }: Props) {
   }, [onClose])
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
+    <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       onClick={(event) => { if (event.target === event.currentTarget) onClose() }}
     >
-      <motion.div
-        initial={{ scale: 0.96, opacity: 0, y: 8 }}
-        animate={{ scale: 1, opacity: 1, y: 0 }}
-        exit={{ scale: 0.96, opacity: 0, y: 8 }}
+      <div
         role="dialog"
         aria-modal="true"
         aria-labelledby="shortcuts-title"
@@ -165,7 +158,7 @@ export function ShortcutsModal({ onClose }: Props) {
             ))}
           </div>
         </div>
-      </motion.div>
-    </motion.div>
+      </div>
+    </div>
   )
 }

--- a/src/stores/agent-streaming-store.test.ts
+++ b/src/stores/agent-streaming-store.test.ts
@@ -39,6 +39,18 @@ describe('agent-streaming-store', () => {
       expect(after.lastContent).toBe('hello')
       expect(after.startTime).toBe(original.startTime)
     })
+
+    it('should reset completed stream when a new run starts', () => {
+      useAgentStreamingStore.getState().ensureStream('task-1')
+      useAgentStreamingStore.getState().appendContent('task-1', 'previous run')
+      useAgentStreamingStore.getState().complete('task-1')
+
+      useAgentStreamingStore.getState().ensureStream('task-1')
+
+      const stream = getStreamOrThrow('task-1')
+      expect(stream.fullContent).toBe('')
+      expect(stream.completedAt).toBeUndefined()
+    })
   })
 
   describe('appendContent', () => {
@@ -76,11 +88,12 @@ describe('agent-streaming-store', () => {
       useAgentStreamingStore.getState().updateTool('task-1', 'tool-1', 'read_file', 'running')
 
       const stream = getStreamOrThrow('task-1')
-      expect(stream.activeTool).toEqual({
+      expect(stream.activeTool).toMatchObject({
         id: 'tool-1',
         name: 'read_file',
         status: 'running',
       })
+      expect(stream.activeTool?.startedAt).toBeGreaterThan(0)
     })
 
     it('should clear active tool when status is completed', () => {
@@ -110,17 +123,38 @@ describe('agent-streaming-store', () => {
       const stream = getStreamOrThrow('task-1')
       expect(stream.toolCount).toBe(1)
     })
+
+    it('should preserve tool start time and set end time when completed', () => {
+      useAgentStreamingStore.getState().ensureStream('task-1')
+      useAgentStreamingStore.getState().updateTool('task-1', 'tool-1', 'read_file', 'running')
+      const startedAt = getStreamOrThrow('task-1').allToolCalls[0]?.startedAt
+
+      useAgentStreamingStore.getState().updateTool('task-1', 'tool-1', 'read_file', 'completed')
+
+      const tool = getStreamOrThrow('task-1').allToolCalls[0]
+      expect(tool?.startedAt).toBe(startedAt)
+      expect(tool?.endedAt).toBeGreaterThanOrEqual(startedAt ?? 0)
+    })
   })
 
   describe('complete', () => {
-    it('should mark the stream completed and preserve final state', () => {
+    it('should mark stream complete while preserving final output', () => {
       useAgentStreamingStore.getState().ensureStream('task-1')
-      useAgentStreamingStore.getState().appendContent('task-1', 'done')
+      useAgentStreamingStore.getState().complete('task-1')
+
+      const stream = useAgentStreamingStore.getState().getStream('task-1')
+      expect(stream?.completedAt).toBeGreaterThan(0)
+    })
+
+    it('should complete active tools', () => {
+      useAgentStreamingStore.getState().ensureStream('task-1')
+      useAgentStreamingStore.getState().updateTool('task-1', 'tool-1', 'read_file', 'running')
       useAgentStreamingStore.getState().complete('task-1')
 
       const stream = getStreamOrThrow('task-1')
-      expect(stream.lastContent).toBe('done')
-      expect(stream.completedAt).toBeGreaterThanOrEqual(stream.startTime)
+      expect(stream.activeTool).toBeNull()
+      expect(stream.allToolCalls[0]).toMatchObject({ status: 'completed' })
+      expect(stream.allToolCalls[0]?.endedAt).toBeGreaterThan(0)
     })
 
     it('should not error if task has no stream', () => {

--- a/src/stores/agent-streaming-store.test.ts
+++ b/src/stores/agent-streaming-store.test.ts
@@ -70,6 +70,18 @@ describe('agent-streaming-store', () => {
       expect(stream.lastContent).toBe('content')
     })
 
+    it('should start a fresh stream if content arrives after completion', () => {
+      useAgentStreamingStore.getState().ensureStream('task-1')
+      useAgentStreamingStore.getState().appendContent('task-1', 'previous run')
+      useAgentStreamingStore.getState().complete('task-1')
+
+      useAgentStreamingStore.getState().appendContent('task-1', 'next run')
+
+      const stream = getStreamOrThrow('task-1')
+      expect(stream.fullContent).toBe('next run')
+      expect(stream.completedAt).toBeUndefined()
+    })
+
     it('should truncate content to last 200 chars', () => {
       useAgentStreamingStore.getState().ensureStream('task-1')
 
@@ -134,6 +146,34 @@ describe('agent-streaming-store', () => {
       const tool = getStreamOrThrow('task-1').allToolCalls[0]
       expect(tool?.startedAt).toBe(startedAt)
       expect(tool?.endedAt).toBeGreaterThanOrEqual(startedAt ?? 0)
+    })
+
+    it('should keep another running tool active when one tool completes', () => {
+      useAgentStreamingStore.getState().ensureStream('task-1')
+      useAgentStreamingStore.getState().updateTool('task-1', 'tool-1', 'read_file', 'running')
+      useAgentStreamingStore.getState().updateTool('task-1', 'tool-2', 'write_file', 'running')
+
+      useAgentStreamingStore.getState().updateTool('task-1', 'tool-1', 'read_file', 'completed')
+
+      const stream = getStreamOrThrow('task-1')
+      expect(stream.activeTool).toMatchObject({
+        id: 'tool-2',
+        status: 'running',
+      })
+    })
+
+    it('should start a fresh stream if a tool update arrives after completion', () => {
+      useAgentStreamingStore.getState().ensureStream('task-1')
+      useAgentStreamingStore.getState().appendContent('task-1', 'previous run')
+      useAgentStreamingStore.getState().complete('task-1')
+
+      useAgentStreamingStore.getState().updateTool('task-1', 'tool-2', 'write_file', 'running')
+
+      const stream = getStreamOrThrow('task-1')
+      expect(stream.fullContent).toBe('')
+      expect(stream.completedAt).toBeUndefined()
+      expect(stream.allToolCalls).toHaveLength(1)
+      expect(stream.allToolCalls[0]).toMatchObject({ id: 'tool-2', status: 'running' })
     })
   })
 

--- a/src/stores/agent-streaming-store.ts
+++ b/src/stores/agent-streaming-store.ts
@@ -72,6 +72,19 @@ function normalizeToolStatus(status: string): LiveToolCall['status'] {
   return 'running'
 }
 
+function getWritableStream(stream: AgentStream | undefined): AgentStream {
+  return stream && !stream.completedAt ? stream : createStream()
+}
+
+function getLatestActiveTool(tools: LiveToolCall[]): LiveToolCall | null {
+  for (let index = tools.length - 1; index >= 0; index -= 1) {
+    const tool = tools[index]
+    if (!tool) continue
+    if (tool.status === 'pending' || tool.status === 'running') return tool
+  }
+  return null
+}
+
 export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => ({
   streams: new Map(),
 
@@ -88,7 +101,7 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
   appendContent: (taskId, content) => {
     set((state) => {
       const next = new Map(state.streams)
-      const stream = next.get(taskId) ?? createStream()
+      const stream = getWritableStream(next.get(taskId))
       const preview = stream.lastContent + content
       next.set(taskId, {
         ...stream,
@@ -102,7 +115,7 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
   appendThinking: (taskId, content) => {
     set((state) => {
       const next = new Map(state.streams)
-      const stream = next.get(taskId) ?? createStream()
+      const stream = getWritableStream(next.get(taskId))
       next.set(taskId, {
         ...stream,
         thinkingContent: stream.thinkingContent + content,
@@ -114,10 +127,9 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
   updateTool: (taskId, toolId, toolName, status) => {
     set((state) => {
       const next = new Map(state.streams)
-      const stream = next.get(taskId) ?? createStream()
+      const stream = getWritableStream(next.get(taskId))
 
       const toolStatus = normalizeToolStatus(status)
-      const isActive = toolStatus === 'pending' || toolStatus === 'running'
       const isNew = !stream.allToolCalls.some((t) => t.id === toolId)
       const existingTool = stream.allToolCalls.find((t) => t.id === toolId)
       const now = Date.now()
@@ -129,13 +141,14 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
         startedAt: existingTool?.startedAt ?? now,
         endedAt: isFinished ? (existingTool?.endedAt ?? now) : undefined,
       }
+      const allToolCalls = isNew
+        ? [...stream.allToolCalls, tool]
+        : stream.allToolCalls.map((t) => t.id === toolId ? tool : t)
 
       next.set(taskId, {
         ...stream,
-        activeTool: isActive ? tool : null,
-        allToolCalls: isNew
-          ? [...stream.allToolCalls, tool]
-          : stream.allToolCalls.map((t) => t.id === toolId ? tool : t),
+        activeTool: getLatestActiveTool(allToolCalls),
+        allToolCalls,
         toolCount: isNew ? stream.toolCount + 1 : stream.toolCount,
       })
       return { streams: next }

--- a/src/stores/agent-streaming-store.ts
+++ b/src/stores/agent-streaming-store.ts
@@ -11,6 +11,8 @@ export type LiveToolCall = {
   id: string
   name: string
   status: 'pending' | 'running' | 'completed' | 'error'
+  startedAt: number
+  endedAt?: number
 }
 
 export type AgentStream = {
@@ -59,14 +61,26 @@ const DEFAULT_STREAM: AgentStream = {
   startTime: Date.now(),
 }
 
+function createStream(): AgentStream {
+  return { ...DEFAULT_STREAM, startTime: Date.now() }
+}
+
+function normalizeToolStatus(status: string): LiveToolCall['status'] {
+  if (status === 'pending' || status === 'running' || status === 'completed' || status === 'error') {
+    return status
+  }
+  return 'running'
+}
+
 export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => ({
   streams: new Map(),
 
   ensureStream: (taskId) => {
-    if (get().streams.has(taskId)) return
+    const existing = get().streams.get(taskId)
+    if (existing && !existing.completedAt) return
     set((state) => {
       const next = new Map(state.streams)
-      next.set(taskId, { ...DEFAULT_STREAM, startTime: Date.now() })
+      next.set(taskId, createStream())
       return { streams: next }
     })
   },
@@ -74,7 +88,7 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
   appendContent: (taskId, content) => {
     set((state) => {
       const next = new Map(state.streams)
-      const stream = next.get(taskId) ?? { ...DEFAULT_STREAM, startTime: Date.now() }
+      const stream = next.get(taskId) ?? createStream()
       const preview = stream.lastContent + content
       next.set(taskId, {
         ...stream,
@@ -88,7 +102,7 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
   appendThinking: (taskId, content) => {
     set((state) => {
       const next = new Map(state.streams)
-      const stream = next.get(taskId) ?? { ...DEFAULT_STREAM, startTime: Date.now() }
+      const stream = next.get(taskId) ?? createStream()
       next.set(taskId, {
         ...stream,
         thinkingContent: stream.thinkingContent + content,
@@ -100,12 +114,21 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
   updateTool: (taskId, toolId, toolName, status) => {
     set((state) => {
       const next = new Map(state.streams)
-      const stream = next.get(taskId) ?? { ...DEFAULT_STREAM, startTime: Date.now() }
+      const stream = next.get(taskId) ?? createStream()
 
-      const toolStatus = status as LiveToolCall['status']
+      const toolStatus = normalizeToolStatus(status)
       const isActive = toolStatus === 'pending' || toolStatus === 'running'
       const isNew = !stream.allToolCalls.some((t) => t.id === toolId)
-      const tool: LiveToolCall = { id: toolId, name: toolName, status: toolStatus }
+      const existingTool = stream.allToolCalls.find((t) => t.id === toolId)
+      const now = Date.now()
+      const isFinished = toolStatus === 'completed' || toolStatus === 'error'
+      const tool: LiveToolCall = {
+        id: toolId,
+        name: toolName,
+        status: toolStatus,
+        startedAt: existingTool?.startedAt ?? now,
+        endedAt: isFinished ? (existingTool?.endedAt ?? now) : undefined,
+      }
 
       next.set(taskId, {
         ...stream,
@@ -125,8 +148,19 @@ export const useAgentStreamingStore = create<AgentStreamingState>((set, get) => 
     set((state) => {
       const stream = state.streams.get(taskId)
       if (!stream) return state
+      const completedAt = Date.now()
+      const allToolCalls = stream.allToolCalls.map((tool) =>
+        tool.status === 'pending' || tool.status === 'running'
+          ? { ...tool, status: 'completed' as const, endedAt: tool.endedAt ?? completedAt }
+          : tool,
+      )
       const next = new Map(state.streams)
-      next.set(taskId, { ...stream, completedAt: Date.now() })
+      next.set(taskId, {
+        ...stream,
+        activeTool: null,
+        allToolCalls,
+        completedAt,
+      })
       return { streams: next }
     })
   },


### PR DESCRIPTION
Terminal UI upgrade to render output in Claude Code style — ANSI handling, markdown, tool-call blocks, diffs, virtualized scroll, theme-aware. Built in B.9 task worktree, committed but never pushed.