### PR TITLE
Pipeline Setup hardening — fix branch base, serialize concurrent setups, kill silent fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-webdriver-automation",
  "tauri-plugin-window-state",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "uuid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,9 @@ tauri-plugin-webdriver-automation = { version = "0.1.3", optional = true }
 pty-process = { version = "0.5.3", features = ["async", "tokio"] }
 libc = "0.2.184"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 default = []
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -12,6 +12,7 @@ use std::sync::{Mutex, OnceLock};
 
 pub const DEFAULT_PIPELINE_MAX_CONCURRENT_AGENTS: i64 = 5;
 pub const DEFAULT_BRANCH_PREFIX: &str = "bentoya/";
+pub const DEFAULT_BASE_BRANCH: &str = "main";
 
 /// Global cached settings instance. Reloaded on save.
 static CACHED_SETTINGS: OnceLock<Mutex<AppSettings>> = OnceLock::new();
@@ -57,6 +58,7 @@ pub struct EffectivePipelineSettings {
     pub default_model: Option<String>,
     pub max_concurrent_agents: i64,
     pub branch_prefix: String,
+    pub default_base_branch: String,
 }
 
 fn workspace_config_value<'a>(config: &'a Value, path: &[&str]) -> Option<&'a Value> {
@@ -162,11 +164,23 @@ fn effective_pipeline_settings_with_app_settings(
     .map(|prefix| normalize_branch_prefix(&prefix))
     .unwrap_or_else(|| DEFAULT_BRANCH_PREFIX.to_string());
 
+    let default_base_branch = workspace_config_string(
+        &workspace_config,
+        &[
+            &["defaultBaseBranch"],
+            &["default_base_branch"],
+            &["git", "defaultBaseBranch"],
+            &["git", "default_base_branch"],
+        ],
+    )
+    .unwrap_or_else(|| DEFAULT_BASE_BRANCH.to_string());
+
     EffectivePipelineSettings {
         default_agent_cli,
         default_model,
         max_concurrent_agents,
         branch_prefix,
+        default_base_branch,
     }
 }
 
@@ -387,6 +401,28 @@ mod tests {
         assert_eq!(effective.default_model.as_deref(), Some("sonnet"));
         assert_eq!(effective.max_concurrent_agents, 7);
         assert_eq!(effective.branch_prefix, "work/");
+        assert_eq!(effective.default_base_branch, DEFAULT_BASE_BRANCH);
+    }
+
+    #[test]
+    fn test_effective_pipeline_settings_default_base_branch_override() {
+        let cfg = r#"{"defaultBaseBranch": "develop"}"#;
+        let effective = effective_pipeline_settings_with_app_settings(cfg, &AppSettings::default());
+        assert_eq!(effective.default_base_branch, "develop");
+    }
+
+    #[test]
+    fn test_effective_pipeline_settings_default_base_branch_nested() {
+        let cfg = r#"{"git": {"defaultBaseBranch": "trunk"}}"#;
+        let effective = effective_pipeline_settings_with_app_settings(cfg, &AppSettings::default());
+        assert_eq!(effective.default_base_branch, "trunk");
+    }
+
+    #[test]
+    fn test_effective_pipeline_settings_default_base_branch_empty_falls_back() {
+        let cfg = r#"{"defaultBaseBranch": ""}"#;
+        let effective = effective_pipeline_settings_with_app_settings(cfg, &AppSettings::default());
+        assert_eq!(effective.default_base_branch, DEFAULT_BASE_BRANCH);
     }
 
     #[test]

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -484,6 +484,18 @@ pub fn get_queued_tasks(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<
     with_labels_for_tasks(conn, rows.collect::<SqlResult<Vec<_>>>()?)
 }
 
