### PR TITLE
fix(pipeline): pre-fetch origin/main before worktree creation + auto-rebase before PR

### DIFF
--- a/src-tauri/src/git/branch_manager.rs
+++ b/src-tauri/src/git/branch_manager.rs
@@ -45,6 +45,101 @@ fn detect_base_branch(repo: &Repository) -> Result<String, git2::Error> {
     Ok(head.shorthand().unwrap_or("HEAD").to_string())
 }
 
+/// Fetch `origin/<base_branch>` and fast-forward the local `<base_branch>`
+/// reference to match. Best-effort: any failure (no remote, network down,
+/// non-fast-forward divergence) is logged at warn level and swallowed so the
+/// caller can proceed with whatever local has.
+///
+/// Why: tasks that create worktrees from a stale local base silently lose
+/// commits when other agents push to remote main between the user's last
+/// `git fetch` and the trigger fire.
+pub fn fetch_and_fastforward_base(repo_path: &str, base_branch: &str) {
+    use std::process::Command;
+
+    let fetch = Command::new("git")
+        .args(["fetch", "origin", base_branch])
+        .current_dir(repo_path)
+        .output();
+
+    match fetch {
+        Ok(o) if o.status.success() => {}
+        Ok(o) => {
+            log::warn!(
+                "[branch_manager] git fetch origin {} failed: {}",
+                base_branch,
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+            return;
+        }
+        Err(e) => {
+            log::warn!("[branch_manager] could not run git fetch: {}", e);
+            return;
+        }
+    }
+
+    // `git fetch origin <base>:<base>` performs a fast-forward refspec update.
+    // Refuses non-FF (diverged) and refuses to overwrite a checked-out branch.
+    let ff = Command::new("git")
+        .args([
+            "fetch",
+            "origin",
+            &format!("{}:{}", base_branch, base_branch),
+        ])
+        .current_dir(repo_path)
+        .output();
+
+    match ff {
+        Ok(o) if o.status.success() => {
+            log::info!(
+                "[branch_manager] fast-forwarded local {} to origin/{}",
+                base_branch,
+                base_branch
+            );
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+            // If <base> is currently checked out, the refspec fetch refuses;
+            // try `merge --ff-only` in-place instead. (Git's exact wording
+            // varies — "refusing to fetch into branch ... checked out".)
+            let stderr_lc = stderr.to_lowercase();
+            if stderr_lc.contains("refusing to fetch into")
+                || stderr_lc.contains("checked out at")
+            {
+                let merge = Command::new("git")
+                    .args(["merge", "--ff-only", &format!("origin/{}", base_branch)])
+                    .current_dir(repo_path)
+                    .output();
+                match merge {
+                    Ok(m) if m.status.success() => {
+                        log::info!(
+                            "[branch_manager] fast-forwarded checked-out {} to origin/{}",
+                            base_branch,
+                            base_branch
+                        );
+                    }
+                    Ok(m) => {
+                        log::warn!(
+                            "[branch_manager] could not fast-forward checked-out {} (likely diverged): {}",
+                            base_branch,
+                            String::from_utf8_lossy(&m.stderr).trim()
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!("[branch_manager] git merge --ff-only failed: {}", e);
+                    }
+                }
+            } else {
+                log::warn!(
+                    "[branch_manager] could not fast-forward local {} (likely diverged): {}",
+                    base_branch,
+                    stderr
+                );
+            }
+        }
+        Err(e) => log::warn!("[branch_manager] could not run git fetch FF: {}", e),
+    }
+}
+
 /// Create a task branch `bentoya/<slug>` from the base branch.
 pub fn create_task_branch(
     repo_path: &str,
@@ -67,6 +162,11 @@ pub fn create_task_branch_with_prefix(
         Some(b) => b.to_string(),
         None => detect_base_branch(&repo).map_err(|e| e.to_string())?,
     };
+
+    // Fetch + fast-forward the base branch before slicing the task branch off
+    // it, so the task starts from fresh remote state instead of a stale local
+    // ref. Best-effort: failures are logged and ignored.
+    fetch_and_fastforward_base(repo_path, &base);
 
     let slug = slugify(task_slug);
     let prefix = normalize_branch_prefix(branch_prefix);
@@ -270,6 +370,13 @@ pub fn create_task_worktree(
     if let Some(parent) = wt_path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("Failed to create worktree parent dir: {}", e))?;
+    }
+
+    // Refresh the local base branch from origin before resolving the task
+    // branch. Best-effort — diverging local commits or missing remote just
+    // log a warning and proceed with whatever local has.
+    if let Ok(base) = detect_base_branch(&repo) {
+        fetch_and_fastforward_base(repo_path, &base);
     }
 
     // Resolve the branch reference
@@ -597,5 +704,229 @@ mod tests {
         let _ = std::fs::remove_dir_all(&missing);
         let err = clean_worktree(missing.to_str().unwrap()).unwrap_err();
         assert!(err.contains("does not exist"));
+    }
+
+    /// Build a "stale local + fresh remote" scenario:
+    /// 1. bare remote with one commit
+    /// 2. consumer clone (stale) — has commit A
+    /// 3. publisher clone pushes commit B to remote
+    ///
+    /// Returns `(consumer_path, fresh_remote_tip_sha)`.
+    #[cfg(test)]
+    fn setup_stale_local_fresh_remote(tag: &str) -> (std::path::PathBuf, String) {
+        use std::process::Command;
+
+        let root = std::env::temp_dir().join(format!(
+            "bentoya-fetch-{}-{}-{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        let remote = root.join("remote.git");
+        let publisher = root.join("publisher");
+        let consumer = root.join("consumer");
+
+        // Bare remote
+        Command::new("git")
+            .args(["init", "--bare", "-b", "main", remote.to_str().unwrap()])
+            .output()
+            .unwrap();
+
+        // Publisher clone — seeds remote with commit A
+        Command::new("git")
+            .args([
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                publisher.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        for (k, v) in [
+            ("user.email", "test@example.com"),
+            ("user.name", "Test"),
+            ("commit.gpgsign", "false"),
+            ("init.defaultBranch", "main"),
+        ] {
+            Command::new("git")
+                .args(["config", k, v])
+                .current_dir(&publisher)
+                .output()
+                .unwrap();
+        }
+        std::fs::write(publisher.join("README.md"), "A\n").unwrap();
+        Command::new("git")
+            .args(["checkout", "-q", "-b", "main"])
+            .current_dir(&publisher)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&publisher)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "A"])
+            .current_dir(&publisher)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["push", "-q", "-u", "origin", "main"])
+            .current_dir(&publisher)
+            .output()
+            .unwrap();
+
+        // Consumer clone — captures the stale view
+        Command::new("git")
+            .args([
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                consumer.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        for (k, v) in [
+            ("user.email", "test@example.com"),
+            ("user.name", "Test"),
+            ("commit.gpgsign", "false"),
+        ] {
+            Command::new("git")
+                .args(["config", k, v])
+                .current_dir(&consumer)
+                .output()
+                .unwrap();
+        }
+
+        // Publisher pushes commit B — consumer is now stale
+        std::fs::write(publisher.join("README.md"), "A\nB\n").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&publisher)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "B"])
+            .current_dir(&publisher)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["push", "-q", "origin", "main"])
+            .current_dir(&publisher)
+            .output()
+            .unwrap();
+
+        let fresh_tip = String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&publisher)
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        (consumer, fresh_tip)
+    }
+
+    #[test]
+    fn test_fetch_and_fastforward_base_advances_stale_local() {
+        let (consumer, fresh_tip) = setup_stale_local_fresh_remote("ff");
+
+        // Sanity: consumer's local main is currently at the stale commit.
+        let stale_tip = String::from_utf8(
+            std::process::Command::new("git")
+                .args(["rev-parse", "main"])
+                .current_dir(&consumer)
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        assert_ne!(
+            stale_tip, fresh_tip,
+            "consumer should start with stale local main"
+        );
+
+        fetch_and_fastforward_base(consumer.to_str().unwrap(), "main");
+
+        let new_tip = String::from_utf8(
+            std::process::Command::new("git")
+                .args(["rev-parse", "main"])
+                .current_dir(&consumer)
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        assert_eq!(
+            new_tip, fresh_tip,
+            "local main should be fast-forwarded to fresh remote tip"
+        );
+
+        let _ = std::fs::remove_dir_all(consumer.parent().unwrap());
+    }
+
+    #[test]
+    fn test_create_task_branch_starts_from_fresh_remote_main() {
+        let (consumer, fresh_tip) = setup_stale_local_fresh_remote("branch");
+
+        // Consumer's main starts stale; create_task_branch should fetch + FF
+        // first so the new task branch is sliced off the fresh tip, not the
+        // stale local view.
+        let branch = create_task_branch(consumer.to_str().unwrap(), "Add Feature", None)
+            .expect("create_task_branch failed");
+
+        let branch_tip = String::from_utf8(
+            std::process::Command::new("git")
+                .args(["rev-parse", &branch])
+                .current_dir(&consumer)
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        assert_eq!(
+            branch_tip, fresh_tip,
+            "task branch should be created from fresh remote main"
+        );
+
+        let _ = std::fs::remove_dir_all(consumer.parent().unwrap());
+    }
+
+    #[test]
+    fn test_fetch_and_fastforward_base_no_remote_is_safe() {
+        // Repo with no `origin` remote — fetch_and_fastforward_base must
+        // log + return without panicking.
+        let tmp = std::env::temp_dir().join(format!(
+            "bentoya-fetch-noremote-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        init_test_repo(&tmp);
+
+        fetch_and_fastforward_base(tmp.to_str().unwrap(), "main");
+
+        // Repo still works
+        assert!(branch_exists(tmp.to_str().unwrap(), "main").unwrap());
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -1375,6 +1375,74 @@ fn maybe_create_batch_pr(
     ))
 }
 
+/// Sentinel prefix used to flag rebase-conflict failures so the outer handler
+/// can mark the task as needing manual review instead of treating the failure
+/// as a generic infrastructural error.
+const REBASE_CONFLICT_PREFIX: &str = "REBASE_CONFLICT: ";
+
+/// Rebase the task branch onto fresh `origin/<base>` before opening a PR.
+///
+/// Why: tasks that were sliced off a stale local `<base>` will, when pushed,
+/// produce a PR whose diff includes "deletions" of commits that landed on
+/// remote main concurrently. Auto-merging that PR (or any conflict-fallback
+/// strategy that prefers the task side) silently regresses the trunk.
+///
+/// On a clean rebase: `Ok(())` and the worktree HEAD now sits on top of
+/// fresh `origin/<base>`. On conflicts: the rebase is aborted (HEAD is
+/// restored), and `Err(REBASE_CONFLICT_PREFIX + detail)` is returned so the
+/// caller can flag the task for manual review rather than auto-resolving with
+/// `--theirs` (which is what caused the regressions in the first place).
+fn rebase_task_branch_on_base(repo_path: &str, base_branch: &str) -> Result<(), String> {
+    let fetch = run_command(repo_path, "git", &["fetch", "origin", base_branch])?;
+    if !fetch.status.success() {
+        // Fetch failure: log + proceed with whatever local origin/<base> has.
+        // No remote / network failure shouldn't block PR creation entirely.
+        log::warn!(
+            "[rebase] git fetch origin {} failed before rebase: {}",
+            base_branch,
+            command_stderr(&fetch)
+        );
+    }
+
+    let target = format!("origin/{}", base_branch);
+    if !git_ref_exists(repo_path, &remote_branch_ref(base_branch))? {
+        // No remote ref to rebase onto — skip rebase, fall back to local view.
+        log::warn!(
+            "[rebase] origin/{} does not exist; skipping rebase",
+            base_branch
+        );
+        return Ok(());
+    }
+
+    let rebase = run_command(repo_path, "git", &["rebase", &target])?;
+    if rebase.status.success() {
+        log::info!("[rebase] task branch cleanly rebased onto {}", target);
+        return Ok(());
+    }
+
+    // Rebase failed — capture conflict files (if any) and abort to restore HEAD.
+    let unmerged = run_command(
+        repo_path,
+        "git",
+        &["diff", "--name-only", "--diff-filter=U"],
+    )
+    .ok()
+    .map(|o| command_stdout(&o))
+    .filter(|s| !s.is_empty());
+
+    let _ = run_command(repo_path, "git", &["rebase", "--abort"]);
+
+    let detail = match unmerged {
+        Some(files) => format!(
+            "conflicts in: {}",
+            files.lines().collect::<Vec<_>>().join(", ")
+        ),
+        None => format!("rebase failed: {}", command_stderr(&rebase)),
+    };
+
+    Err(format!("{}{}", REBASE_CONFLICT_PREFIX, detail))
+}
+
 fn push_task_branch(repo_path: &str, branch_name: &str) -> Result<(), String> {
     let output = run_command(repo_path, "git", &["push", "-u", "origin", branch_name])?;
     if output.status.success() {
@@ -1644,6 +1712,12 @@ fn execute_create_pr(
         let result = tokio::task::spawn_blocking(move || -> Result<(i64, String), String> {
             ensure_staging_branch(&pr_repo_path, &pr_staging_branch, &pr_final_base)?;
 
+            // Rebase task branch onto fresh `origin/<base>` before pushing.
+            // On conflicts the rebase is aborted and we propagate a
+            // REBASE_CONFLICT_PREFIX error so the outer handler flags the
+            // task for manual review (no `--theirs` auto-resolution).
+            rebase_task_branch_on_base(&pr_repo_path, &pr_final_base)?;
+
             // gh pr create requires the branch to exist on remote.
             push_task_branch(&pr_repo_path, &pr_branch_name)?;
 
@@ -1710,6 +1784,32 @@ fn execute_create_pr(
             }
             Ok(Err(e)) => {
                 log::error!("[create_pr] Failed for task {}: {}", task_id, e);
+
+                // If the rebase reported conflicts, flag the task for manual
+                // review instead of letting the trigger silently retry — we
+                // explicitly do NOT auto-resolve with `--theirs` (that's the
+                // strategy that caused regressions).
+                if let Some(detail) = e.strip_prefix(REBASE_CONFLICT_PREFIX) {
+                    if let Some(ref conn) = conn {
+                        let reason = format!(
+                            "needs-manual-review: rebase against origin/{} hit conflicts — {}",
+                            final_base, detail
+                        );
+                        let _ = db::update_task_review_status(
+                            conn,
+                            &task_id,
+                            Some("needs-manual-review"),
+                        );
+                        let _ = db::update_task_pipeline_state(
+                            conn,
+                            &task_id,
+                            PipelineState::Idle.as_str(),
+                            None,
+                            Some(&reason),
+                        );
+                    }
+                }
+
                 let _ = app_handle.emit(
                     "pipeline:error",
                     &super::PipelineEvent {

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -1602,7 +1602,6 @@ fn execute_auto_merge(
     let cleaned =
         super::cleanup_task_worktree_if_terminal(conn, &moved, &done_col, "auto_merge")?;
     let _ = super::dependencies::check_dependents(conn, app, &cleaned);
-    let last_updated = Some(cleaned);
 
     emit_pipeline(
         app,
@@ -1614,7 +1613,7 @@ fn execute_auto_merge(
     );
     super::emit_tasks_changed(app, &task.workspace_id, "auto_merge_done");
 
-    Ok(last_updated.unwrap_or_else(|| task.clone()))
+    Ok(cleaned)
 }
 
 fn execute_create_pr(


### PR DESCRIPTION
## Why

Bento-ya did NOT fetch \`origin/main\` before creating task worktrees. The pipeline used whatever local \`main\` pointed to at task-fire time. When concurrent work landed new commits to remote main, bento-ya's task created a PR against stale main, and the auto-rebase \`--theirs\` strategy preserved the stale view and overwrote the new commits.

Confirmed via \`grep -rn "fetch" src-tauri/src/git src-tauri/src/commands\` — zero hits.

## Changes

3 changes, ONE PR.

### Fix 1 — Pre-fetch origin/main before worktree creation
\`src-tauri/src/git/branch_manager.rs::create_task_worktree\`:
- Before resolving the branch reference, calls \`git fetch origin <base_branch>\`
- After fetch, fast-forward local \`<base_branch>\` to \`origin/<base_branch>\` if behind
- If fast-forward fails (local has diverging commits): logs warning, proceeds with whatever local has

### Fix 2 — Auto-rebase before PR push
\`src-tauri/src/pipeline/triggers.rs\`: rebase the working branch onto \`origin/main\` immediately before PR push, so the PR is always rooted at the freshest remote state.

### Fix 3 — Loud failures
Both new operations log clearly so silent regressions can't recur.

## Test Plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy -- -D warnings\` clean
- [ ] Live test: kick off 2 concurrent tasks against bento-ya, watch them get correct origin/main base
- [ ] Verify \`git log\` on resulting branches shows recent remote commits

## Notes

Reviewed manually — Review-Quality stage hit Anthropic server-side rate limit (not a real review failure). Code is committed clean, +431 lines across 2 files. Direct review encouraged before merge.