### PR TITLE
feat(pipeline): auto-archive Done tasks + clear stale agent_sessions on merge

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -315,6 +315,9 @@ pub fn run() {
             // Start GitHub issues sync poller (every 5 minutes)
             github_sync::start_github_sync(app.handle().clone());
 
+            // Start pipeline hygiene worker (auto-archive Done + clear stale failure flags)
+            start_pipeline_hygiene(app.handle().clone());
+
             Ok(())
         })
         .run(tauri::generate_context!())
@@ -449,6 +452,64 @@ fn start_nightly_worktree_sweep(app: tauri::AppHandle) {
             warn_stale_worktrees_once(&app);
         }
     });
+}
+
+/// Pipeline hygiene worker: auto-archives Done tasks past the per-workspace
+/// grace period and clears stale `agent_status='failed'` / `pipeline_error`
+/// markers on tasks that already reached Done. Runs once a minute.
+fn start_pipeline_hygiene(app: tauri::AppHandle) {
+    const HYGIENE_INTERVAL_SECS: u64 = 60;
+    const STARTUP_DELAY_SECS: u64 = 30;
+
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(STARTUP_DELAY_SECS)).await;
+        loop {
+            run_hygiene_once(&app);
+            tokio::time::sleep(std::time::Duration::from_secs(HYGIENE_INTERVAL_SECS)).await;
+        }
+    });
+}
+
+fn run_hygiene_once(app: &tauri::AppHandle) {
+    let workspaces = {
+        let state: tauri::State<db::AppState> = app.state();
+        let conn = match state.db.lock() {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("[hygiene] DB lock failed: {}", e);
+                return;
+            }
+        };
+
+        let result = match pipeline::hygiene::run_hygiene_cycle(&conn) {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("[hygiene] cycle failed: {}", e);
+                return;
+            }
+        };
+
+        if result.is_empty() {
+            return;
+        }
+
+        log::info!(
+            "[hygiene] archived={} reconciled={} sessions_cleared={}",
+            result.archived,
+            result.tasks_reconciled,
+            result.sessions_cleared,
+        );
+
+        match db::list_workspaces(&conn) {
+            Ok(ws) => ws.into_iter().map(|w| w.id).collect::<Vec<_>>(),
+            Err(_) => Vec::new(),
+        }
+    };
+
+    // Notify each workspace so the frontend re-fetches tasks.
+    for workspace_id in workspaces {
+        pipeline::emit_tasks_changed(app, &workspace_id, "pipeline_hygiene");
+    }
 }
 
 /// Recover tmux sessions from a previous app instance.

--- a/src-tauri/src/pipeline/hygiene.rs
+++ b/src-tauri/src/pipeline/hygiene.rs
@@ -9,13 +9,10 @@
 use rusqlite::{params, Connection};
 use serde_json::Value;
 
+use crate::db;
+
 /// Default grace period before auto-archiving a Done task.
 pub const DEFAULT_AUTO_ARCHIVE_GRACE_MINUTES: i64 = 5;
-
-/// Returns true if the column is a "Done" terminal column based on its name.
-pub fn is_done_column_name(name: &str) -> bool {
-    name.eq_ignore_ascii_case("done")
-}
 
 /// Read per-workspace auto-archive settings from the JSON `workspace.config` blob.
 ///
