### PR TITLE
Add db:migrate documentation and command

### DIFF
--- a/.task.md
+++ b/.task.md
@@ -1,0 +1,8 @@
+# Add db:migrate documentation and command
+
+Implement this as a real docs/dev tooling task. Add a pnpm db:migrate command that applies Bento-ya SQLite migrations to the local app database, document it in README troubleshooting/database setup, and ensure Linux setup docs include the database location and migration troubleshooting guidance. Keep the change focused and run targeted checks.
+
+## Context
+- Workspace: bento-ya
+- Branch: bentoya/add-db-migrate-documentation-and-command
+- Working dir: /home/anonabento/bento-ya/.worktrees/bentoya-ab6c2ccd-35b9-4c84-9cd2-e4c69bb41d28

--- a/README.md
+++ b/README.md
@@ -44,7 +44,38 @@ Opening `http://localhost:1420` by itself only shows the Vite frontend. It is us
 
 If `tauri-driver` is unavailable or reports that the platform is unsupported, use Playwright for browser-only checks and `pnpm tauri dev` for manual native verification.
 
+### Database setup and migrations
+
+Bento-ya stores its local SQLite database at `~/.bentoya/data.db`. The app runs pending migrations automatically on startup, but you can apply them explicitly after pulling schema changes:
+
+```bash
+pnpm db:migrate
+```
+
+The command uses the same Rust database initializer as the app, creates `~/.bentoya/` if needed, enables WAL mode, and records applied migrations in the `_migrations` table.
+
+### Linux setup notes
+
+On Linux, the app uses the same local data path as other platforms: `~/.bentoya/data.db`. If the app starts with database errors after a branch switch or update, run:
+
+```bash
+pnpm db:migrate
+```
+
+If migration still fails, close all Bento-ya windows and any `bento-mcp` process before retrying. SQLite lock errors usually mean another process still has `~/.bentoya/data.db`, `~/.bentoya/data.db-wal`, or `~/.bentoya/data.db-shm` open. Permission errors usually mean `~/.bentoya/` or the database files are owned by another user; fix ownership rather than deleting the database.
+
 ### Troubleshooting
+
+#### Database migration errors
+
+**Symptom:** The app launches but database-backed features fail, or startup logs mention missing columns, missing tables, `_migrations`, `database is locked`, or `readonly database`.
+
+**Fix:**
+```bash
+pnpm db:migrate
+```
+
+If the command reports `database is locked`, quit Bento-ya and stop `bento-mcp`, then rerun it. If it reports a readonly or permission error, check ownership and permissions on `~/.bentoya/` and `~/.bentoya/data.db`.
 
 #### White screen on launch
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Bento-ya stores its local SQLite database at `~/.bentoya/data.db`. The app runs 
 pnpm db:migrate
 ```
 
-The command uses the same Rust database initializer as the app, creates `~/.bentoya/` if needed, enables WAL mode, and records applied migrations in the `_migrations` table.
+Run the command from the repository root. It uses the same Rust database initializer as the app, creates `~/.bentoya/` if needed, enables WAL mode, and records applied migrations in the `_migrations` table. It is safe to rerun; already-applied migrations are skipped.
 
 ### Linux setup notes
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "prepare": "husky",
     "precommit": "lint-staged",
-    "db:migrate": "cargo run --manifest-path src-tauri/Cargo.toml --bin db-migrate",
+    "db:migrate": "cargo run --quiet --manifest-path src-tauri/Cargo.toml --bin db-migrate",
     "sync:updater-endpoint": "node scripts/sync-updater-endpoint.js",
     "tauri": "node scripts/sync-updater-endpoint.js && tauri",
     "type-check": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "prepare": "husky",
     "precommit": "lint-staged",
+    "db:migrate": "cargo run --manifest-path src-tauri/Cargo.toml --bin db-migrate",
     "sync:updater-endpoint": "node scripts/sync-updater-endpoint.js",
     "tauri": "node scripts/sync-updater-endpoint.js && tauri",
     "type-check": "tsc --noEmit",

--- a/src-tauri/src/bin/db-migrate.rs
+++ b/src-tauri/src/bin/db-migrate.rs
@@ -1,0 +1,33 @@
+#![deny(clippy::all)]
+
+#[allow(dead_code, unused_imports)]
+#[path = "../db/mod.rs"]
+mod db;
+
+fn main() {
+    let db_path = db::db_path();
+
+    match db::init() {
+        Ok(conn) => {
+            let migration_count = conn
+                .query_row("SELECT COUNT(*) FROM _migrations", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap_or(0);
+
+            println!(
+                "Applied Bento-ya migrations to {} ({} recorded migrations).",
+                db_path.display(),
+                migration_count
+            );
+        }
+        Err(error) => {
+            eprintln!(
+                "Failed to apply Bento-ya migrations to {}: {}",
+                db_path.display(),
+                error
+            );
+            std::process::exit(1);
+        }
+    }
+}

--- a/src-tauri/src/bin/db-migrate.rs
+++ b/src-tauri/src/bin/db-migrate.rs
@@ -1,8 +1,6 @@
 #![deny(clippy::all)]
 
-#[allow(dead_code, unused_imports)]
-#[path = "../db/mod.rs"]
-mod db;
+use bento_ya_lib::db;
 
 fn main() {
     let db_path = db::db_path();


### PR DESCRIPTION
## Description

Implement this as a real docs/dev tooling task. Add a pnpm db:migrate command that applies Bento-ya SQLite migrations to the local app database, document it in README troubleshooting/database setup, and ensure Linux setup docs include the database location and migration troubleshooting guidance. Keep the change focused and run targeted checks.

## Pipeline Context

- **Workspace:** bento-ya
- **Column:** Merge main
- **Branch:** `bentoya/add-db-migrate-documentation-and-command` → `staging/batch-20260511120425482`