### PR TITLE
fix(panel): unstick the task side panel — replace Framer Motion with CSS transition

### DIFF
--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -321,7 +321,7 @@ const CLAUDE_STREAM_PRETTY_JQ: &str = r#"
 fn build_trigger_command(cli_command: &str, args: &[String], initial_prompt: &str) -> String {
     let cli_name = cli_command.rsplit('/').next().unwrap_or(cli_command);
 
-    if cli_name == "claude" {
+    if cli_name == "claude" || cli_name == "claude-mock" {
         return build_claude_streaming_command(cli_command, args, initial_prompt);
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,7 +63,8 @@ pub fn run() {
     let session_registry_for_shutdown = Arc::clone(&session_registry);
     let session_registry_for_sweep = Arc::clone(&session_registry);
 
-    let builder = tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())

--- a/src/components/layout/split-view.test.tsx
+++ b/src/components/layout/split-view.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * Regression tests for the right-side TaskSidePanel.
+ *
+ * The bug this guards against:
+ *
+ *   PR #192 added `<AgentPanel key={task.id}>` inside an outer
+ *   `<motion.div>` to fix a stale-content issue. In some lifecycle
+ *   sequences (HMR refresh, React StrictMode double-invokes, tight
+ *   task→task switching) Framer Motion's animation state could end
+ *   up convinced it had animated to the target while motion's async
+ *   keyframe resolver had never flushed — leaving the actual element
+ *   stuck at the `initial` values (`width: 0; opacity: 0`). The
+ *   panel mounted but never visibly opened, so users could not see
+ *   streaming agent output. With `mode="wait"` the exit on the old
+ *   key never resolved either, so the new panel never got to mount.
+ *
+ *   The fix swaps Framer Motion for a plain CSS `width` transition:
+ *   no JS frame-loop dependency, no async keyframe resolver, no
+ *   AnimatePresence orchestration that can stall. The container
+ *   stays mounted and just transitions its width between 0 and the
+ *   configured panel width.
+ *
+ *   Stale-content protection is preserved by keeping
+ *   `<AgentPanel key={task.id}>` so the inner panel + TerminalView
+ *   + xterm fully unmount on task switch (the original purpose of
+ *   #192's key).
+ *
+ * jsdom doesn't run CSS transitions, so these tests assert the
+ * structural invariants that make the bug impossible:
+ *   - When a task is selected, the container's inline style targets
+ *     the configured panel width and opacity:1 (not 0).
+ *   - When no task is selected, the container collapses to width:0
+ *     and opacity:0.
+ *   - The AgentPanel inside is keyed by task.id, so switching tasks
+ *     forces a fresh AgentPanel + xterm.
+ */
+
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Task } from '@/types'
+import { useTaskStore } from '@/stores/task-store'
+import { useUIStore } from '@/stores/ui-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { TaskSidePanel } from './split-view'
+
+// AgentPanel pulls in xterm + Tauri PTY plumbing — heavy and unnecessary
+// for the structural invariants we're checking here. Stub it with a
+// simple tagged div so tests can verify it mounts/remounts.
+vi.mock('@/components/panel/agent-panel', () => ({
+  AgentPanel: ({ task }: { task: Task; onClose?: () => void }) => (
+    <div data-testid="agent-panel" data-task-id={task.id}>
+      Agent for {task.title}
+    </div>
+  ),
+}))
+
+// ResizeHandle is decorative for these tests; stub to a no-op.
+vi.mock('@/components/shared/resize-handle', () => ({
+  ResizeHandle: () => <div data-testid="resize-handle" />,
+}))
+
+const PANEL_CLASS_SELECTOR = '.border-l.border-border-default'
+
+const TEST_TASK_BASE: Omit<Task, 'id' | 'title'> = {
+  workspaceId: 'ws-1',
+  columnId: 'col-1',
+  description: '',
+  branch: null,
+  agentType: null,
+  agentMode: null,
+  agentStatus: null,
+  queuedAt: null,
+  pipelineState: 'idle',
+  pipelineTriggeredAt: null,
+  pipelineError: null,
+  retryCount: 0,
+  model: null,
+  lastScriptExitCode: null,
+  reviewStatus: null,
+  prNumber: null,
+  prUrl: null,
+  siegeIteration: 0,
+  siegeActive: false,
+  siegeMaxIterations: 0,
+  siegeLastChecked: null,
+  prMergeable: null,
+  prCiStatus: null,
+  prReviewDecision: null,
+  prCommentCount: 0,
+  prIsDraft: false,
+  prLabels: '[]',
+  prLastFetched: null,
+  prHeadSha: null,
+  checklist: null,
+  estimatedHours: null,
+  actualHours: 0,
+  notifyStakeholders: null,
+  notificationSentAt: null,
+  triggerOverrides: null,
+  triggerPrompt: null,
+  lastOutput: null,
+  dependencies: null,
+  blocked: false,
+  worktreePath: null,
+  archivedAt: null,
+  labels: [],
+  position: 0,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+}
+
+function makeTask(id: string, title: string): Task {
+  return { ...TEST_TASK_BASE, id, title }
+}
+
+describe('TaskSidePanel — panel-collapsed regression guard', () => {
+  beforeEach(() => {
+    useTaskStore.setState({
+      tasks: [
+        makeTask('task-a', 'Task A'),
+        makeTask('task-b', 'Task B'),
+      ],
+    })
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Workspace',
+          repoPath: '/tmp/ws',
+          tabOrder: 0,
+          isActive: true,
+          activeTaskCount: 2,
+          config: '{}',
+          createdAt: '',
+          updatedAt: '',
+        },
+      ],
+    })
+    useUIStore.setState({ agentPanelWidth: 480 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('opens the panel to the configured width when a task is selected', () => {
+    // The original bug: the container was rendered but stuck at
+    // width:0;opacity:0 because Framer Motion's enter animation
+    // stalled before painting. This test pins the steady-state:
+    // a selected task = panel inline style targets the configured
+    // width and full opacity. No JS animation needed.
+    useUIStore.setState({ agentPanelWidth: 480 })
+    const { container } = render(
+      <TaskSidePanel taskId="task-a" onClose={vi.fn()} />,
+    )
+
+    const panel = container.querySelector<HTMLElement>(PANEL_CLASS_SELECTOR)
+    if (!panel) throw new Error('panel container should be rendered')
+    expect(panel.style.width).toBe('480px')
+    expect(panel.style.opacity).toBe('1')
+    expect(panel.getAttribute('aria-hidden')).toBeNull()
+  })
+
+  it('renders the AgentPanel for the currently selected task', () => {
+    const { container } = render(
+      <TaskSidePanel taskId="task-a" onClose={vi.fn()} />,
+    )
+
+    const inner = container.querySelector('[data-testid="agent-panel"]')
+    expect(inner).not.toBeNull()
+    expect(inner?.getAttribute('data-task-id')).toBe('task-a')
+  })
+
+  it('collapses the panel when no task is selected', () => {
+    // Container stays mounted (so the CSS transition has something
+    // to animate), but its width and opacity are zero, the border
+    // is hidden, and pointer events are disabled so it can't steal
+    // hover/click on the column behind it.
+    const { container } = render(
+      <TaskSidePanel taskId={null} onClose={vi.fn()} />,
+    )
+
+    const panel = container.querySelector<HTMLElement>(PANEL_CLASS_SELECTOR)
+    if (!panel) throw new Error('panel container should always be mounted')
+    expect(panel.style.width).toBe('0px')
+    expect(panel.style.opacity).toBe('0')
+    expect(panel.style.pointerEvents).toBe('none')
+    expect(panel.getAttribute('aria-hidden')).toBe('true')
+    // No inner agent panel when there's no task.
+    expect(container.querySelector('[data-testid="agent-panel"]')).toBeNull()
+  })
+
+  it('switches the AgentPanel to the new task on rerender', () => {
+    const { container, rerender } = render(
+      <TaskSidePanel taskId="task-a" onClose={vi.fn()} />,
+    )
+
+    expect(
+      container.querySelector('[data-testid="agent-panel"]')?.getAttribute('data-task-id'),
+    ).toBe('task-a')
+
+    rerender(<TaskSidePanel taskId="task-b" onClose={vi.fn()} />)
+
+    expect(
+      container.querySelector('[data-testid="agent-panel"]')?.getAttribute('data-task-id'),
+    ).toBe('task-b')
+  })
+
+  it('remounts the AgentPanel when switching tasks (preserves the stale-content fix from #192)', () => {
+    // Switching tasks must fully unmount the previous AgentPanel
+    // (and its TerminalView + xterm + Tauri listeners) before the
+    // new one mounts, so async work from the OLD task can't race
+    // with the new task's render. We pin this by checking that
+    // the AgentPanel DOM node is a different instance after the
+    // switch — which is only true if React unmounted it (and only
+    // happens because we key AgentPanel by task.id).
+    const { container, rerender } = render(
+      <TaskSidePanel taskId="task-a" onClose={vi.fn()} />,
+    )
+
+    const before = container.querySelector('[data-testid="agent-panel"]')
+    expect(before).not.toBeNull()
+
+    rerender(<TaskSidePanel taskId="task-b" onClose={vi.fn()} />)
+
+    const after = container.querySelector('[data-testid="agent-panel"]')
+    expect(after).not.toBeNull()
+    expect(after).not.toBe(before)
+  })
+
+  it('reopens to the new width when a previously-collapsed panel gets a task selected', () => {
+    // Cold path: mount with no task, then receive a task. The
+    // container must transition from collapsed (width:0) to open
+    // (width:480) without depending on any prior open state.
+    const { container, rerender } = render(
+      <TaskSidePanel taskId={null} onClose={vi.fn()} />,
+    )
+
+    const collapsed = container.querySelector<HTMLElement>(PANEL_CLASS_SELECTOR)
+    if (!collapsed) throw new Error('panel container should be mounted')
+    expect(collapsed.style.width).toBe('0px')
+
+    rerender(<TaskSidePanel taskId="task-a" onClose={vi.fn()} />)
+
+    const opened = container.querySelector<HTMLElement>(PANEL_CLASS_SELECTOR)
+    if (!opened) throw new Error('panel container should still be mounted')
+    expect(opened.style.width).toBe('480px')
+    expect(opened.style.opacity).toBe('1')
+  })
+
+  it('respects updates to agentPanelWidth from the UI store', () => {
+    // Catches: someone hard-codes a width or breaks the store
+    // wiring, leaving the panel a fixed size. The panel should
+    // track whatever the store says.
+    useUIStore.setState({ agentPanelWidth: 600 })
+    const { container, rerender } = render(
+      <TaskSidePanel taskId="task-a" onClose={vi.fn()} />,
+    )
+
+    const panel = container.querySelector<HTMLElement>(PANEL_CLASS_SELECTOR)
+    if (!panel) throw new Error('panel container should be rendered')
+    expect(panel.style.width).toBe('600px')
+
+    act(() => {
+      useUIStore.setState({ agentPanelWidth: 720 })
+    })
+    rerender(<TaskSidePanel taskId="task-a" onClose={vi.fn()} />)
+
+    const after = container.querySelector<HTMLElement>(PANEL_CLASS_SELECTOR)
+    if (!after) throw new Error('panel container should be rendered')
+    expect(after.style.width).toBe('720px')
+  })
+})

--- a/src/components/layout/split-view.tsx
+++ b/src/components/layout/split-view.tsx
@@ -1,13 +1,47 @@
-import { motion, AnimatePresence } from 'motion/react'
 import { useTaskStore } from '@/stores/task-store'
 import { useUIStore } from '@/stores/ui-store'
 import { useResizablePanel } from '@/hooks/use-resizable-panel'
 import { ResizeHandle } from '@/components/shared/resize-handle'
 import { AgentPanel } from '@/components/panel/agent-panel'
 
-const SPRING = { type: 'spring' as const, stiffness: 300, damping: 28 }
+/** Resizable chat panel docked to the right side of the board.
+ *
+ * Open / close uses a CSS `width` transition instead of Framer Motion.
+ * Why CSS and not motion?
+ *
+ *   PR #192 added `<AgentPanel key={task.id}>` inside an outer
+ *   `<motion.div>` to force a remount on task switch. In some lifecycle
+ *   sequences (HMR refresh, tight task→task switching, React StrictMode
+ *   double-invokes) motion's animation state could end up convinced
+ *   it had animated to the target while motion's async keyframe
+ *   resolver had never flushed — leaving the actual element stuck at
+ *   the `initial` values (`width: 0; opacity: 0`). The panel mounted
+ *   but never visibly opened, so users couldn't see streaming agent
+ *   output. With `mode="wait"` the exit on the old key never resolved
+ *   either, so the new panel never got to mount at all.
+ *
+ *   Plain CSS doesn't depend on a JS frame-loop or async keyframe
+ *   resolution. The browser sets the inline width on render and
+ *   transitions to the target width over `--panel-anim-duration`.
+ *   No queued-but-unresolved animations, no stuck exit, no remount-
+ *   per-task gymnastics.
+ *
+ * Stale-content protection (the original reason #192 keyed the inner
+ * AgentPanel): we still key `<AgentPanel key={task?.id}>` so switching
+ * between tasks unmounts the previous AgentPanel + TerminalView +
+ * xterm instance before the new one mounts. That kills any in-flight
+ * `ensure_pty_session` / scrollback fetches / Tauri listeners from
+ * the old task before they can race with the new task's render.
+ *
+ * The container itself stays mounted (collapsed to width 0) when no
+ * task is selected. Keeping it in the DOM means the CSS transition has
+ * an element to animate.
+ */
 
-/** Resizable chat panel docked to the right */
+// Animation timing matches the previous Framer Motion spring's
+// perceived duration; tuned to feel snappy without overshoot.
+const PANEL_ANIM_MS = 200
+
 export function TaskSidePanel({
   taskId,
   onClose,
@@ -28,35 +62,46 @@ export function TaskSidePanel({
     disabled: !task,
   })
 
+  const isOpen = !!task
+  const targetWidth = isOpen ? agentPanelWidth : 0
+
+  // While the user is actively dragging the resize handle, kill the
+  // transition so the panel tracks the cursor 1:1. We restore it as
+  // soon as the drag ends.
+  const transition = isDragging
+    ? 'none'
+    : `width ${String(PANEL_ANIM_MS)}ms cubic-bezier(0.22, 1, 0.36, 1), opacity ${String(PANEL_ANIM_MS)}ms ease`
+
   return (
-    <AnimatePresence mode="wait">
-      {task && (
-        <motion.div
-          key="task-chat-panel"
-          initial={{ width: 0, opacity: 0 }}
-          animate={{ width: agentPanelWidth, opacity: 1 }}
-          exit={{ width: 0, opacity: 0 }}
-          transition={isDragging ? { duration: 0 } : SPRING}
-          className="relative h-full shrink-0 overflow-hidden border-l border-border-default"
-        >
-          <ResizeHandle
-            direction="horizontal"
-            position="left"
-            onMouseDown={handleResize}
-          />
-          {/*
-            Key the AgentPanel by task.id so switching tasks fully unmounts
-            the panel (and its TerminalView / xterm instance) and remounts a
-            fresh one. Without this, React reuses the same component instance
-            across task switches, which means async work from the OLD task
-            (ensure_pty_session, scrollback fetch, in-flight Tauri events)
-            can race with the NEW task's render and surface stale content.
-            A key guarantees clean teardown — at the cost of one extra
-            xterm instantiation per click, which is cheap.
-          */}
-          <AgentPanel key={task.id} task={task} onClose={onClose} />
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <div
+      className="relative h-full shrink-0 overflow-hidden border-l border-border-default"
+      style={{
+        width: `${String(targetWidth)}px`,
+        opacity: isOpen ? 1 : 0,
+        transition,
+        // Hide the border when collapsed so a 1px slice doesn't peek
+        // out at the edge of the board.
+        borderLeftWidth: isOpen ? undefined : 0,
+        // Collapsed panel must not catch pointer events (would steal
+        // hover/click on the column behind it).
+        pointerEvents: isOpen ? undefined : 'none',
+      }}
+      // Hide from the a11y tree when collapsed.
+      aria-hidden={isOpen ? undefined : true}
+    >
+      <ResizeHandle
+        direction="horizontal"
+        position="left"
+        onMouseDown={handleResize}
+      />
+      {/*
+        Key AgentPanel by task.id so the inner panel + TerminalView +
+        xterm fully unmount on task switch. This is the stale-content
+        fix from PR #192, kept here. We render `null` when no task is
+        active so `useMemo`/`useEffect` chains inside AgentPanel don't
+        run against a stale taskId.
+      */}
+      {task && <AgentPanel key={task.id} task={task} onClose={onClose} />}
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

The right-side `<TaskSidePanel>` could mount with a task selected but never visibly open — DOM showed `width: 0px; opacity: 0;` even when `activeTaskId` was set. Tasks triggered, agents ran, output streamed to tmux — but users saw a collapsed sliver because the panel never animated open. With `mode=\"wait\"` on AnimatePresence, switching tasks could also lock the panel to the old task's content forever (exit on the old key never resolved, so the new key never got to mount).

This PR swaps the open/close animation from Framer Motion to a plain CSS `width` transition. The container always renders; its inline width flips between 0 and the configured `agentPanelWidth` based on the task selection.

## Root cause

The motion.div used `animate={{ width, opacity }}` inside `<AnimatePresence mode=\"wait\">`. In several common lifecycle sequences — HMR refresh, tight task → task switching, React 19 StrictMode synthetic ref unmount/remount — Framer Motion's animation state ended up convinced it had animated to the target (its `prevResolvedValues` showed the final width/opacity) while motion's async `DOMKeyframesResolver` had never flushed. The motion-value animation object was created with `state: \"running\"` but no keyframes were ever applied. Probing `wrapper.state` (which calls `flushKeyframeResolvers()` via the wrapper getter) made the animation immediately complete from the in-flight middle of a fiber tree dump — confirming the resolver was the stuck step.

With `mode=\"wait\"`, the exit animation on the previously-keyed motion.div ALSO failed to resolve (same stuck-resolver path), so AnimatePresence held back the new task's motion.div indefinitely. Switching tasks left the user looking at an old panel collapsed to width:0 with the new task's data unable to mount.

The audit suggested moving `key={task.id}` from `<AgentPanel>` to the outer `<motion.div>` (Option A). I tried that first and verified empirically it doesn't fully fix the bug — the keyframe resolver can still stall on the FRESH motion.div mount, especially after HMR. The problem is in motion's async resolver pipeline, not in React's reconciliation.

## Fix

Drop Framer Motion for this animation and use a CSS `width` + `opacity` transition. CSS transitions don't depend on a JS frame loop or async keyframe resolver — they can't get stuck in the same way.

```tsx
<div
  className=\"relative h-full shrink-0 overflow-hidden border-l border-border-default\"
  style={{
    width: `${targetWidth}px`,
    opacity: isOpen ? 1 : 0,
    transition,
    borderLeftWidth: isOpen ? undefined : 0,
    pointerEvents: isOpen ? undefined : 'none',
  }}
  aria-hidden={isOpen ? undefined : true}
>
  <ResizeHandle ... />
  {task && <AgentPanel key={task.id} task={task} onClose={onClose} />}
</div>
```

Stale-content protection from #192 is preserved: `AgentPanel` is still keyed by `task.id`, so switching tasks fully unmounts the previous TerminalView + xterm + Tauri listeners before the new one mounts.

The container always stays in the DOM (collapsed to width:0, opacity:0, pointer-events:none, aria-hidden) when no task is active, so the CSS transition has something to animate.

## Repro (before fix)

1. `bun tauri dev` (vite + debug binary)
2. Click any task card
3. Observe panel mounted but stuck at `width: 0px; opacity: 0;` — no streaming output visible
4. Edit any line of `split-view.tsx` to trigger HMR, close the panel, click a different task
5. Reliably reproduces: new panel never opens; sometimes the new task's title is visible in the (collapsed) panel header

## After fix

1. Click any task → panel transitions open to full width over 200ms
2. Click another task → AgentPanel remounts with new task data, panel stays open, no flicker
3. HMR + close + new task → still works, panel opens cleanly

Verified end-to-end via `mcp__tauri-automation` — closing/reopening, rapid task switches, the previously-broken HMR sequence, and a cold-start launch all leave the panel at `width: 500px; opacity: 1`.

## Tests

New regression test at `src/components/layout/split-view.test.tsx` (7 cases). The key one is the remount test — pins that AgentPanel must be a different DOM node after task switch, which only holds with `key={task.id}`. I verified it FAILS if the dynamic key is replaced with a constant (proves it would catch the original buggy state).

- `bun run type-check` ✓
- `bun run lint` ✓
- `bun run test:run` — 296 passed (including 7 new)
- `cargo check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test` — 281 passed

## Out of scope (in this branch — flag for maintainers)

Per the agent prompt that authored this fix: I left two unrelated edits in this branch and want to call them out so they can be kept or carved out separately.

- `src-tauri/src/chat/bridge.rs` — extends the claude streaming wrapper's `if cli_name == \"claude\"` to also recognize `claude-mock`, so e2e tests can drive the same pipeline path. Useful as a testing hook.
- `src-tauri/src/lib.rs` — adds `mut` + `#[allow(unused_mut)]` to the Tauri builder binding. Cosmetic, no runtime effect.

Both are tiny and don't affect the panel fix; happy to split into a separate PR if preferred.

## Test plan

- [x] Cold-start: launch app, click any task, panel opens to full width
- [x] Task switch: click task A, then task B, panel stays open and shows task B's data without contamination
- [x] HMR sequence: trigger HMR, close panel, click a different task — panel opens cleanly
- [x] Rapid task switches (5 cards in a row) — final panel state is correct
- [x] No-task → task: panel transitions from collapsed to open
- [x] Task → no-task: panel collapses, no leftover panel content
- [x] Resize handle still works (no transition during drag)
- [x] All existing frontend tests pass
- [x] All existing cargo tests pass