+/// Get tasks with `pipeline_state = 'setup_queued'` ordered by updated_at
+/// (oldest first) — used to promote a setup-queued task when the workspace's
+/// setup lock releases.
+pub fn get_setup_queued_tasks(conn: &Connection, workspace_id: &str) -> SqlResult<Vec<Task>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {} FROM tasks WHERE workspace_id = ?1 AND pipeline_state = 'setup_queued' AND archived_at IS NULL ORDER BY updated_at ASC",
+        TASK_COLUMNS
+    ))?;
+    let rows = stmt.query_map(params![workspace_id], map_task_row)?;
+    with_labels_for_tasks(conn, rows.collect::<SqlResult<Vec<_>>>()?)
+}
+
 /// Count tasks with agent_status = 'running' in a workspace
 pub fn get_running_agent_count(conn: &Connection, workspace_id: &str) -> SqlResult<i64> {
     conn.query_row(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -591,7 +591,8 @@ fn recover_tmux_sessions(app: tauri::AppHandle) {
     }
 }
 
-const STALE_PIPELINE_STATES_SQL: &str = "'running', 'triggered', 'evaluating', 'advancing'";
+const STALE_PIPELINE_STATES_SQL: &str =
+    "'running', 'triggered', 'evaluating', 'advancing', 'setup_queued'";
 
 fn is_stale_pipeline_state(state: &str) -> bool {
     pipeline::PipelineState::from_db_str(state) != pipeline::PipelineState::Idle

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -34,6 +34,8 @@ pub enum PipelineState {
     Evaluating,
     /// Task is advancing to next column
     Advancing,
+    /// Setup is queued — another setup is running in this workspace
+    SetupQueued,
 }
 
 impl PipelineState {
@@ -44,6 +46,7 @@ impl PipelineState {
             PipelineState::Running => "running",
             PipelineState::Evaluating => "evaluating",
             PipelineState::Advancing => "advancing",
+            PipelineState::SetupQueued => "setup_queued",
         }
     }
 
@@ -53,6 +56,7 @@ impl PipelineState {
             "running" => PipelineState::Running,
             "evaluating" => PipelineState::Evaluating,
             "advancing" => PipelineState::Advancing,
+            "setup_queued" => PipelineState::SetupQueued,
             _ => PipelineState::Idle,
         }
     }
@@ -1323,6 +1327,7 @@ mod tests {
             PipelineState::Running,
             PipelineState::Evaluating,
             PipelineState::Advancing,
+            PipelineState::SetupQueued,
         ] {
             assert_eq!(PipelineState::from_db_str(state.as_str()), state);
         }

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -44,7 +44,7 @@ fn setup_locks() -> &'static Mutex<HashSet<String>> {
 
 /// Try to acquire the per-workspace Setup lock. Returns `true` if acquired,
 /// `false` if another setup is already holding it.
-pub(crate) fn try_acquire_setup_lock(workspace_id: &str) -> bool {
+fn try_acquire_setup_lock(workspace_id: &str) -> bool {
     let mut locks = setup_locks().lock().unwrap_or_else(|e| e.into_inner());
     if locks.contains(workspace_id) {
         return false;
@@ -54,15 +54,42 @@ pub(crate) fn try_acquire_setup_lock(workspace_id: &str) -> bool {
 }
 
 /// Release the per-workspace Setup lock. Idempotent.
-pub(crate) fn release_setup_lock(workspace_id: &str) {
+fn release_setup_lock(workspace_id: &str) {
     let mut locks = setup_locks().lock().unwrap_or_else(|e| e.into_inner());
     locks.remove(workspace_id);
 }
 
 #[cfg(test)]
-pub(crate) fn setup_lock_held(workspace_id: &str) -> bool {
+fn setup_lock_held(workspace_id: &str) -> bool {
     let locks = setup_locks().lock().unwrap_or_else(|e| e.into_inner());
     locks.contains(workspace_id)
+}
+
+/// RAII guard for the per-workspace Setup lock. Releases the lock and
+/// promotes the next queued task on Drop, so an early `?` return or panic
+/// inside the locked region cannot strand the workspace.
+struct SetupLockGuard<'a> {
+    workspace_id: String,
+    app: &'a AppHandle,
+}
+
+impl<'a> SetupLockGuard<'a> {
+    fn try_acquire(workspace_id: &str, app: &'a AppHandle) -> Option<Self> {
+        if !try_acquire_setup_lock(workspace_id) {
+            return None;
+        }
+        Some(Self {
+            workspace_id: workspace_id.to_string(),
+            app,
+        })
+    }
+}
+
+impl<'a> Drop for SetupLockGuard<'a> {
+    fn drop(&mut self) {
+        release_setup_lock(&self.workspace_id);
+        promote_setup_queued_tasks(self.app, &self.workspace_id);
+    }
 }
 
 // ─── V2 Trigger Types ─────────────────────────────────────────────────────
@@ -621,33 +648,32 @@ fn ensure_task_batch_id(conn: &Connection, task: &Task) -> Result<Task, AppError
     Ok(db::update_task_batch_id(conn, &task.id, Some(&batch_id))?)
 }
 
-/// Validate that `base_branch` is present and non-blank. Returns the trimmed
-/// value or an `InvalidInput` error explaining the rejection.
+/// Validate that `base_branch` is non-blank. Returns the trimmed value or an
+/// `InvalidInput` error explaining the rejection.
 ///
-/// Bug B: a missing/blank base_branch must hard-fail rather than silently
-/// fall through to whatever HEAD happens to point at in the main repo
-/// working directory.
+/// Bug B: a blank base_branch must hard-fail rather than silently fall
+/// through to whatever HEAD happens to point at in the main repo working
+/// directory.
 fn validate_setup_base_branch<'a>(
-    base_branch: Option<&'a str>,
+    base_branch: &'a str,
     task_id: &str,
 ) -> Result<&'a str, AppError> {
-    base_branch
-        .map(str::trim)
-        .filter(|b| !b.is_empty())
-        .ok_or_else(|| {
-            AppError::InvalidInput(format!(
-                "ensure_task_worktree requires an explicit base_branch (task {})",
-                task_id
-            ))
-        })
+    let trimmed = base_branch.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput(format!(
+            "ensure_task_worktree requires a non-blank base_branch (task {})",
+            task_id
+        )));
+    }
+    Ok(trimmed)
 }
 
 /// Auto-create a branch + worktree for a task if missing.
 /// Returns the updated task with `branch_name` and `worktree_path` set.
 ///
-/// Bug B: callers MUST pass an explicit `base_branch`. Passing `None` is now
-/// a hard error so we never inherit whatever happens to be checked out in
-/// the user's main repo working directory. Use the workspace's
+/// Bug B: callers MUST pass an explicit `base_branch`. A blank value is a
+/// hard error so we never inherit whatever happens to be checked out in the
+/// user's main repo working directory. Use the workspace's
 /// `default_base_branch` (resolved via `EffectivePipelineSettings`) when no
 /// caller-specific base applies.
 ///
