### PR TITLE
Spec: chain-aware auto_setup — branch off predecessor HEAD, not main

### DIFF
--- a/docs/pipeline-v2-spec.md
+++ b/docs/pipeline-v2-spec.md
@@ -23,10 +23,16 @@ Backlog → Setup → Plan → Implement → Review → Verify → PR → Stagin
 
 ### `auto_setup`
 No agent. Pipeline logic only:
-1. Create branch: `bentoya/<task-slug>` from `main`
-2. Create worktree: `.worktrees/bentoya-<task-id>`
-3. Update task: `branch_name`, `worktree_path`
-4. Auto-advance to next column
+1. Resolve base branch:
+   - If the task has dependencies on other tasks in the same `batch_id`
+     and any of them already have a branch on disk, branch off the
+     most-progressed predecessor's HEAD (chain-aware base — see "Chains"
+     below).
+   - Otherwise, branch off the workspace default (`main`/`master`).
+2. Create branch: `bentoya/<task-slug>` from the resolved base
+3. Create worktree: `.worktrees/bentoya-<task-id>`
+4. Update task: `branch_name`, `worktree_path`
+5. Auto-advance to next column
 
 ### `batch_wait`
 No agent. Waits for conditions:
@@ -55,6 +61,28 @@ Tasks queued together (or in the same dependency chain) form a **batch**:
 - All tasks in a batch share one staging branch
 - Staging column waits for the full batch before combining
 - Batch size: configurable per workspace (default: queue everything until user says "go")