@@ -41,24 +38,12 @@ pub fn read_auto_archive_config(workspace_config: &str) -> (bool, i64) {
 pub fn auto_archive_done_tasks(conn: &Connection) -> rusqlite::Result<i64> {
     let mut total = 0i64;
 
-    let mut stmt = conn.prepare("SELECT id, config FROM workspaces")?;
-    let workspaces: Vec<(String, String)> = stmt
-        .query_map([], |row| {
-            let config: Option<String> = row.get(1)?;
-            Ok((
-                row.get::<_, String>(0)?,
-                config.unwrap_or_else(|| "{}".to_string()),
-            ))
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    drop(stmt);
-
-    for (workspace_id, config_json) in workspaces {
-        let (enabled, grace_minutes) = read_auto_archive_config(&config_json);
+    for workspace in db::list_workspaces(conn)? {
+        let (enabled, grace_minutes) = read_auto_archive_config(&workspace.config);
         if !enabled {
             continue;
         }
-        total += archive_done_tasks_for_workspace(conn, &workspace_id, grace_minutes)?;
+        total += archive_done_tasks_for_workspace(conn, &workspace.id, grace_minutes)?;
     }
 
     Ok(total)
@@ -70,21 +55,20 @@ pub fn archive_done_tasks_for_workspace(
     workspace_id: &str,
     grace_minutes: i64,
 ) -> rusqlite::Result<i64> {
-    let cutoff_clause = format!("datetime('now', '-{} minutes')", grace_minutes);
-    let sql = format!(
+    let ts = db::now();
+    let cutoff_modifier = format!("-{} minutes", grace_minutes);
+    let n = conn.execute(
         "UPDATE tasks
          SET archived_at = ?1, updated_at = ?1
          WHERE workspace_id = ?2
            AND archived_at IS NULL
-           AND datetime(updated_at) < {}
+           AND datetime(updated_at) < datetime('now', ?3)
            AND column_id IN (
                SELECT id FROM columns
                WHERE workspace_id = ?2 AND LOWER(name) = 'done'
            )",
-        cutoff_clause
-    );
-    let ts = super::super::db::now();
-    let n = conn.execute(&sql, params![ts, workspace_id])? as i64;
+        params![ts, workspace_id, cutoff_modifier],
+    )? as i64;
     Ok(n)
 }
 
@@ -99,7 +83,7 @@ pub fn archive_done_tasks_for_workspace(
 /// The PR is in main, the task is in Done — the failure flags are stale.
 /// Returns `(tasks_reconciled, sessions_cleared)`.
 pub fn reconcile_done_task_state(conn: &Connection) -> rusqlite::Result<(i64, i64)> {
-    let ts = super::super::db::now();
+    let ts = db::now();
 
     let stale_tasks: Vec<String> = {
         let mut stmt = conn.prepare(

--- a/src-tauri/src/pipeline/hygiene.rs
+++ b/src-tauri/src/pipeline/hygiene.rs
@@ -1,0 +1,412 @@
+//! Pipeline hygiene: periodic self-healing for Done tasks.
+//!
+//! Two responsibilities:
+//! 1. Auto-archive tasks that have sat in Done for the workspace's grace period.
+//! 2. Reconcile stale `agent_status='failed'` and `pipeline_error` on Done tasks
+//!    (the work succeeded — the badge is lying), and delete failed
+//!    `agent_sessions` rows so the UI stops showing red badges.
+
+use rusqlite::{params, Connection};
+use serde_json::Value;
+
+/// Default grace period before auto-archiving a Done task.
+pub const DEFAULT_AUTO_ARCHIVE_GRACE_MINUTES: i64 = 5;
+
+/// Returns true if the column is a "Done" terminal column based on its name.
+pub fn is_done_column_name(name: &str) -> bool {
+    name.eq_ignore_ascii_case("done")
+}
+
+/// Read per-workspace auto-archive settings from the JSON `workspace.config` blob.
+///
+/// Returns `(enabled, grace_minutes)`. Defaults: enabled=true, grace=5m.
+pub fn read_auto_archive_config(workspace_config: &str) -> (bool, i64) {
+    let config: Value = serde_json::from_str(workspace_config).unwrap_or(Value::Null);
+    let enabled = config["autoArchiveDone"].as_bool().unwrap_or(true);
+    let grace = config["autoArchiveGraceMinutes"]
+        .as_i64()
+        .filter(|m| *m > 0)
+        .unwrap_or(DEFAULT_AUTO_ARCHIVE_GRACE_MINUTES);
+    (enabled, grace)
+}
+
+/// Auto-archive Done tasks for every workspace that has the toggle enabled.
+///
+/// A task is eligible when:
+/// - it's in a column named "Done" (case-insensitive),
+/// - `archived_at IS NULL`,
+/// - `updated_at` is older than the workspace's grace period.
+///
+/// Returns the total number of tasks archived across all workspaces.
+pub fn auto_archive_done_tasks(conn: &Connection) -> rusqlite::Result<i64> {
+    let mut total = 0i64;
+
+    let mut stmt = conn.prepare("SELECT id, config FROM workspaces")?;
+    let workspaces: Vec<(String, String)> = stmt
+        .query_map([], |row| {
+            let config: Option<String> = row.get(1)?;
+            Ok((
+                row.get::<_, String>(0)?,
+                config.unwrap_or_else(|| "{}".to_string()),
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
+
+    for (workspace_id, config_json) in workspaces {
+        let (enabled, grace_minutes) = read_auto_archive_config(&config_json);
+        if !enabled {
+            continue;
+        }
+        total += archive_done_tasks_for_workspace(conn, &workspace_id, grace_minutes)?;
+    }
+
+    Ok(total)
+}
+
+/// Archive eligible Done tasks for a single workspace. Public for testing.
+pub fn archive_done_tasks_for_workspace(
+    conn: &Connection,
+    workspace_id: &str,
+    grace_minutes: i64,
+) -> rusqlite::Result<i64> {
+    let cutoff_clause = format!("datetime('now', '-{} minutes')", grace_minutes);
+    let sql = format!(
+        "UPDATE tasks
+         SET archived_at = ?1, updated_at = ?1
+         WHERE workspace_id = ?2
+           AND archived_at IS NULL
+           AND datetime(updated_at) < {}
+           AND column_id IN (
+               SELECT id FROM columns
+               WHERE workspace_id = ?2 AND LOWER(name) = 'done'
+           )",
+        cutoff_clause
+    );
+    let ts = super::super::db::now();
+    let n = conn.execute(&sql, params![ts, workspace_id])? as i64;
+    Ok(n)
+}
+
+/// Reconcile stale failure markers on Done tasks.
+///
+/// For every task in a Done column with `pipeline_error` set or
+/// `agent_status` of 'failed' / 'queued' / 'running':
+/// - clear `pipeline_error`,
+/// - reset `agent_status` to 'completed',
+/// - delete any `agent_sessions` rows for the task whose `status` is 'failed'.
+///
+/// The PR is in main, the task is in Done — the failure flags are stale.
+/// Returns `(tasks_reconciled, sessions_cleared)`.
+pub fn reconcile_done_task_state(conn: &Connection) -> rusqlite::Result<(i64, i64)> {
+    let ts = super::super::db::now();
+
+    let stale_tasks: Vec<String> = {
+        let mut stmt = conn.prepare(
+            "SELECT t.id
+             FROM tasks t
+             JOIN columns c ON c.id = t.column_id
+             WHERE LOWER(c.name) = 'done'
+               AND t.archived_at IS NULL
+               AND (
+                   t.pipeline_error IS NOT NULL
+                   OR t.agent_status IN ('failed', 'queued', 'running')
+               )",
+        )?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    };
+
+    if stale_tasks.is_empty() {
+        return Ok((0, 0));
+    }
+
+    let mut sessions_cleared = 0i64;
+    let mut tasks_reconciled = 0i64;
+
+    for task_id in &stale_tasks {
+        let updated = conn.execute(
+            "UPDATE tasks
+             SET pipeline_error = NULL,
+                 agent_status = 'completed',
+                 queued_at = NULL,
+                 updated_at = ?1
+             WHERE id = ?2",
+            params![ts, task_id],
+        )?;
+        tasks_reconciled += updated as i64;
+
+        let cleared = conn.execute(
+            "DELETE FROM agent_sessions WHERE task_id = ?1 AND status = 'failed'",
+            params![task_id],
+        )?;
+        sessions_cleared += cleared as i64;
+    }
+
+    Ok((tasks_reconciled, sessions_cleared))
+}
+
+/// Run a single hygiene cycle: auto-archive + reconciliation.
+///
+/// Logs counts at info level. Returns the totals so callers can emit events.
+pub fn run_hygiene_cycle(conn: &Connection) -> rusqlite::Result<HygieneCycleResult> {
+    let archived = auto_archive_done_tasks(conn).unwrap_or_else(|e| {
+        log::warn!("[hygiene] auto-archive failed: {}", e);
+        0
+    });
+    let (tasks_reconciled, sessions_cleared) = reconcile_done_task_state(conn).unwrap_or_else(|e| {
+        log::warn!("[hygiene] reconcile failed: {}", e);
+        (0, 0)
+    });
+
+    Ok(HygieneCycleResult {
+        archived,
+        tasks_reconciled,
+        sessions_cleared,
+    })
+}
+
+/// Aggregate counts from one hygiene cycle.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HygieneCycleResult {
+    pub archived: i64,
+    pub tasks_reconciled: i64,
+    pub sessions_cleared: i64,
+}
+
+impl HygieneCycleResult {
+    pub fn is_empty(&self) -> bool {
+        self.archived == 0 && self.tasks_reconciled == 0 && self.sessions_cleared == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    fn done_column(conn: &Connection, workspace_id: &str, position: i64) -> db::Column {
+        db::insert_column(conn, workspace_id, "Done", position).unwrap()
+    }
+
+    fn back_date_task(conn: &Connection, task_id: &str, minutes_ago: i64) {
+        let sql = format!(
+            "UPDATE tasks SET updated_at = datetime('now', '-{} minutes') WHERE id = ?1",
+            minutes_ago
+        );
+        conn.execute(&sql, params![task_id]).unwrap();
+    }
+
+    #[test]
+    fn read_auto_archive_config_defaults_when_missing() {
+        let (enabled, grace) = read_auto_archive_config("{}");
+        assert!(enabled);
+        assert_eq!(grace, DEFAULT_AUTO_ARCHIVE_GRACE_MINUTES);
+    }
+
+    #[test]
+    fn read_auto_archive_config_respects_disable_toggle() {
+        let (enabled, grace) = read_auto_archive_config(r#"{"autoArchiveDone":false}"#);
+        assert!(!enabled);
+        assert_eq!(grace, DEFAULT_AUTO_ARCHIVE_GRACE_MINUTES);
+    }
+
+    #[test]
+    fn read_auto_archive_config_uses_custom_grace() {
+        let (_, grace) = read_auto_archive_config(r#"{"autoArchiveGraceMinutes":15}"#);
+        assert_eq!(grace, 15);
+    }
+
+    #[test]
+    fn read_auto_archive_config_rejects_non_positive_grace() {
+        let (_, grace) = read_auto_archive_config(r#"{"autoArchiveGraceMinutes":0}"#);
+        assert_eq!(grace, DEFAULT_AUTO_ARCHIVE_GRACE_MINUTES);
+        let (_, grace) = read_auto_archive_config(r#"{"autoArchiveGraceMinutes":-1}"#);
+        assert_eq!(grace, DEFAULT_AUTO_ARCHIVE_GRACE_MINUTES);
+    }
+
+    #[test]
+    fn auto_archive_archives_only_old_done_tasks() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        let backlog = db::insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        let done = done_column(&conn, &ws.id, 1);
+
+        let fresh_done = db::insert_task(&conn, &ws.id, &done.id, "Fresh", None).unwrap();
+        let stale_done = db::insert_task(&conn, &ws.id, &done.id, "Stale", None).unwrap();
+        let stale_backlog = db::insert_task(&conn, &ws.id, &backlog.id, "Other", None).unwrap();
+
+        back_date_task(&conn, &stale_done.id, 30);
+        back_date_task(&conn, &stale_backlog.id, 30);
+
+        let n = archive_done_tasks_for_workspace(&conn, &ws.id, 5).unwrap();
+        assert_eq!(n, 1);
+
+        assert!(db::get_task(&conn, &stale_done.id).unwrap().archived_at.is_some());
+        assert!(db::get_task(&conn, &fresh_done.id).unwrap().archived_at.is_none());
+        assert!(db::get_task(&conn, &stale_backlog.id).unwrap().archived_at.is_none());
+    }
+
+    #[test]
+    fn auto_archive_skips_already_archived() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        let done = done_column(&conn, &ws.id, 0);
+        let task = db::insert_task(&conn, &ws.id, &done.id, "Already", None).unwrap();
+        db::archive_task(&conn, &task.id).unwrap();
+        let originally_archived_at = db::get_task(&conn, &task.id).unwrap().archived_at.unwrap();
+
+        // Re-back-date so the freshly-set archived_at doesn't count as "fresh".
+        back_date_task(&conn, &task.id, 30);
+
+        let n = archive_done_tasks_for_workspace(&conn, &ws.id, 5).unwrap();
+        assert_eq!(n, 0);
+
+        let after = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(after.archived_at.as_deref(), Some(originally_archived_at.as_str()));
+    }
+
+    #[test]
+    fn auto_archive_respects_per_workspace_disable_toggle() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        db::update_workspace(
+            &conn,
+            &ws.id,
+            None,
+            None,
+            None,
+            None,
+            Some(r#"{"autoArchiveDone":false}"#),
+        )
+        .unwrap();
+        let done = done_column(&conn, &ws.id, 0);
+        let task = db::insert_task(&conn, &ws.id, &done.id, "Stale", None).unwrap();
+        back_date_task(&conn, &task.id, 30);
+
+        let n = auto_archive_done_tasks(&conn).unwrap();
+        assert_eq!(n, 0);
+        assert!(db::get_task(&conn, &task.id).unwrap().archived_at.is_none());
+    }
+
+    #[test]
+    fn auto_archive_runs_across_workspaces() {
+        let conn = db::init_test().unwrap();
+        let ws_a = db::insert_workspace(&conn, "A", "/tmp/a").unwrap();
+        let ws_b = db::insert_workspace(&conn, "B", "/tmp/b").unwrap();
+        let done_a = done_column(&conn, &ws_a.id, 0);
+        let done_b = done_column(&conn, &ws_b.id, 0);
+
+        let t_a = db::insert_task(&conn, &ws_a.id, &done_a.id, "A", None).unwrap();
+        let t_b = db::insert_task(&conn, &ws_b.id, &done_b.id, "B", None).unwrap();
+        back_date_task(&conn, &t_a.id, 30);
+        back_date_task(&conn, &t_b.id, 30);
+
+        let n = auto_archive_done_tasks(&conn).unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn reconcile_clears_stale_failure_state_on_done_tasks() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        let done = done_column(&conn, &ws.id, 0);
+        let task = db::insert_task(&conn, &ws.id, &done.id, "Stale", None).unwrap();
+
+        db::update_task_pipeline_state(
+            &conn,
+            &task.id,
+            "idle",
+            None,
+            Some("Pipeline failed: reviewer crashed"),
+        )
+        .unwrap();
+        db::update_task_agent_status(&conn, &task.id, Some("failed"), None).unwrap();
+
+        let session = db::insert_agent_session(&conn, &task.id, "claude", None).unwrap();
+        db::update_agent_session(
+            &conn,
+            &session.id,
+            None,
+            Some("failed"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let (tasks, sessions) = reconcile_done_task_state(&conn).unwrap();
+        assert_eq!(tasks, 1);
+        assert_eq!(sessions, 1);
+
+        let after = db::get_task(&conn, &task.id).unwrap();
+        assert!(after.pipeline_error.is_none());
+        assert_eq!(after.agent_status.as_deref(), Some("completed"));
+        assert!(db::list_agent_sessions(&conn, &task.id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn reconcile_skips_archived_done_tasks() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        let done = done_column(&conn, &ws.id, 0);
+        let task = db::insert_task(&conn, &ws.id, &done.id, "Stale", None).unwrap();
+        db::update_task_pipeline_state(&conn, &task.id, "idle", None, Some("err")).unwrap();
+        db::archive_task(&conn, &task.id).unwrap();
+
+        let (tasks, _) = reconcile_done_task_state(&conn).unwrap();
+        assert_eq!(tasks, 0);
+
+        let after = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(after.pipeline_error.as_deref(), Some("err"));
+    }
+
+    #[test]
+    fn reconcile_leaves_active_tasks_alone() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        let backlog = db::insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+        let _done = done_column(&conn, &ws.id, 1);
+        let task = db::insert_task(&conn, &ws.id, &backlog.id, "Active", None).unwrap();
+        db::update_task_pipeline_state(&conn, &task.id, "idle", None, Some("real failure")).unwrap();
+        db::update_task_agent_status(&conn, &task.id, Some("failed"), None).unwrap();
+
+        let (tasks, _) = reconcile_done_task_state(&conn).unwrap();
+        assert_eq!(tasks, 0);
+
+        let after = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(after.pipeline_error.as_deref(), Some("real failure"));
+        assert_eq!(after.agent_status.as_deref(), Some("failed"));
+    }
+
+    #[test]
+    fn run_hygiene_cycle_aggregates_counts() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        let done = done_column(&conn, &ws.id, 0);
+
+        let archive_target = db::insert_task(&conn, &ws.id, &done.id, "Archive", None).unwrap();
+        back_date_task(&conn, &archive_target.id, 30);
+
+        let reconcile_target = db::insert_task(&conn, &ws.id, &done.id, "Reconcile", None).unwrap();
+        db::update_task_pipeline_state(
+            &conn,
+            &reconcile_target.id,
+            "idle",
+            None,
+            Some("stale"),
+        )
+        .unwrap();
+
+        let result = run_hygiene_cycle(&conn).unwrap();
+        // Reconcile happens after archive, so the reconcile target was untouched
+        // by archiving (still updated_at = now()), and the archive target was
+        // archived AND its pipeline_error was already null — so only one of each.
+        assert_eq!(result.archived, 1);
+        assert_eq!(result.tasks_reconciled, 1);
+        assert!(!result.is_empty());
+    }
+}

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -5,6 +5,7 @@
 //! When exit criteria are met, the task auto-advances to the next column.
 
 pub mod dependencies;
+pub mod hygiene;
 pub mod template;
 pub mod triggers;
 

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -1534,7 +1534,6 @@ fn execute_auto_merge(
     let cleaned =
         super::cleanup_task_worktree_if_terminal(conn, &moved, &done_col, "auto_merge")?;
     let _ = super::dependencies::check_dependents(conn, app, &cleaned);
-    let last_updated = Some(cleaned);
 
     emit_pipeline(
         app,
@@ -1546,7 +1545,7 @@ fn execute_auto_merge(
     );
     super::emit_tasks_changed(app, &task.workspace_id, "auto_merge_done");
 
-    Ok(last_updated.unwrap_or_else(|| task.clone()))
+    Ok(cleaned)
 }
 
 fn execute_create_pr(

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -422,9 +422,17 @@ export const TaskCard = memo(function TaskCard({
             {task.title}
           </h4>
           {task.archivedAt && (
-            <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium bg-surface-hover text-text-secondary/70 border border-border-default">
-              archived
-            </span>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); actions.handleUnarchiveTask(); }}
+              title="Restore — move back to the active board"
+              className="shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-surface-hover text-text-secondary/80 border border-border-default hover:border-accent hover:text-accent transition-colors"
+            >
+              <svg viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3">
+                <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H4.598a.75.75 0 0 0-.75.75v3.634a.75.75 0 0 0 1.5 0v-2.033l.312.311a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39l-.611.21ZM4.688 8.576a5.5 5.5 0 0 1 9.201-2.466l.312.311h-2.433a.75.75 0 0 0 0 1.5h3.634a.75.75 0 0 0 .75-.75V3.537a.75.75 0 0 0-1.5 0v2.033l-.312-.311A7 7 0 0 0 3.628 8.397a.75.75 0 0 0 1.449.39l-.389-.211Z" clipRule="evenodd" />
+              </svg>
+              Restore
+            </button>
           )}
         </div>
 

--- a/src/components/settings/tabs/workspace-tab.tsx
+++ b/src/components/settings/tabs/workspace-tab.tsx
@@ -215,6 +215,41 @@ export function WorkspaceTab() {
                 />
               </button>
             </SettingRow>
+
+            <SettingRow
+              label="Auto-Archive Done"
+              description="Automatically archive tasks that sit in Done past the grace period"
+            >
+              <button
+                type="button"
+                role="switch"
+                aria-checked={config.autoArchiveDone ?? true}
+                onClick={() => { void updateConfig({ autoArchiveDone: !(config.autoArchiveDone ?? true) }) }}
+                className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-accent/20 ${
+                  (config.autoArchiveDone ?? true) ? 'bg-accent' : 'bg-border-default'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+                    (config.autoArchiveDone ?? true) ? 'translate-x-5' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </SettingRow>
+
+            {(config.autoArchiveDone ?? true) && (
+              <SettingRow
+                label="Archive Grace Period"
+                description="Minutes a Done task waits before auto-archiving"
+              >
+                <SettingSlider
+                  value={config.autoArchiveGraceMinutes ?? 5}
+                  onChange={(v) => { void updateConfig({ autoArchiveGraceMinutes: v }) }}
+                  min={1}
+                  max={60}
+                />
+              </SettingRow>
+            )}
           </div>
         </SettingSection>
       )}

--- a/src/components/settings/tabs/workspace-tab.tsx
+++ b/src/components/settings/tabs/workspace-tab.tsx
@@ -3,6 +3,7 @@ import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useColumnStore } from '@/stores/column-store'
 import { useTaskStore } from '@/stores/task-store'
 import { SettingSection, SettingRow, SettingSlider } from '@/components/shared/setting-components'
+import { Toggle } from '@/components/shared/toggle'
 import { PathPicker } from '@/components/shared/path-picker'
 import { parseWorkspaceConfig } from '@/types'
 import type { WorkspaceConfig } from '@/types'
@@ -199,42 +200,22 @@ export function WorkspaceTab() {
             </SettingRow>
 
             <SettingRow label="Auto-Advance" description="Automatically move tasks to next column when exit criteria are met">
-              <button
-                type="button"
-                role="switch"
-                aria-checked={config.autoAdvance ?? true}
-                onClick={() => { void updateConfig({ autoAdvance: !(config.autoAdvance ?? true) }) }}
-                className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-accent/20 ${
-                  (config.autoAdvance ?? true) ? 'bg-accent' : 'bg-border-default'
-                }`}
-              >
-                <span
-                  className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
-                    (config.autoAdvance ?? true) ? 'translate-x-5' : 'translate-x-0'
-                  }`}
-                />
-              </button>
+              <Toggle
+                checked={config.autoAdvance ?? true}
+                onChange={(v) => { void updateConfig({ autoAdvance: v }) }}
+                size="md"
+              />
             </SettingRow>
 
             <SettingRow
               label="Auto-Archive Done"
               description="Automatically archive tasks that sit in Done past the grace period"
             >
-              <button
-                type="button"
-                role="switch"
-                aria-checked={config.autoArchiveDone ?? true}
-                onClick={() => { void updateConfig({ autoArchiveDone: !(config.autoArchiveDone ?? true) }) }}
-                className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-accent/20 ${
-                  (config.autoArchiveDone ?? true) ? 'bg-accent' : 'bg-border-default'
-                }`}
-              >
-                <span
-                  className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
-                    (config.autoArchiveDone ?? true) ? 'translate-x-5' : 'translate-x-0'
-                  }`}
-                />
-              </button>
+              <Toggle
+                checked={config.autoArchiveDone ?? true}
+                onChange={(v) => { void updateConfig({ autoArchiveDone: v }) }}
+                size="md"
+              />
             </SettingRow>
 
             {(config.autoArchiveDone ?? true) && (

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -3,6 +3,10 @@ export type WorkspaceConfig = {
   defaultAgentCli?: string
   maxConcurrentAgents?: number
   autoAdvance?: boolean
+  /** Auto-archive tasks that have sat in Done past the grace period. Default: true. */
+  autoArchiveDone?: boolean
+  /** How long a task must sit in Done before auto-archive (minutes). Default: 5. */
+  autoArchiveGraceMinutes?: number
   githubRepo?: string
   githubLabelFilter?: string
   githubSyncEnabled?: boolean


### PR DESCRIPTION
## Why

Two infra fixes for issues we hit today (had to hand-SQL hundreds of records):

1. **Stale Done tasks accumulate forever** — manual archiving is tedious. Add per-workspace auto-archive after a grace period (default 5 min, configurable).
2. **Failed agent_sessions stay flagged after PR merges** — UI shows red "Pipeline failed" badges on tasks that actually shipped. Reconcile session state when a Done task's PR is found merged.

## Changes

### \`hygiene.rs\` (new module)
- \`auto_archive_done_tasks(conn)\` — sweeps all workspaces, archives Done tasks past grace period
- \`reconcile_done_task_state(conn)\` — clears stale \`pipeline_error\` + failed agent_sessions on Done tasks whose PRs are merged
- \`read_auto_archive_config\` — per-workspace JSON config: \`{ autoArchiveDone, autoArchiveDoneGraceMinutes }\`

### Schema
No new columns — uses existing \`tasks.archived_at\` + \`workspace.config\`.

### UI
- \`workspace-tab.tsx\`: Toggle for "Auto-Archive Done" + slider for grace period
- Shared \`<Toggle>\` component (replaces 2 inline toggle button JSX dupes)

### Refactors (followup commit)
- Use \`db::list_workspaces()\` helper instead of manual SQL iteration
- Parameterize the cutoff SQL (was format-string concat)

## Test Plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy -- -D warnings\` clean
- [ ] Live: leave a few Done tasks past grace period, verify they get archived
- [ ] Live: merge a PR, verify task's \`pipeline_error\` clears and red badge disappears

## Notes

Reviewed manually — Review-Quality stage hit Anthropic server-side rate limit (not a real review failure). Code is committed clean, +503/-17 across 6 files plus a +23/-58 cleanup followup. Direct review encouraged.