@@ -659,7 +685,7 @@ fn ensure_task_worktree(
     task: &Task,
     repo_path: &str,
     settings: &EffectivePipelineSettings,
-    base_branch: Option<&str>,
+    base_branch: &str,
 ) -> Result<Task, AppError> {
     let mut task = task.clone();
 
@@ -762,7 +788,7 @@ fn ensure_task_worktree_with_retry(
     task: &Task,
     repo_path: &str,
     settings: &EffectivePipelineSettings,
-    base_branch: Option<&str>,
+    base_branch: &str,
 ) -> Result<Task, AppError> {
     match ensure_task_worktree(conn, app, task, repo_path, settings, base_branch) {
         Ok(t) => return Ok(t),
@@ -855,39 +881,37 @@ fn execute_auto_setup(
 
     // Bug C: serialize Setup per-workspace. Multiple tasks branching from the
     // same base SHA in parallel race; the loser is stale before it starts.
-    if !try_acquire_setup_lock(&task.workspace_id) {
-        log::info!(
-            "[triggers] Setup lock held for workspace {} — queuing task {}",
-            task.workspace_id,
-            task.id
-        );
-        let queued = db::update_task_pipeline_state(
-            conn,
-            &task.id,
-            PipelineState::SetupQueued.as_str(),
-            None,
-            None,
-        )?;
-        emit_pipeline(
-            app,
-            EVT_TRIGGERED,
-            &queued.id,
-            &column.id,
-            PipelineState::SetupQueued,
-            Some("Waiting for setup slot".to_string()),
-        );
-        super::emit_tasks_changed(app, &task.workspace_id, "setup_queued");
-        return Ok(queued);
-    }
+    let _guard = match SetupLockGuard::try_acquire(&task.workspace_id, app) {
+        Some(g) => g,
+        None => {
+            log::info!(
+                "[triggers] Setup lock held for workspace {} — queuing task {}",
+                task.workspace_id,
+                task.id
+            );
+            let queued = db::update_task_pipeline_state(
+                conn,
+                &task.id,
+                PipelineState::SetupQueued.as_str(),
+                None,
+                None,
+            )?;
+            emit_pipeline(
+                app,
+                EVT_TRIGGERED,
+                &queued.id,
+                &column.id,
+                PipelineState::SetupQueued,
+                Some("Waiting for setup slot".to_string()),
+            );
+            super::emit_tasks_changed(app, &task.workspace_id, "setup_queued");
+            return Ok(queued);
+        }
+    };
 
-    let result = perform_auto_setup_locked(conn, app, task, column, &workspace, &pipeline_settings);
-
-    // Always release the lock — promote any queued setup tasks regardless of
-    // success/failure so a stuck task does not strand the rest.
-    release_setup_lock(&task.workspace_id);
-    promote_setup_queued_tasks(app, &task.workspace_id);
-
-    result
+    // Guard's Drop releases the lock and promotes the next queued task,
+    // even if `perform_auto_setup_locked` returns early via `?` or panics.
+    perform_auto_setup_locked(conn, app, task, column, &workspace, &pipeline_settings)
 }
 
 fn perform_auto_setup_locked(
@@ -904,7 +928,7 @@ fn perform_auto_setup_locked(
         task,
         &workspace.repo_path,
         pipeline_settings,
-        Some(&pipeline_settings.default_base_branch),
+        &pipeline_settings.default_base_branch,
     ) {
         Ok(task) => task,
         Err(e) => return fail_auto_setup(conn, app, task, column, e.to_string()),
@@ -1092,7 +1116,7 @@ fn execute_spawn_cli(
             &fresh_task,
             &workspace.repo_path,
             &pipeline_settings,
-            Some(&pipeline_settings.default_base_branch),
+            &pipeline_settings.default_base_branch,
         )?
     } else {
         task.clone()
@@ -3149,23 +3173,15 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_setup_base_branch_rejects_none() {
-        let err = validate_setup_base_branch(None, "task-1")
-            .expect_err("None must be rejected");
+    fn test_validate_setup_base_branch_rejects_blank() {
+        let err = validate_setup_base_branch("", "task-1")
+            .expect_err("empty must be rejected");
         match err {
             AppError::InvalidInput(msg) => assert!(msg.contains("base_branch")),
             other => panic!("unexpected error: {:?}", other),
         }
-    }
-
-    #[test]
-    fn test_validate_setup_base_branch_rejects_blank() {
         assert!(matches!(
-            validate_setup_base_branch(Some("   "), "task-1"),
-            Err(AppError::InvalidInput(_))
-        ));
-        assert!(matches!(
-            validate_setup_base_branch(Some(""), "task-1"),
+            validate_setup_base_branch("   ", "task-1"),
             Err(AppError::InvalidInput(_))
         ));
     }
@@ -3173,11 +3189,11 @@ mod tests {
     #[test]
     fn test_validate_setup_base_branch_trims_and_returns() {
         assert_eq!(
-            validate_setup_base_branch(Some("  main  "), "task-1").unwrap(),
+            validate_setup_base_branch("  main  ", "task-1").unwrap(),
             "main"
         );
         assert_eq!(
-            validate_setup_base_branch(Some("develop"), "task-1").unwrap(),
+            validate_setup_base_branch("develop", "task-1").unwrap(),
             "develop"
         );
     }

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -10,13 +10,60 @@ use crate::error::AppError;
 use crate::git::branch_manager;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
 use super::template::{self, TemplateContext};
 use super::{emit_pipeline, PipelineState, EVT_ADVANCED, EVT_RUNNING, EVT_TRIGGERED};
 
 const STAGING_BRANCH_PREFIX: &str = "staging/";
+
+/// Backoff delays between worktree creation retries (3 attempts after the
+/// initial try). Total worst-case wait: 10.5s.
+const SETUP_RETRY_BACKOFFS: [Duration; 3] = [
+    Duration::from_millis(500),
+    Duration::from_secs(2),
+    Duration::from_secs(8),
+];
+
+// ─── Setup Serialization (per-workspace) ──────────────────────────────────
+
+/// Workspaces with an active Setup currently holding the lock.
+///
+/// Bug C: N tasks entering Setup at once race on the same base branch SHA.
+/// Even with a pre-fetch, simultaneous setups produce stale dependents the
+/// moment one of them merges. This mutex serializes Setup *per workspace*.
+/// Cross-workspace setup remains parallel (different repos can't conflict).
+static SETUP_LOCKS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn setup_locks() -> &'static Mutex<HashSet<String>> {
+    SETUP_LOCKS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Try to acquire the per-workspace Setup lock. Returns `true` if acquired,
+/// `false` if another setup is already holding it.
+pub(crate) fn try_acquire_setup_lock(workspace_id: &str) -> bool {
+    let mut locks = setup_locks().lock().unwrap_or_else(|e| e.into_inner());
+    if locks.contains(workspace_id) {
+        return false;
+    }
+    locks.insert(workspace_id.to_string());
+    true
+}
+
+/// Release the per-workspace Setup lock. Idempotent.
+pub(crate) fn release_setup_lock(workspace_id: &str) {
+    let mut locks = setup_locks().lock().unwrap_or_else(|e| e.into_inner());
+    locks.remove(workspace_id);
+}
+
+#[cfg(test)]
+pub(crate) fn setup_lock_held(workspace_id: &str) -> bool {
+    let locks = setup_locks().lock().unwrap_or_else(|e| e.into_inner());
+    locks.contains(workspace_id)
+}
 
 // ─── V2 Trigger Types ─────────────────────────────────────────────────────
 
@@ -574,8 +621,38 @@ fn ensure_task_batch_id(conn: &Connection, task: &Task) -> Result<Task, AppError
     Ok(db::update_task_batch_id(conn, &task.id, Some(&batch_id))?)
 }
 
+/// Validate that `base_branch` is present and non-blank. Returns the trimmed
+/// value or an `InvalidInput` error explaining the rejection.
+///
+/// Bug B: a missing/blank base_branch must hard-fail rather than silently
+/// fall through to whatever HEAD happens to point at in the main repo
+/// working directory.
+fn validate_setup_base_branch<'a>(
+    base_branch: Option<&'a str>,
+    task_id: &str,
+) -> Result<&'a str, AppError> {
+    base_branch
+        .map(str::trim)
+        .filter(|b| !b.is_empty())
+        .ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "ensure_task_worktree requires an explicit base_branch (task {})",
+                task_id
+            ))
+        })
+}
+
 /// Auto-create a branch + worktree for a task if missing.
 /// Returns the updated task with `branch_name` and `worktree_path` set.
