### PR TITLE
Pipeline smoke test — add elevator-pitch comment to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bento-ya
+<!-- A drag-and-drop kanban that turns columns into automated agent pipelines. -->
 
 Tauri desktop app for orchestrating AI coding agents — an automated kanban board where columns are pipeline stages with trigger-driven automation.
 


### PR DESCRIPTION
## Description

## Why

Smoke-test the bento-ya pipeline end-to-end after today's 4 PRs landed (#182 #185 #186 #187). Tiny, safe, exercises every column.

## What to do

In `/Users/bentomac/bento-ya/README.md`, find the very first heading line (`# Bento-ya` or whatever is on line 1). Immediately AFTER it, add a single HTML comment line that captures bento-ya's elevator pitch. Example:

```
# Bento-ya
<!-- A drag-and-drop kanban that turns columns into automated agent pipelines. -->
```

That's the entire change. One-line HTML comment, max 120 chars.

## Acceptance criteria

1. README.md gains exactly one new line (an HTML comment) right after the H1.
2. No other files modified.
3. Commit message: `docs(readme): add elevator-pitch comment` (no trailing footers, no body).
4. PR opens cleanly.

## Test plan

None needed beyond CI compiling. This is a docs-only change.

## Why we picked this

- Tiny diff so reviewers (you + me) can eyeball every column behavior without reading 500 lines
- Exercises Setup serialization (no concurrent tasks → trivial pass), Plan + Working columns (live agent output), Review-Logic + Review-Quality (reviewer agents), PR creation (with the new pre-fetch + auto-rebase logic), and Done (with hygiene worker auto-archive)
- Zero risk to actual codebase
- Zero risk to dependent flows

## Out of scope
- Any other README polish
- Reformatting existing content
- Adding image/badges/etc

Just one HTML comment. Stop there.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** PR
- **Branch:** `bentoya/pipeline-smoke-test-add-elevator-pitch-comment-to` → `staging/batch-20260504233500701`