+
+## Chains (sequential dependencies inside a batch)
+
+A **chain** is a sequence of batch members where each task depends on its
+predecessor (typically via `in_review`/`at_or_past_column` feeding `batch_wait`).
+When tasks in the chain touch shared modules (db migrations, model structs,
+top-level UI files), branching every chain member off the same `main` SHA
+produces PRs that cascade-conflict at merge time, defeating automation.
+
+`auto_setup` is **chain-aware**:
+1. Detects chain membership: a task has `dependencies` referencing other
+   tasks that share its `batch_id`.
+2. Picks the predecessor with the highest column position whose branch
+   already exists on disk (closest ancestor — contains all earlier
+   predecessors' work too).
+3. Cuts the new branch from that predecessor's HEAD instead of `main`.
+4. Falls back to the workspace default base if no eligible predecessor
+   has a branch yet (e.g. predecessor still in Backlog).
+
+The selection is implemented by
+`pipeline::dependencies::predecessor_branch_for_chain` — see its tests for
+edge cases (different batch, no branch yet, multi-predecessor preference).
 
 ## Conditional E2E
 

--- a/src-tauri/src/pipeline/dependencies.rs
+++ b/src-tauri/src/pipeline/dependencies.rs
@@ -955,8 +955,8 @@ mod tests {
 
     #[test]
     fn test_predecessor_branch_prefers_furthest_along() {
-        // Chain: A → B → C, all in batch-1. C depends on both A and B.
-        // C should branch off B (further along) not A.
+        // Chain: A, B → C, all in batch-1. C depends on both A and B.
+        // C should branch off A (further along the pipeline) not B.
         let conn = setup_test_db();
         let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
         let col_setup = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();

--- a/src-tauri/src/pipeline/dependencies.rs
+++ b/src-tauri/src/pipeline/dependencies.rs
@@ -58,6 +58,75 @@ pub fn find_dependents(
     Ok(results)
 }
 
+/// Find the branch a chained task should base its worktree off.
+///
+/// When a task has dependencies on other tasks that share its `batch_id`,
+/// the new branch should be cut from the predecessor's HEAD rather than
+/// `origin/main`, so that chained PRs don't cascade-conflict on shared
+/// modules (e.g. db migrations, model structs, top-level UI files).
+///
+/// Returns `Some(branch_name)` when at least one same-batch predecessor
+/// already has a branch, preferring the predecessor that has progressed
+/// furthest along the pipeline (highest column position) — that's the
+/// closest ancestor and contains all earlier predecessors' work too.
+/// Returns `None` when there is no chain or no predecessor branch exists
+/// yet; the caller should fall back to the workspace default base.
+pub fn predecessor_branch_for_chain(
+    conn: &Connection,
+    task: &Task,
+) -> Result<Option<String>, AppError> {
+    let Some(batch_id) = task
+        .batch_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    let Some(deps_json) = task.dependencies.as_deref() else {
+        return Ok(None);
+    };
+    let trimmed = deps_json.trim();
+    if trimmed.is_empty() || trimmed == "[]" {
+        return Ok(None);
+    }
+    let Ok(deps) = serde_json::from_str::<Vec<TaskDependency>>(deps_json) else {
+        return Ok(None);
+    };
+    if deps.is_empty() {
+        return Ok(None);
+    }
+
+    let mut best: Option<(i64, String)> = None;
+
+    for dep in &deps {
+        let Ok(predecessor) = db::get_task(conn, &dep.task_id) else {
+            continue;
+        };
+        if predecessor.batch_id.as_deref() != Some(batch_id) {
+            continue;
+        }
+        let Some(branch) = predecessor
+            .branch_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        let position = db::get_column(conn, &predecessor.column_id)
+            .map(|c| c.position)
+            .unwrap_or(-1);
+        match &best {
+            Some((current_pos, _)) if *current_pos >= position => {}
+            _ => best = Some((position, branch.to_string())),
+        }
+    }
+
+    Ok(best.map(|(_, branch)| branch))
+}
+
 /// Check if a dependency condition is met based on the source task's state.
 pub fn check_condition(
     dep: &TaskDependency,
@@ -755,6 +824,226 @@ mod tests {
             on_met: TriggerActionV2::None,
         };
         assert!(!check_condition(&dep, &task, &conn).unwrap());
+    }
+
+    fn set_deps(conn: &Connection, task_id: &str, deps: &[TaskDependency]) {
+        let json = serde_json::to_string(deps).unwrap();
+        conn.execute(
+            "UPDATE tasks SET dependencies = ?1 WHERE id = ?2",
+            rusqlite::params![json, task_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_predecessor_branch_no_batch_id() {
+        let conn = setup_test_db();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
+        let col = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();
+        let pred = db::insert_task(&conn, &ws.id, &col.id, "Pred", None).unwrap();
+        let task = db::insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+
+        db::update_task_branch(&conn, &pred.id, Some("bentoya/pred")).unwrap();
+        db::update_task_batch_id(&conn, &pred.id, Some("batch-1")).unwrap();
+        // task has dep on pred but no batch_id of its own
+        set_deps(
+            &conn,
+            &task.id,
+            &[TaskDependency {
+                task_id: pred.id.clone(),
+                condition: "in_review".to_string(),
+                target_column: None,
+                on_met: TriggerActionV2::None,
+            }],
+        );
+
+        let task = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(predecessor_branch_for_chain(&conn, &task).unwrap(), None);
+    }
+
+    #[test]
+    fn test_predecessor_branch_no_dependencies() {
+        let conn = setup_test_db();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
+        let col = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();
+        let task = db::insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+        db::update_task_batch_id(&conn, &task.id, Some("batch-1")).unwrap();
+
+        let task = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(predecessor_branch_for_chain(&conn, &task).unwrap(), None);
+    }
+
+    #[test]
+    fn test_predecessor_branch_different_batch() {
+        let conn = setup_test_db();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
+        let col = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();
+        let pred = db::insert_task(&conn, &ws.id, &col.id, "Pred", None).unwrap();
+        let task = db::insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+
+        db::update_task_branch(&conn, &pred.id, Some("bentoya/pred")).unwrap();
+        db::update_task_batch_id(&conn, &pred.id, Some("batch-A")).unwrap();
+        db::update_task_batch_id(&conn, &task.id, Some("batch-B")).unwrap();
+        set_deps(
+            &conn,
+            &task.id,
+            &[TaskDependency {
+                task_id: pred.id.clone(),
+                condition: "in_review".to_string(),
+                target_column: None,
+                on_met: TriggerActionV2::None,
+            }],
+        );
+
+        let task = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(predecessor_branch_for_chain(&conn, &task).unwrap(), None);
+    }
+
+    #[test]
+    fn test_predecessor_branch_no_branch_yet() {
+        let conn = setup_test_db();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
+        let col = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();
+        let pred = db::insert_task(&conn, &ws.id, &col.id, "Pred", None).unwrap();
+        let task = db::insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+
+        db::update_task_batch_id(&conn, &pred.id, Some("batch-1")).unwrap();
+        db::update_task_batch_id(&conn, &task.id, Some("batch-1")).unwrap();
+        set_deps(
+            &conn,
+            &task.id,
+            &[TaskDependency {
+                task_id: pred.id.clone(),
+                condition: "in_review".to_string(),
+                target_column: None,
+                on_met: TriggerActionV2::None,
+            }],
+        );
+
+        let task = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(predecessor_branch_for_chain(&conn, &task).unwrap(), None);
+    }
+
+    #[test]
+    fn test_predecessor_branch_same_batch_returns_branch() {
+        let conn = setup_test_db();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
+        let col = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();
+        let pred = db::insert_task(&conn, &ws.id, &col.id, "Pred", None).unwrap();
+        let task = db::insert_task(&conn, &ws.id, &col.id, "Task", None).unwrap();
+
+        db::update_task_branch(&conn, &pred.id, Some("bentoya/pred")).unwrap();
+        db::update_task_batch_id(&conn, &pred.id, Some("batch-1")).unwrap();
+        db::update_task_batch_id(&conn, &task.id, Some("batch-1")).unwrap();
+        set_deps(
+            &conn,
+            &task.id,
+            &[TaskDependency {
+                task_id: pred.id.clone(),
+                condition: "in_review".to_string(),
+                target_column: None,
+                on_met: TriggerActionV2::None,
+            }],
+        );
+
+        let task = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(
+            predecessor_branch_for_chain(&conn, &task).unwrap(),
+            Some("bentoya/pred".to_string())
+        );
+    }
+
+    #[test]
+    fn test_predecessor_branch_prefers_furthest_along() {
+        // Chain: A → B → C, all in batch-1. C depends on both A and B.
+        // C should branch off B (further along) not A.
+        let conn = setup_test_db();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
+        let col_setup = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();
+        let col_implement = db::insert_column(&conn, &ws.id, "Implement", 1).unwrap();
+        let col_review = db::insert_column(&conn, &ws.id, "Review", 2).unwrap();
+
+        // A is in Review (furthest along among predecessors)
+        let task_a = db::insert_task(&conn, &ws.id, &col_review.id, "A", None).unwrap();
+        // B is in Implement (less progress than A)
+        let task_b = db::insert_task(&conn, &ws.id, &col_implement.id, "B", None).unwrap();
+        // C is the new task being set up
+        let task_c = db::insert_task(&conn, &ws.id, &col_setup.id, "C", None).unwrap();
+
+        db::update_task_branch(&conn, &task_a.id, Some("bentoya/a")).unwrap();
+        db::update_task_branch(&conn, &task_b.id, Some("bentoya/b")).unwrap();
+        db::update_task_batch_id(&conn, &task_a.id, Some("batch-1")).unwrap();
+        db::update_task_batch_id(&conn, &task_b.id, Some("batch-1")).unwrap();
+        db::update_task_batch_id(&conn, &task_c.id, Some("batch-1")).unwrap();
+
+        set_deps(
+            &conn,
+            &task_c.id,
+            &[
+                TaskDependency {
+                    task_id: task_a.id.clone(),
+                    condition: "in_review".to_string(),
+                    target_column: None,
+                    on_met: TriggerActionV2::None,
+                },
+                TaskDependency {
+                    task_id: task_b.id.clone(),
+                    condition: "in_review".to_string(),
+                    target_column: None,
+                    on_met: TriggerActionV2::None,
+                },
+            ],
+        );
+
+        let task_c = db::get_task(&conn, &task_c.id).unwrap();
+        assert_eq!(
+            predecessor_branch_for_chain(&conn, &task_c).unwrap(),
+            Some("bentoya/a".to_string())
+        );
+    }
+
+    #[test]
+    fn test_predecessor_branch_skips_same_batch_pred_without_branch() {
+        // A (batch-1, no branch yet) and B (batch-1, has branch). C depends on both.
+        // C should pick B's branch even though A is later in pipeline but unbranched.
+        let conn = setup_test_db();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp").unwrap();
+        let col_setup = db::insert_column(&conn, &ws.id, "Setup", 0).unwrap();
+        let col_review = db::insert_column(&conn, &ws.id, "Review", 2).unwrap();
+
+        let task_a = db::insert_task(&conn, &ws.id, &col_review.id, "A", None).unwrap();
+        let task_b = db::insert_task(&conn, &ws.id, &col_setup.id, "B", None).unwrap();
+        let task_c = db::insert_task(&conn, &ws.id, &col_setup.id, "C", None).unwrap();
+
+        db::update_task_branch(&conn, &task_b.id, Some("bentoya/b")).unwrap();
+        db::update_task_batch_id(&conn, &task_a.id, Some("batch-1")).unwrap();
+        db::update_task_batch_id(&conn, &task_b.id, Some("batch-1")).unwrap();
+        db::update_task_batch_id(&conn, &task_c.id, Some("batch-1")).unwrap();
+
+        set_deps(
+            &conn,
+            &task_c.id,
+            &[
+                TaskDependency {
+                    task_id: task_a.id.clone(),
+                    condition: "in_review".to_string(),
+                    target_column: None,
+                    on_met: TriggerActionV2::None,
+                },
+                TaskDependency {
+                    task_id: task_b.id.clone(),
+                    condition: "in_review".to_string(),
+                    target_column: None,
+                    on_met: TriggerActionV2::None,
+                },
+            ],
+        );
+
+        let task_c = db::get_task(&conn, &task_c.id).unwrap();
+        assert_eq!(
+            predecessor_branch_for_chain(&conn, &task_c).unwrap(),
+            Some("bentoya/b".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -696,13 +696,34 @@ fn execute_auto_setup(
     }
 
     let pipeline_settings = config::effective_pipeline_settings(&workspace.config);
+
+    // Chain-aware base resolution: if this task has dependencies on
+    // same-batch predecessors that already have branches, cut the new
+    // branch off the most-progressed predecessor's HEAD instead of
+    // `main`. Without this, sequential tasks in a chain all branch off
+    // the same base SHA and cascade-conflict on shared modules at PR
+    // merge time, defeating the point of `batch_wait` chaining.
+    let chain_base = super::dependencies::predecessor_branch_for_chain(conn, task)
+        .ok()
+        .flatten()
+        .filter(|branch| {
+            branch_manager::branch_exists(&workspace.repo_path, branch).unwrap_or(false)
+        });
+    if let Some(ref branch) = chain_base {
+        log::info!(
+            "[auto_setup] task {} branching off predecessor '{}' (chain-aware)",
+            task.id,
+            branch
+        );
+    }
+
     let setup_task = match ensure_task_worktree(
         conn,
         app,
         task,
         &workspace.repo_path,
         &pipeline_settings,
-        None,
+        chain_base.as_deref(),
     ) {
         Ok(task) => task,
         Err(e) => return fail_auto_setup(conn, app, task, column, e.to_string()),


### PR DESCRIPTION
## Description

## Problem

Chained tasks (sequential dependencies via `in_review` condition feeding `batch_wait`) all branch off the same SHA (current `origin/main` at chain start) when `auto_setup` fires. When tasks touch shared modules (Task struct, db/migrations, app.tsx, column.tsx, etc.), the resulting feature PRs cascade-conflict with each other, defeating the chain.

Real example (2026-05-02): a 5-task chain produced PRs #150-154 that all conflicted because each agent worked from the same base. Required a manual rollup PR (#155) with hand-resolved migrations, model struct merges, and feature-restoration from main — ~45 minutes of human-driven cleanup.

## Proposed fix

When `auto_setup` fires for a task that has `dependencies` referencing another task in the same `batch_id`:

1. Wait for the predecessor task's branch to exist (or fall back to `origin/main` if not yet)
2. Cut the new worktree's branch off the predecessor's HEAD instead of `origin/main`
3. Migration files: bump number to max(existing) + 1 instead of hardcoded next-number-up
4. Optionally: rebase chain branches onto each other as predecessors land

## Acceptance criteria

- [ ] auto_setup detects chain membership (deps + batch_id present)
- [ ] Branch base resolution: predecessor.branch_name if exists, else origin/main
- [ ] Migration scaffolding script auto-numbers based on `ls migrations/` max
- [ ] Test: 3-task chain on Task struct produces 3 PRs that all merge clean serially
- [ ] Updated docs/pipeline-v2.md with chain semantics

## Files

- src-tauri/src/pipeline/triggers.rs — execute_auto_setup
- src-tauri/src/pipeline/dependencies.rs — chain detection helper
- src-tauri/src/db/task.rs — list_tasks_by_batch_id (already exists)
- docs/pipeline-v2.md — add Chain section

## Notes

This unblocks `batch_wait` for shared-module chains (currently only safe for fully-independent batches). Without this, the operator must either:
- Guarantee chain members touch disjoint files (impractical), or
- Manually rollup every chain (defeats automation)

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/spec-chain-aware-auto-setup-branch-off-predecessor` → `staging/batch-20260504105423719`