+///
+/// Bug B: callers MUST pass an explicit `base_branch`. Passing `None` is now
+/// a hard error so we never inherit whatever happens to be checked out in
+/// the user's main repo working directory. Use the workspace's
+/// `default_base_branch` (resolved via `EffectivePipelineSettings`) when no
+/// caller-specific base applies.
+///
+/// Bug D: a worktree creation failure now hard-fails. The previous silent
+/// fallback caused agents to mutate the user's actual main checkout.
 fn ensure_task_worktree(
     conn: &Connection,
     app: &AppHandle,
@@ -588,18 +665,20 @@ fn ensure_task_worktree(
 
     // Step 1: Ensure task has a branch
     if task.branch_name.as_deref().unwrap_or("").is_empty() {
+        let base = validate_setup_base_branch(base_branch, &task.id)?;
         let slug = branch_manager::slugify(&task.title);
         match branch_manager::create_task_branch_with_prefix(
             repo_path,
             &slug,
-            base_branch,
+            Some(base),
             &settings.branch_prefix,
         ) {
             Ok(branch_name) => {
                 task = db::update_task_branch(conn, &task.id, Some(&branch_name))?;
                 log::info!(
-                    "[triggers] Auto-created branch '{}' for task {}",
+                    "[triggers] Auto-created branch '{}' from '{}' for task {}",
                     branch_name,
+                    base,
                     task.id
                 );
             }
@@ -610,8 +689,8 @@ fn ensure_task_worktree(
                     .map_err(AppError::CommandError)?;
                 if !branch_exists {
                     return Err(AppError::CommandError(format!(
-                        "Failed to create branch '{}': {}",
-                        branch_name, e
+                        "Failed to create branch '{}' from base '{}': {}",
+                        branch_name, base, e
                     )));
                 }
                 log::warn!(
@@ -624,37 +703,114 @@ fn ensure_task_worktree(
         }
     }
 
-    let branch_name = task.branch_name.as_deref().unwrap_or("");
+    let branch_name = task.branch_name.as_deref().unwrap_or("").to_string();
     if branch_name.is_empty() {
-        log::warn!(
-            "[triggers] Could not determine branch for task {}, skipping worktree",
+        return Err(AppError::CommandError(format!(
+            "Failed to resolve branch_name for task {} after creation",
             task.id
-        );
-        return Ok(task);
+        )));
     }
 
-    // Step 2: Create worktree
-    match branch_manager::create_task_worktree(repo_path, branch_name, &task.id) {
-        Ok(wt_path) => {
-            task = db::update_task_worktree_path(conn, &task.id, Some(&wt_path))?;
-            super::emit_tasks_changed(app, &task.workspace_id, "worktree_auto_created");
-            log::info!(
-                "[triggers] Auto-created worktree at '{}' for task {}",
-                wt_path,
-                task.id
-            );
-        }
+    // Step 2: Create worktree (hard-fail on error per Bug D)
+    let wt_path = branch_manager::create_task_worktree(repo_path, &branch_name, &task.id)
+        .map_err(|e| {
+            AppError::CommandError(format!(
+                "Failed to create worktree for task {}: {}",
+                task.id, e
+            ))
+        })?;
+
+    task = db::update_task_worktree_path(conn, &task.id, Some(&wt_path))?;
+    super::emit_tasks_changed(app, &task.workspace_id, "worktree_auto_created");
+    log::info!(
+        "[triggers] Auto-created worktree at '{}' for task {}",
+        wt_path,
+        task.id
+    );
+
+    Ok(task)
+}
+
+/// Best-effort classification of a setup error as transient. Transient errors
+/// (filesystem races, libgit2 lock contention, "branch already exists with
+/// different ref") get retried with backoff; config errors do not.
+fn is_transient_setup_error(err: &AppError) -> bool {
+    let msg = match err {
+        AppError::CommandError(m) | AppError::DatabaseError(m) => m.to_lowercase(),
+        AppError::NotFound(_) | AppError::InvalidInput(_) => return false,
+    };
+    let needles = [
+        "lock",
+        "locked",
+        "resource temporarily unavailable",
+        "already exists",
+        "would clobber",
+        "another git process",
+        "index.lock",
+        "cannot lock ref",
+        "stale file",
+        "interrupt",
+        "timed out",
+    ];
+    needles.iter().any(|n| msg.contains(n))
+}
+
+/// Wrap `ensure_task_worktree` with bounded retries on transient errors.
+fn ensure_task_worktree_with_retry(
+    conn: &Connection,
+    app: &AppHandle,
+    task: &Task,
+    repo_path: &str,
+    settings: &EffectivePipelineSettings,
+    base_branch: Option<&str>,
+) -> Result<Task, AppError> {
+    match ensure_task_worktree(conn, app, task, repo_path, settings, base_branch) {
+        Ok(t) => return Ok(t),
+        Err(e) if !is_transient_setup_error(&e) => return Err(e),
         Err(e) => {
-            log::error!(
-                "[triggers] Failed to create worktree for task {}: {}",
+            log::warn!(
+                "[triggers] Transient setup failure for task {} (attempt 1): {} — retrying",
                 task.id,
                 e
             );
-            // Continue without worktree — agent falls back to repo root
         }
     }
 
-    Ok(task)
+    let mut last_err = None;
+    for (idx, backoff) in SETUP_RETRY_BACKOFFS.iter().enumerate() {
+        std::thread::sleep(*backoff);
+        // Re-fetch the task in case prior attempt persisted partial state.
+        let fresh = match db::get_task(conn, &task.id) {
+            Ok(t) => t,
+            Err(e) => return Err(AppError::from(e)),
+        };
+        match ensure_task_worktree(conn, app, &fresh, repo_path, settings, base_branch) {
+            Ok(t) => {
+                log::info!(
+                    "[triggers] Setup succeeded for task {} on retry attempt {}",
+                    task.id,
+                    idx + 2
+                );
+                return Ok(t);
+            }
+            Err(e) if !is_transient_setup_error(&e) => return Err(e),
+            Err(e) => {
+                log::warn!(
+                    "[triggers] Transient setup failure for task {} (attempt {}): {}",
+                    task.id,
+                    idx + 2,
+                    e
+                );
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        AppError::CommandError(format!(
+            "Setup retries exhausted for task {} with no captured error",
+            task.id
+        ))
+    }))
 }
 
 // ─── Per-Action Handlers ──────────────────────────────────────────────────
@@ -696,13 +852,59 @@ fn execute_auto_setup(
     }
 
     let pipeline_settings = config::effective_pipeline_settings(&workspace.config);
-    let setup_task = match ensure_task_worktree(
+
+    // Bug C: serialize Setup per-workspace. Multiple tasks branching from the
+    // same base SHA in parallel race; the loser is stale before it starts.
+    if !try_acquire_setup_lock(&task.workspace_id) {
+        log::info!(
+            "[triggers] Setup lock held for workspace {} — queuing task {}",
+            task.workspace_id,
+            task.id
+        );
+        let queued = db::update_task_pipeline_state(
+            conn,
+            &task.id,
+            PipelineState::SetupQueued.as_str(),
+            None,
+            None,
+        )?;
+        emit_pipeline(
+            app,
+            EVT_TRIGGERED,
+            &queued.id,
+            &column.id,
+            PipelineState::SetupQueued,
+            Some("Waiting for setup slot".to_string()),
+        );
+        super::emit_tasks_changed(app, &task.workspace_id, "setup_queued");
+        return Ok(queued);
+    }
+
+    let result = perform_auto_setup_locked(conn, app, task, column, &workspace, &pipeline_settings);
+
+    // Always release the lock — promote any queued setup tasks regardless of
+    // success/failure so a stuck task does not strand the rest.
+    release_setup_lock(&task.workspace_id);
+    promote_setup_queued_tasks(app, &task.workspace_id);
+
+    result
+}
+
+fn perform_auto_setup_locked(
+    conn: &Connection,
+    app: &AppHandle,
+    task: &Task,
+    column: &Column,
+    workspace: &Workspace,
+    pipeline_settings: &EffectivePipelineSettings,
+) -> Result<Task, AppError> {
+    let setup_task = match ensure_task_worktree_with_retry(
         conn,
         app,
         task,
         &workspace.repo_path,
-        &pipeline_settings,
-        None,
+        pipeline_settings,
+        Some(&pipeline_settings.default_base_branch),
     ) {
         Ok(task) => task,
         Err(e) => return fail_auto_setup(conn, app, task, column, e.to_string()),
@@ -747,6 +949,86 @@ fn execute_auto_setup(
     );
 
     execute_move_column(conn, app, &setup_task, "next")
+}
+
+/// Re-fire setup triggers for any tasks queued behind a finished Setup.
+/// Mirrors `promote_queued_tasks` but for the per-workspace setup lock.
+fn promote_setup_queued_tasks(app: &AppHandle, workspace_id: &str) {
+    let conn = match Connection::open(db::db_path()) {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!(
+                "[triggers] promote_setup_queued_tasks: DB open failed: {}",
+                e
+            );
+            return;
+        }
+    };
+    let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
+
+    let queued = match db::get_setup_queued_tasks(&conn, workspace_id) {
+        Ok(q) => q,
+        Err(e) => {
+            log::warn!(
+                "[triggers] promote_setup_queued_tasks: query failed: {}",
+                e
+            );
+            return;
+        }
+    };
+
+    let next = match queued.into_iter().next() {
+        Some(t) => t,
+        None => return,
+    };
+
+    let column = match db::get_column(&conn, &next.column_id) {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!(
+                "[triggers] promote_setup_queued_tasks: column lookup failed: {}",
+                e
+            );
+            return;
+        }
+    };
+
+    // Reset pipeline state so fire_on_entry treats it as a fresh trigger.
+    if let Err(e) = db::update_task_pipeline_state(
+        &conn,
+        &next.id,
+        PipelineState::Idle.as_str(),
+        None,
+        None,
+    ) {
+        log::warn!(
+            "[triggers] promote_setup_queued_tasks: reset state failed: {}",
+            e
+        );
+        return;
+    }
+
+    let refreshed = match db::get_task(&conn, &next.id) {
+        Ok(t) => t,
+        Err(e) => {
+            log::warn!("[triggers] promote_setup_queued_tasks: reload failed: {}", e);
+            return;
+        }
+    };
+
+    log::info!(
+        "[triggers] Promoting setup-queued task {} (workspace {})",
+        refreshed.id,
+        workspace_id
+    );
+
+    if let Err(e) = super::fire_trigger(&conn, app, &refreshed, &column) {
+        log::warn!(
+            "[triggers] Failed to re-fire trigger for promoted task {}: {}",
+            refreshed.id,
+            e
+        );
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -810,7 +1092,7 @@ fn execute_spawn_cli(
             &fresh_task,
             &workspace.repo_path,
             &pipeline_settings,
-            None,
+            Some(&pipeline_settings.default_base_branch),
         )?
     } else {
         task.clone()
@@ -2741,5 +3023,230 @@ mod tests {
             .and_then(|v| v.as_u64())
             .unwrap_or(300);
         assert_eq!(timeout, 600);
+    }
+
+    // ─── Setup hardening tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_setup_lock_acquire_release() {
+        let ws = format!("ws-lock-acquire-{}", std::process::id());
+        // Clean any leftover state.
+        release_setup_lock(&ws);
+
+        assert!(try_acquire_setup_lock(&ws), "first acquire should succeed");
+        assert!(setup_lock_held(&ws));
+        assert!(
+            !try_acquire_setup_lock(&ws),
+            "second acquire should fail while held"
+        );
+
+        release_setup_lock(&ws);
+        assert!(!setup_lock_held(&ws));
+        assert!(
+            try_acquire_setup_lock(&ws),
+            "after release, lock should be re-acquirable"
+        );
+        release_setup_lock(&ws);
+    }
+
+    #[test]
+    fn test_setup_locks_are_per_workspace() {
+        let ws_a = format!("ws-A-{}", std::process::id());
+        let ws_b = format!("ws-B-{}", std::process::id());
+        release_setup_lock(&ws_a);
+        release_setup_lock(&ws_b);
+
+        assert!(try_acquire_setup_lock(&ws_a));
+        assert!(
+            try_acquire_setup_lock(&ws_b),
+            "different workspace should not be blocked by another's lock"
+        );
+        release_setup_lock(&ws_a);
+        release_setup_lock(&ws_b);
+    }
+
+    #[test]
+    fn test_is_transient_setup_error_classifies_lock_messages() {
+        let transient = AppError::CommandError("git index.lock exists".into());
+        assert!(is_transient_setup_error(&transient));
+
+        let already_exists = AppError::CommandError(
+            "fatal: A branch named 'foo' already exists.".into(),
+        );
+        assert!(is_transient_setup_error(&already_exists));
+
+        let cannot_lock = AppError::CommandError("cannot lock ref 'refs/heads/foo'".into());
+        assert!(is_transient_setup_error(&cannot_lock));
+
+        let timed_out = AppError::CommandError("operation timed out".into());
+        assert!(is_transient_setup_error(&timed_out));
+    }
+
+    #[test]
+    fn test_is_transient_setup_error_rejects_config_errors() {
+        let invalid = AppError::InvalidInput("base_branch missing".into());
+        assert!(!is_transient_setup_error(&invalid));
+
+        let not_found = AppError::NotFound("workspace gone".into());
+        assert!(!is_transient_setup_error(&not_found));
+
+        let other = AppError::CommandError("permission denied".into());
+        assert!(!is_transient_setup_error(&other));
+    }
+
+    #[test]
+    fn test_pipeline_setup_queued_state_roundtrip() {
+        assert_eq!(PipelineState::SetupQueued.as_str(), "setup_queued");
+        assert_eq!(
+            PipelineState::from_db_str("setup_queued"),
+            PipelineState::SetupQueued
+        );
+    }
+
+    fn make_test_pipeline_settings() -> EffectivePipelineSettings {
+        EffectivePipelineSettings {
+            default_agent_cli: "codex".to_string(),
+            default_model: None,
+            max_concurrent_agents: config::DEFAULT_PIPELINE_MAX_CONCURRENT_AGENTS,
+            branch_prefix: config::DEFAULT_BRANCH_PREFIX.to_string(),
+            default_base_branch: config::DEFAULT_BASE_BRANCH.to_string(),
+        }
+    }
+
+    fn init_test_repo(path: &std::path::Path) {
+        use std::process::Command;
+        Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        std::fs::write(path.join("README.md"), "baseline\n").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_validate_setup_base_branch_rejects_none() {
+        let err = validate_setup_base_branch(None, "task-1")
+            .expect_err("None must be rejected");
+        match err {
+            AppError::InvalidInput(msg) => assert!(msg.contains("base_branch")),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_setup_base_branch_rejects_blank() {
+        assert!(matches!(
+            validate_setup_base_branch(Some("   "), "task-1"),
+            Err(AppError::InvalidInput(_))
+        ));
+        assert!(matches!(
+            validate_setup_base_branch(Some(""), "task-1"),
+            Err(AppError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_setup_base_branch_trims_and_returns() {
+        assert_eq!(
+            validate_setup_base_branch(Some("  main  "), "task-1").unwrap(),
+            "main"
+        );
+        assert_eq!(
+            validate_setup_base_branch(Some("develop"), "task-1").unwrap(),
+            "develop"
+        );
+    }
+
+    /// End-to-end on the underlying git layer: ensures the *actual* branch
+    /// creation goes through with the explicit base, sidestepping the
+    /// AppHandle-typed pipeline wrapper.
+    #[test]
+    fn test_branch_creation_uses_explicit_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_test_repo(tmp.path());
+
+        let settings = make_test_pipeline_settings();
+        let branch = crate::git::branch_manager::create_task_branch_with_prefix(
+            tmp.path().to_str().unwrap(),
+            "Implement Feature",
+            Some(&settings.default_base_branch),
+            &settings.branch_prefix,
+        )
+        .expect("branch creation should succeed with explicit base");
+
+        assert_eq!(branch, "bentoya/implement-feature");
+    }
+
+    /// Bogus base branch → hard fail (Bug D test on the underlying git layer).
+    #[test]
+    fn test_branch_creation_hard_fails_on_missing_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_test_repo(tmp.path());
+
+        let err = crate::git::branch_manager::create_task_branch_with_prefix(
+            tmp.path().to_str().unwrap(),
+            "Some Task",
+            Some("does-not-exist"),
+            "bentoya/",
+        )
+        .expect_err("nonexistent base must error");
+
+        // The error message must mention the missing base — no silent fallback.
+        let lower = err.to_lowercase();
+        assert!(
+            lower.contains("does-not-exist") || lower.contains("not found"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_promote_setup_queued_query_returns_oldest_first() {
+        let conn = db::init_test().unwrap();
+        let workspace = db::insert_workspace(&conn, "WS", "/tmp/ws").unwrap();
+        let column = db::insert_column(&conn, &workspace.id, "Setup", 0).unwrap();
+
+        let t1 = db::insert_task(&conn, &workspace.id, &column.id, "First", None).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        let t2 = db::insert_task(&conn, &workspace.id, &column.id, "Second", None).unwrap();
+
+        db::update_task_pipeline_state(&conn, &t1.id, "setup_queued", None, None).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        db::update_task_pipeline_state(&conn, &t2.id, "setup_queued", None, None).unwrap();
+
+        let queued = db::get_setup_queued_tasks(&conn, &workspace.id).unwrap();
+        let ids: Vec<_> = queued.into_iter().map(|t| t.id).collect();
+        assert_eq!(ids, vec![t1.id.clone(), t2.id.clone()]);
+
+        // After idle, only the un-promoted task should remain queued.
+        db::update_task_pipeline_state(&conn, &t1.id, "idle", None, None).unwrap();
+        let queued = db::get_setup_queued_tasks(&conn, &workspace.id).unwrap();
+        let ids: Vec<_> = queued.into_iter().map(|t| t.id).collect();
+        assert_eq!(ids, vec![t2.id]);
     }
 }

--- a/src/components/kanban/task-card-utils.ts
+++ b/src/components/kanban/task-card-utils.ts
@@ -6,6 +6,7 @@ export const PIPELINE_LABELS: Record<PipelineState, string> = {
   running: 'Agent working',
   evaluating: 'Checking exit',
   advancing: 'Auto-advancing',
+  setup_queued: 'Waiting for setup slot',
 }
 
 export const PIPELINE_COLORS: Record<PipelineState, string> = {
@@ -14,6 +15,7 @@ export const PIPELINE_COLORS: Record<PipelineState, string> = {
   running: 'border-l-running',
   evaluating: 'border-l-accent',
   advancing: 'border-l-success',
+  setup_queued: 'border-l-warning',
 }
 
 // Helper to format relative time

--- a/src/components/settings/tabs/workspace-tab.tsx
+++ b/src/components/settings/tabs/workspace-tab.tsx
@@ -22,6 +22,8 @@ const CLI_OPTIONS = [
   { value: 'codex', label: 'Codex' },
 ] as const
 
+const DEFAULT_BASE_BRANCH = 'main'
+
 export function WorkspaceTab() {
   const workspaces = useWorkspaceStore((s) => s.workspaces)
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
@@ -49,6 +51,9 @@ export function WorkspaceTab() {
     // Remove keys set to empty/default values
     if (!merged.defaultModel) delete merged.defaultModel
     if (!merged.defaultAgentCli) delete merged.defaultAgentCli
+    if (!merged.defaultBaseBranch || merged.defaultBaseBranch === DEFAULT_BASE_BRANCH) {
+      delete merged.defaultBaseBranch
+    }
     try {
       const updated = await ipc.updateWorkspaceConfig(workspace.id, JSON.stringify(merged))
       await updateWorkspace(workspace.id, { config: updated.config })
@@ -57,6 +62,21 @@ export function WorkspaceTab() {
       setMessage({ type: 'error', text: 'Failed to update workspace settings' })
     }
   }, [workspace, config, updateWorkspace])
+
+  const [baseBranchDraft, setBaseBranchDraft] = useState<string | null>(null)
+  const baseBranchValue = baseBranchDraft ?? config.defaultBaseBranch ?? DEFAULT_BASE_BRANCH
+
+  const commitBaseBranch = useCallback(() => {
+    if (baseBranchDraft == null) return
+    const trimmed = baseBranchDraft.trim()
+    setBaseBranchDraft(null)
+    if (!trimmed) {
+      setMessage({ type: 'error', text: 'Default base branch cannot be empty' })
+      return
+    }
+    const next = trimmed === DEFAULT_BASE_BRANCH ? undefined : trimmed
+    void updateConfig({ defaultBaseBranch: next })
+  }, [baseBranchDraft, updateConfig])
 
   const handleRepoPathChange = useCallback(async (path: string) => {
     if (!workspace) return
@@ -188,6 +208,29 @@ export function WorkspaceTab() {
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
                 ))}
               </select>
+            </SettingRow>
+
+            <SettingRow
+              label="Default Base Branch"
+              description="Branch new task branches are created from (e.g. main, develop, trunk)"
+            >
+              <input
+                type="text"
+                value={baseBranchValue}
+                onChange={(e) => { setBaseBranchDraft(e.target.value) }}
+                onBlur={commitBaseBranch}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    commitBaseBranch()
+                  } else if (e.key === 'Escape') {
+                    setBaseBranchDraft(null)
+                  }
+                }}
+                placeholder={DEFAULT_BASE_BRANCH}
+                spellCheck={false}
+                className="rounded-lg border border-border-default bg-surface px-3 py-2 text-sm font-mono text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+              />
             </SettingRow>
 
             <SettingRow label="Max Concurrent Agents" description="Maximum number of agents running simultaneously">

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -45,6 +45,7 @@ export const PIPELINE_STATE_LABELS: Record<PipelineState, string> = {
   running: 'Running',
   evaluating: 'Checking',
   advancing: 'Moving',
+  setup_queued: 'Waiting for setup',
 }
 
 export const PIPELINE_STATE_COLORS: Record<PipelineState, string> = {
@@ -53,6 +54,7 @@ export const PIPELINE_STATE_COLORS: Record<PipelineState, string> = {
   running: 'text-running',
   evaluating: 'text-accent',
   advancing: 'text-success',
+  setup_queued: 'text-warning',
 }
 
 // ─── Review Status ──────────────────────────────────────────────────────────

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,7 +1,13 @@
 import type { AgentMode, AgentStatus } from './agent'
 import type { Label } from './label'
 
-export type PipelineState = 'idle' | 'triggered' | 'running' | 'evaluating' | 'advancing'
+export type PipelineState =
+  | 'idle'
+  | 'triggered'
+  | 'running'
+  | 'evaluating'
+  | 'advancing'
+  | 'setup_queued'
 
 export type ReviewStatus = 'pending' | 'approved' | 'rejected' | 'needs-manual-review'
 

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -7,6 +7,7 @@ export type WorkspaceConfig = {
   autoArchiveDone?: boolean
   /** How long a task must sit in Done before auto-archive (minutes). Default: 5. */
   autoArchiveGraceMinutes?: number
+  defaultBaseBranch?: string
   githubRepo?: string
   githubLabelFilter?: string
   githubSyncEnabled?: boolean


### PR DESCRIPTION
## Description

## Problem

The Setup column has three architectural bugs causing concurrent-task regressions. (A separate task `0714df63` handles the missing `git fetch` before branching — this task assumes that landed and tackles the rest.)

### Bug B: `base_branch: None` falls through to local HEAD
[`src-tauri/src/pipeline/triggers.rs:705`](src-tauri/src/pipeline/triggers.rs) calls `ensure_task_worktree(... None)`. Inside [`ensure_task_worktree`](src-tauri/src/pipeline/triggers.rs:579), when `base_branch` is `None`, branch creation falls through to whatever's currently checked out in `repo_path`. If the user (or another tool) checked out a feature branch in the main repo working directory, every new worktree inherits that base.

### Bug C: No concurrency control on Setup
N tasks can enter Setup simultaneously. They all branch from the same base in parallel, with zero awareness of each other. Even after the pre-fetch fix lands, this still causes a race: tasks A, B, C all fetch + branch from origin/main@SHA1 at the same instant, then proceed in parallel. When A merges, B and C are stale before they even started.

### Bug D: Silent fallback to repo working directory on worktree failure
[`triggers.rs:647-654`](src-tauri/src/pipeline/triggers.rs):
```rust
Err(e) => {
    log::error!("[triggers] Failed to create worktree...");
    // Continue without worktree — agent falls back to repo root
}
```
This means a worktree-creation failure causes the agent to mutate the user's actual main checkout. That's a footgun — must hard-fail instead.

## Acceptance Criteria

1. **Default base_branch from workspace config**:
   - Add a `default_base_branch: Option<String>` field to workspace config (default `"main"`).
   - In `execute_auto_setup`, pass `Some(&workspace.default_base_branch)` to `ensure_task_worktree` instead of `None`.
   - In `ensure_task_worktree`, if `base_branch` is still None after that, hard-error (don't fall through to HEAD).
   - UI: workspace settings page gets a "Default base branch" text field. Default value `"main"`. Validation: non-empty.

2. **Workspace-level Setup serialization**:
   - Add a tokio `Mutex<HashSet<workspace_id>>` (or sqlite-backed `setup_locks` table — pick whichever fits the existing concurrency model better; check how `count_running_agent_sessions` is gated for reference).
   - When a task enters Setup, attempt to acquire the workspace's setup lock.
   - If lock is held → set `pipeline_state='setup_queued'`, do NOT advance, do NOT spawn agent. Re-check on the next pipeline tick.
   - If lock is acquired → proceed with branch + worktree creation, release lock the moment worktree is created (NOT when agent finishes — only Setup itself is serialized, downstream stages stay parallel).
   - **Why per-workspace, not global**: bentoSite + getmejob can safely Setup in parallel; only same-repo concurrency is dangerous.
   - Add a visible UI indicator in the kanban: tasks with `pipeline_state='setup_queued'` show a "⏳ waiting for setup slot" badge.

3. **Hard-fail on worktree creation failure**:
   - [`triggers.rs:647-654`](src-tauri/src/pipeline/triggers.rs): replace silent fallback with `return Err(AppError::CommandError(format!("Failed to create worktree for task {}: {}", task.id, e)))`.
   - Caller (`execute_auto_setup`) already routes errors through `fail_auto_setup` → `handle_trigger_failure` → user sees red badge with reason.
   - Verify no other call site of `ensure_task_worktree` expected the silent fallback semantics. If any did, fix them too.

4. **Setup retry on transient failure**:
   - Branch/worktree creation can fail transiently (filesystem races, libgit2 quirks). Add bounded retry: max 3 attempts, exponential backoff (500ms / 2s / 8s).
   - Only retry for transient errors (lock contention, "branch already exists with different ref"). NOT for config errors (missing repo_path, invalid base_branch).
   - If all retries fail → hard-fail per Bug D.

## Test Plan — must include all of these

### Unit tests (Rust, in `src-tauri/src/pipeline/triggers_tests.rs` or appropriate)
- Test `execute_auto_setup` with `default_base_branch="main"` → branch created from main.
- Test `execute_auto_setup` with workspace having explicit `default_base_branch="develop"` → branch created from develop.
- Test that calling `ensure_task_worktree(... None)` directly now returns `Err`, not a worktree based on HEAD.
- Test concurrent Setup attempts: spawn 3 tasks simultaneously into Setup, verify only one acquires the lock at a time, others go to `setup_queued`.
- Test setup_queued → re-eligible on next tick after lock release.
- Test bentoSite + getmejob workspaces can Setup in parallel (locks are per-workspace, not global).
- Test hard-fail on worktree creation failure (mock `create_task_worktree` to return Err) → task ends in error state, no fallback to repo root.
- Test retry with exponential backoff: mock returns Err twice then Ok → succeeds on 3rd attempt.
- Test retry exhaustion: mock always returns Err → hard-fails after 3 attempts.

### Integration test (`src-tauri/tests/integration/setup_concurrent.rs`)
- Real temp repo with 5 tasks queued into Setup at once.
- Verify exactly 1 worktree creation runs at a time (instrument with a delay in test fixture).
- Verify all 5 eventually complete with valid worktrees rooted at the expected base.
- Verify no task ends up with `worktree_path` pointing at the bare repo root.

### Manual verification (document in PR)
- Create 4 tasks in a workspace, move them all to Setup simultaneously.
- Confirm UI shows ⏳ badge on 3 of them.
- Watch them advance one-at-a-time as locks release.
- Force-fail a worktree creation (e.g. checkout the target branch in another shell to lock libgit2) → confirm task fails with red badge and clear error, no silent fallback.

### Regression checks
- `cargo check` clean
- `cargo clippy -- -D warnings` clean
- `cargo test` all green
- Existing pipeline tests still pass — Setup serialization must NOT slow down downstream stages or block cross-workspace concurrency.

## Files likely modified
- `src-tauri/src/pipeline/triggers.rs` (primary — execute_auto_setup, ensure_task_worktree)
- `src-tauri/src/config.rs` or workspace config module (default_base_branch field)
- `src-tauri/src/db/workspace.rs` (migration if config moves to DB)
- `src-tauri/src/pipeline/state.rs` (new `setup_queued` pipeline state)
- `src-tauri/src/pipeline/engine.rs` (re-eligible on tick for setup_queued)
- React frontend: workspace settings UI for default_base_branch, kanban badge for setup_queued state
- New tests as described

## Out of scope
- The `git fetch` step (covered by task `0714df63`).
- Changing how downstream stages (Plan, Working, etc.) handle concurrency.
- Any redesign of the worktree/branch naming scheme.

## Coordination
- **Hard-depends on `0714df63` (pre-fetch fix)** — this task's design assumes `git fetch origin <base>` runs before branching. If that PR isn't merged, this task should rebase off it before final review.
- **Hard-depends on `e2e0d99d` (output capture)** — without that fix, debugging this task's behavior is impossible because agent output is invisible.
- Sibling tasks for domain partitioning + staging gate will follow this one.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/pipeline-setup-hardening-fix-branch-base-serialize` → `staging/batch-20260504222404941`