### PR TITLE
Launch-readiness audit: security, updater, release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
         run: tmux new-session -d -s _bentoya_ci_keepalive 'sleep 86400'
 
       - name: Cargo check
-        run: cargo check
+        run: cargo check --workspace
 
       - name: Cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Cargo test
-        run: cargo test
+        run: cargo test --workspace
 
   frontend:
     name: Frontend
@@ -43,23 +43,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install frontend dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Type check
-        run: npm run type-check
+        run: pnpm run type-check
 
       - name: Lint
-        run: npm run lint
+        run: pnpm run lint
+
+      - name: IPC registration check
+        run: pnpm run test:ipc
+
+      - name: Dependency audit
+        run: pnpm audit --audit-level moderate
 
       - name: Frontend tests
-        run: npx vitest run
+        run: pnpm exec vitest run
 
   notify-failure:
     name: Notify failure
@@ -83,8 +95,8 @@ jobs:
               `Pusher: @${context.actor}`,
               '',
               'Checks run:',
-              '- Rust: `cargo check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test`',
-              '- Frontend: `npm run type-check`, `npm run lint`, `npx vitest run`',
+              '- Rust: `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`',
+              '- Frontend: `pnpm run type-check`, `pnpm run lint`, `pnpm run test:ipc`, `pnpm audit --audit-level moderate`, `pnpm exec vitest run`',
               '',
               'Please inspect the failed workflow run and fix main.'
             ].join('\n');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,43 +14,103 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: macos-latest
-            args: --target aarch64-apple-darwin
-            name: macOS-arm64
-          - platform: macos-latest
-            args: --target x86_64-apple-darwin
-            name: macOS-x64
-          - platform: ubuntu-22.04
-            args: ''
-            name: Linux-x64
-          - platform: windows-latest
-            args: ''
-            name: Windows-x64
-
-    runs-on: ${{ matrix.platform }}
+  preflight:
+    name: Release preflight
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
           version: 9
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-action@stable
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev tmux
+
+      - name: Start tmux server (required for bridge integration tests)
+        run: tmux new-session -d -s _kaitencode_release_keepalive 'sleep 86400'
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm run type-check
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: IPC registration check
+        run: pnpm run test:ipc
+
+      - name: Dependency audit
+        run: pnpm audit --audit-level moderate
+
+      - name: Frontend tests
+        run: pnpm run test:run
+
+      - name: Cargo check
+        run: cargo check --workspace
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Cargo test
+        run: cargo test --workspace
+
+  build:
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-15
+            args: --target aarch64-apple-darwin --bundles dmg,app
+            rust-targets: aarch64-apple-darwin
+            name: macOS-arm64
+          - platform: macos-15-intel
+            args: --target x86_64-apple-darwin --bundles dmg,app
+            rust-targets: x86_64-apple-darwin
+            name: macOS-x64
+          - platform: ubuntu-22.04
+            args: --bundles deb,appimage
+            rust-targets: ''
+            name: Linux-x64
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-targets }}
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -59,19 +119,99 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev
 
       - name: Install frontend dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate release version
+        shell: bash
+        run: |
+          RELEASE_VERSION="${{ github.event.inputs.version || github.ref_name }}"
+          if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].*)?$ ]]; then
+            echo "Release version must look like v0.1.0; got '$RELEASE_VERSION'" >&2
+            exit 1
+          fi
+          APP_VERSION="${RELEASE_VERSION#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          TAURI_VERSION="$(node -p "require('./src-tauri/tauri.conf.json').version")"
+          CARGO_VERSION="$(node -e "const fs=require('fs'); const m=fs.readFileSync('src-tauri/Cargo.toml','utf8').match(/^version\\s*=\\s*\"([^\"]+)\"/m); console.log(m && m[1])")"
+          if [[ "$PACKAGE_VERSION" != "$APP_VERSION" || "$TAURI_VERSION" != "$APP_VERSION" || "$CARGO_VERSION" != "$APP_VERSION" ]]; then
+            echo "Version mismatch for $RELEASE_VERSION: package=$PACKAGE_VERSION tauri=$TAURI_VERSION cargo=$CARGO_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Validate release signing secrets
+        shell: bash
+        env:
+          TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          missing=()
+          [[ -n "$TAURI_UPDATER_PUBKEY" ]] || missing+=(TAURI_UPDATER_PUBKEY)
+          [[ -n "$TAURI_SIGNING_PRIVATE_KEY" ]] || missing+=(TAURI_SIGNING_PRIVATE_KEY)
+
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            [[ -n "$APPLE_SIGNING_IDENTITY" ]] || missing+=(APPLE_SIGNING_IDENTITY)
+            [[ -n "$APPLE_CERTIFICATE" ]] || missing+=(APPLE_CERTIFICATE)
+            [[ -n "$APPLE_CERTIFICATE_PASSWORD" ]] || missing+=(APPLE_CERTIFICATE_PASSWORD)
+            [[ -n "$APPLE_API_ISSUER" ]] || missing+=(APPLE_API_ISSUER)
+            [[ -n "$APPLE_API_KEY" ]] || missing+=(APPLE_API_KEY)
+            [[ -n "$APPLE_API_KEY_PATH" || -n "$APPLE_API_KEY_P8" ]] || missing+=(APPLE_API_KEY_PATH_OR_APPLE_API_KEY_P8)
+          fi
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required production release secret(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Prepare Apple notarization API key
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH_SECRET: ${{ secrets.APPLE_API_KEY_PATH }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          if [[ -n "$APPLE_API_KEY_PATH_SECRET" ]]; then
+            echo "APPLE_API_KEY_PATH=$APPLE_API_KEY_PATH_SECRET" >> "$GITHUB_ENV"
+          elif [[ -n "$APPLE_API_KEY_P8" ]]; then
+            KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+            printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
+            chmod 600 "$KEY_PATH"
+            echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure updater endpoint
+        run: node scripts/sync-updater-endpoint.js
+        env:
+          REQUIRE_TAURI_UPDATER_PUBKEY: '1'
+          TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIRE_TAURI_UPDATER_PUBKEY: '1'
+          TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'KaitenCode ${{ github.ref_name }}'
+          tagName: ${{ github.event.inputs.version || github.ref_name }}
+          releaseName: 'KaitenCode ${{ github.event.inputs.version || github.ref_name }}'
           releaseBody: |
             ## What's New
 
-            See the [commit history](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}) for changes.
+            See the [commit history](https://github.com/${{ github.repository }}/commits/${{ github.event.inputs.version || github.ref_name }}) for changes.
 
             ## Rename Notes
 
@@ -86,13 +226,18 @@ jobs:
 
             | Platform | File |
             |----------|------|
-            | macOS (Apple Silicon) | `.dmg` |
-            | macOS (Intel) | `.dmg` |
-            | Windows | `.msi` or `.exe` |
+            | macOS (Apple Silicon) | `.dmg`, `.app.tar.gz` |
+            | macOS (Intel) | `.dmg`, `.app.tar.gz` |
             | Linux | `.deb` or `.AppImage` |
 
             ### macOS Note
-            Since this app isn't signed, you may need to right-click → Open the first time.
+            Public release builds require Developer ID signing and notarization secrets.
+
+            ### Linux Update Note
+            In-app updater artifacts are generated for AppImage builds. `.deb` packages are provided for manual package-manager installs and should be upgraded by installing a newer `.deb` from a published release.
+
+            ### Updater Note
+            This workflow creates a draft release for inspection. Publish the draft after verifying artifacts so `/releases/latest/download/latest.json` points at this version.
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "kaitencode": {
+      "command": "/home/anonabento/.cargo/bin/kaitencode-mcp"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,11 +229,9 @@ mcp-server/
 
 **Config:** `{ "command": "kaitencode-mcp" }` — auto-detects DB at `~/.kaitencode/data.db` with platform-specific Tauri data dir fallbacks.
 
-**App requirement:** Most mutation tools route through the Tauri app's HTTP API (port discovered via `~/.kaitencode/api.port`) so triggers fire and `tasks:changed` events flow to the UI. If the app isn't running, those tools error out (production builds disable direct-DB fallback; only `cfg!(test)` allows it). Read-only tools work without the app.
+**App requirement:** Most mutation tools route through the Tauri app's HTTP API (port and bearer token discovered via `~/.kaitencode/api.port`) so triggers fire and `tasks:changed` events flow to the UI. If the app isn't running, those tools error out (production builds disable direct-DB fallback; only `cfg!(test)` allows it). Read-only tools work without the app.
 
 **Known gaps (see `.tickets/_docs/MCP_DOGFOOD_REPORT.md`):**
-- `create_task` accepts a `model` parameter but silently drops it — the `/api/create_task` payload doesn't include it.
-- `create_task` does not expose `trigger_prompt` even though the API accepts it.
 - `mark_complete`, `add_dependency`, `remove_dependency` bypass the API and write the DB directly — no `tasks:changed` event, so the UI doesn't refresh in real-time.
 - No recursion guard / source attribution on MCP-created tasks. See `.tickets/_docs/MCP_SELF_TASK_WORKFLOW.md` for a safe self-task pattern.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,25 +2145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,8 +2300,6 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
- "tauri-plugin-fs",
- "tauri-plugin-shell",
  "tauri-plugin-updater",
  "tauri-plugin-webdriver-automation",
  "tauri-plugin-window-state",
@@ -2986,18 +2965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "open"
-version = "5.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
-dependencies = [
- "dunce",
- "is-wsl",
- "libc",
- "pathdiff",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,16 +3019,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "osakit"
@@ -3124,12 +3081,6 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -4288,42 +4239,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -5009,27 +4928,6 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "url",
-]
-
-[[package]]
-name = "tauri-plugin-shell"
-version = "2.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
-dependencies = [
- "encoding_rs",
- "log",
- "open",
- "os_pipe",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "shared_child",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1085,7 +1085,7 @@ Tauri is confirmed. Reasons:
 - Tiny bundles (~5-10MB vs Electron's 150MB+)
 - Rust backend handles PTY management, git operations, process lifecycle
 - Built-in updater, system tray, native dialogs
-- Cross-platform (macOS, Windows, Linux)
+- Launch platforms: macOS and Linux
 - portable-pty crate for terminal management
 - Security model (sandboxed webview, explicit API surface)
 
@@ -1146,7 +1146,7 @@ Tauri is confirmed. Reasons:
 - **pnpm** for frontend dependencies
 - **Vite** for frontend bundling
 - **Cargo** for Rust backend
-- Tauri bundler for .dmg / .app / .msi / .AppImage
+- Tauri bundler for `.dmg`, `.app`, `.deb`, and `.AppImage`
 
 ---
 
@@ -1793,7 +1793,7 @@ Users can configure in settings:
 - IPC call timing (warn if >500ms)
 
 ### Diagnostics
-- **"Export diagnostics" button** in settings: bundles logs, system info, config (no secrets) into a zip
+- Planned **"Export diagnostics" button** in settings: bundles logs, system info, config (no secrets) into a zip
 - System info: OS version, Tauri version, app version, available memory, GPU info
 - Agent info: CLI version, model in use, session duration
 - Useful for bug reports

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Per-workspace and global settings: concurrency limits, default CLI, default mode
 
 ![Settings panel](docs/screenshots/settings.png)
 
-> Regenerate these screenshots: `npm run test:webdriver -- --spec ./tests/webdriver/screenshots.spec.mjs` (see [Native WebDriver E2E](#native-webdriver-e2e) below for one-time setup).
+> Regenerate these screenshots: `pnpm test:webdriver -- --spec ./tests/webdriver/screenshots.spec.mjs` (see [Native WebDriver E2E](#native-webdriver-e2e) below for one-time setup).
 
 ## v2.0 Features
 
@@ -34,35 +34,66 @@ Per-workspace and global settings: concurrency limits, default CLI, default mode
 
 - **Per-task embedded terminal** — each task gets a full xterm.js terminal (lazy PTY, bare shell in working dir). Click a task card to open its terminal.
 - **xterm.js integration** — WebGL renderer, 10k line scrollback, fit-addon for responsive resizing, theme-reactive (dark/light), Unicode 11 support
-- **Lazy PTY sessions** — shell spawned on first panel open via `ensure_pty_session`, killed on panel close. Triggers will inject CLI commands directly into the shell.
+- **Persistent tmux sessions** — running task terminals attach to per-task tmux sessions and keep scrollback across panel reopens. Completed tasks open in attach-only mode so viewing history does not spawn a fresh shell.
 - **Unified chat session layer** — `UnifiedChatSession` manages lifecycle (idle/running/suspended), resume ID tracking, transport switching (pipe ↔ PTY)
 - **Legacy process layer removed** — deleted `pty_manager.rs`, `agent_runner.rs`. All PTY/agent management through unified `SessionRegistry`
 
 ## Development
 
+### Runtime prerequisites
+
+Packaged macOS and Linux builds expect these tools to be available on `PATH` for the corresponding features:
+
+| Tool | Required for | Install |
+|------|--------------|---------|
+| `tmux` | Agent sessions, embedded terminals, pipeline triggers | macOS: `brew install tmux`; Linux: distro package manager |
+| `git` | Workspace validation, branches, diffs, task worktrees | macOS command line tools or distro package manager |
+| `gh` | PR creation and GitHub status sync | `brew install gh` or GitHub CLI packages |
+| `claude` / `codex` | Running the selected agent CLI | Install and authenticate the CLI you plan to use |
+
+Desktop-launched apps on macOS/Linux may not inherit your shell dotfiles. First-run onboarding shows a system check for required tools. If a CLI is not detected, set its path in Settings > Agents & Models.
+
+The local HTTP API used by external automation is disabled by default in packaged apps. Start KaitenCode with `KAITENCODE_LOCAL_API=1` only when you intentionally want a local MCP/automation client to control the running app; the app writes a user-readable-only JSON discovery file with the selected port and a per-run bearer token to `~/.kaitencode/api.port` while enabled.
+
 ### Building
 
-**Always use `pnpm tauri build` (or `bun tauri build`) for production rebuilds.** Don't run `cargo build --release` standalone unless you are 100% sure no frontend changes are involved.
+**Always use `pnpm tauri build` for production rebuilds.** Don't run `cargo build --release` standalone unless you are 100% sure no frontend changes are involved.
 
 ```bash
 # Full production build (frontend + binary + .app + .dmg)
 pnpm tauri build
 
+# Linux packages
+pnpm tauri build --bundles deb,appimage
+
 # Dev mode (vite dev server + hot reload)
 pnpm tauri dev
 ```
 
-### Testing modes
+In-app updates are disabled unless the build has a Tauri updater public key, update endpoint, and generated updater artifacts. The release workflow enforces `TAURI_UPDATER_PUBKEY`; local ad-hoc builds show the disabled state in Settings > Updates instead of failing a check with a generic updater error. Linux updater artifacts target AppImage builds; `.deb` users should upgrade by installing the newer `.deb` from a published release.
+
+### Testing and runtime modes
+
+KaitenCode is a Tauri desktop app. The Vite dev server is still useful, but it is not the full app by itself.
 
 KaitenCode has three local test surfaces, each backed by a different runtime:
 
 | Surface | Command | Backend | Use it for |
 |---------|---------|---------|------------|
-| Browser/Vite | `npm run dev`, then `npm run test:e2e` | Mocked Tauri IPC | Fast React UI/layout/interaction checks |
+| Browser/Vite | `pnpm dev`, then open `http://localhost:1420` or run `pnpm test:e2e` | Mocked Tauri IPC | Fast React UI/layout/interaction checks |
 | Native Tauri | `pnpm tauri dev` | Real Rust backend, tmux, filesystem, WebView | Manual end-to-end agent and terminal testing |
 | Native WebDriver | See below | Real Tauri app under automation | Automated UI/IPC regression + screenshots |
 
-Opening `http://localhost:1420` by itself only shows the Vite frontend with mocked Tauri IPC — agent execution, tmux sessions, filesystem, and Rust-backed features need `pnpm tauri dev` or the WebDriver setup below.
+Opening `http://localhost:1420` by itself only shows the Vite frontend with browser mocks from `src/lib/browser-mock.ts`. That mode can render the board, settings, panels, dialogs, drag/drop, responsive layout, and most pure React state. It cannot run the real Rust commands: agent execution, tmux/PTY terminal sessions, local filesystem work, shell commands, native dialogs, updater behavior, and real SQLite persistence require `pnpm tauri dev`, `pnpm tauri build`, or the WebDriver setup below.
+
+Use this rule of thumb:
+
+- UI/layout/copy/regression check: `pnpm dev` or `pnpm test:e2e`
+- Real agent, terminal, git, filesystem, MCP, updater, or app dark-mode/WebView behavior: `pnpm tauri dev`
+- Release verification: `pnpm tauri build`, then launch the packaged app/binary
+- Automated native regression/screenshots: `pnpm build:webdriver`, `pnpm dev`, `tauri-driver`, then `pnpm test:webdriver`
+
+More detail: [Testing and Runtime Modes](docs/testing-and-runtime-modes.md).
 
 ### Native WebDriver E2E
 
@@ -87,17 +118,17 @@ safaridriver --enable        # one-time, requires admin
 
 ```bash
 # 1. Build the webdriver-enabled binary (one-time per Rust change)
-npm run build:webdriver
+pnpm build:webdriver
 
 # 2. Start Vite dev server on port 1420 (terminal A)
-npm run dev
+pnpm dev
 
 # 3. Start tauri-driver with an isolated data dir (terminal B)
 rm -rf /tmp/kaitencode-wdio && mkdir -p /tmp/kaitencode-wdio
 KAITENCODE_DATA_DIR=/tmp/kaitencode-wdio tauri-driver --port 4444
 
 # 4. Run the test suite (terminal C)
-npm run test:webdriver
+pnpm test:webdriver
 ```
 
 Tests live in `tests/webdriver/*.spec.mjs`; screenshots land in `tests/webdriver/screenshots/`. The binary path defaults to `<repo>/target/debug/kaitencode`; override with `KAITENCODE_BINARY=...` (e.g. for a release build).
@@ -105,7 +136,7 @@ Tests live in `tests/webdriver/*.spec.mjs`; screenshots land in `tests/webdriver
 **Troubleshooting:**
 - `window.__TAURI_INTERNALS__ is undefined` in test output — usually means `tauri-driver` fell back to its default browser (MiniBrowser/Safari). Verify `wdio.conf.mjs` uses `tauri:options.application` (not `binary`) and that `KAITENCODE_BINARY` resolves to a binary built with `--features webdriver`.
 - "can not find WebKitWebDriver" — install `webkit2gtk-driver` (Linux) or enable `safaridriver` (macOS).
-- Tests fail on the very first IPC call — check that `npm run dev` is actually serving on port 1420.
+- Tests fail on the very first IPC call — check that `pnpm dev` is actually serving on port 1420.
 
 ### Troubleshooting
 

--- a/docs/macos-bundle.md
+++ b/docs/macos-bundle.md
@@ -14,23 +14,36 @@ CFBundleExecutable = kaitencode
 
 The app also keeps Tauri `setup()` lightweight during macOS launch. Startup recovery that can touch SQLite, tmux, shell commands, or pipeline resume runs from background tasks after Tauri has returned from `didFinishLaunching`.
 
+Local builds use ad-hoc signing by default via `bundle.macOS.signingIdentity = "-"`. Public release builds must provide Developer ID signing and notarization secrets in the release workflow; the workflow fails early if the Apple signing/notarization secrets are missing. For notarization, provide either `APPLE_API_KEY_PATH` when the `.p8` key file already exists on the runner, or `APPLE_API_KEY_P8` with the private key contents so the workflow can write a temporary key file before `tauri-action` runs.
+
+In-app updates are also build-configured. A build needs all of the following before Settings > Updates can check for releases:
+
+- `TAURI_UPDATER_PUBKEY`
+- an updater endpoint in `tauri.conf.json`
+- updater artifacts generated during `tauri build`
+
+Local ad-hoc builds intentionally ship with updater artifacts disabled, so the app reports that updates are not configured for the build instead of attempting a network check.
+
+The release workflow also runs the same preflight gates as CI before packaging, pins explicit macOS runner labels per architecture, and builds explicit bundle targets (`dmg,app` for macOS; `deb,appimage` for Linux) instead of relying on `targets = "all"`. Linux updater artifacts are for AppImage builds; `.deb` packages are manual install/upgrade artifacts.
+
+Release workflow runs create draft releases for inspection. Publish the draft after verifying artifacts so the `/releases/latest/download/latest.json` updater endpoint points at the new version.
+
 ## Required Metadata
 
-The macOS bundle also includes usage descriptions in `src-tauri/Info.plist`:
+The macOS bundle also includes the usage description currently needed by native features in `src-tauri/Info.plist`:
 
 ```text
 NSMicrophoneUsageDescription
-NSCameraUsageDescription
 ```
 
-These keys must stay present because the app has voice-related functionality and macOS can terminate apps that access protected devices without usage strings.
+This key must stay present because the app has voice-related functionality and macOS can terminate apps that access protected devices without usage strings. Do not add camera or other protected-device permissions until the app actually uses those APIs.
 
 ## Verification
 
 Build and inspect the app bundle:
 
 ```sh
-npm run tauri -- build --bundles app
+pnpm tauri build --bundles app
 plutil -p target/release/bundle/macos/KaitenCode.app/Contents/Info.plist
 ```
 

--- a/docs/pipeline-v2-spec.md
+++ b/docs/pipeline-v2-spec.md
@@ -35,10 +35,10 @@ No agent. Pipeline logic only:
 ### `batch_wait`
 No agent. Waits for conditions:
 1. Check if all tasks in the same batch have reached PR/Staging
-2. If yes: create a `staging/<batch-id>` branch from main
+2. If yes: create a `staging/<batch-id>` branch from the workspace default base branch
 3. Merge all task branches into staging (resolve conflicts)
 4. Run type-check on staging. If fails, mark batch as needs-review.
-5. Push staging + create PR: staging → main
+5. Push staging + create PR: staging -> workspace default base branch
 6. Auto-advance all batch tasks to Merge (waiting for CI)
 
 ### `auto_merge`
@@ -77,7 +77,7 @@ workspace default base branch.
 Verify column checks which files the task modified:
 - If any file in `src/app/` (routes): run E2E
 - If only `src/lib/`, `src/components/`, config files: skip E2E
-- Check via: `git diff --name-only main..HEAD | grep "^src/app/"`
+- Check via: `git diff --name-only <workspace-default-base>..HEAD | grep "^src/app/"`
 
 ## Stale Session Cleanup
 

--- a/docs/testing-and-runtime-modes.md
+++ b/docs/testing-and-runtime-modes.md
@@ -1,0 +1,91 @@
+# Testing and Runtime Modes
+
+KaitenCode is a Tauri desktop app. There is a browser frontend for fast development, but the browser is not the product runtime.
+
+## Short Answer
+
+`pnpm dev` starts Vite and serves the React UI in a regular browser. It works for visual and interaction checks because the app falls back to browser mocks when Tauri is not available.
+
+It does not run the real Rust backend. Anything that depends on Tauri IPC, tmux, PTYs, the filesystem, shell commands, native dialogs, SQLite persistence, update installation, or real agent processes must be tested in the Tauri app.
+
+## Modes
+
+| Mode | Command | Runtime | What is real | What is mocked |
+|------|---------|---------|--------------|----------------|
+| Browser dev | `pnpm dev` | Chrome/Firefox/Safari + Vite | React, CSS, routing, browser layout, most UI state | Tauri IPC, data, filesystem, shell, tmux, agents |
+| Playwright browser E2E | `pnpm test:e2e` | Browser + Vite | Browser interactions and layout assertions | Tauri IPC and native features |
+| Tauri dev app | `pnpm tauri dev` | Native app WebView + Rust | Rust commands, SQLite, tmux/PTY, filesystem, shell, native WebView behavior | Nothing intentionally mocked |
+| Native WebDriver | `pnpm build:webdriver` + `pnpm dev` + `tauri-driver` + `pnpm test:webdriver` | Native app driven by WebDriver | Native app and Rust backend | Test data is isolated via env vars |
+| Production build | `pnpm tauri build` | Packaged app/binary | Release frontend assets embedded in the native app | Nothing intentionally mocked |
+
+## Browser/Vite: What Works
+
+Use the browser dev server for:
+
+- Board layout, columns, cards, scrolling, hover states, and responsive checks
+- Settings screens and dialogs where the behavior is pure React or mockable IPC
+- Visual regressions and fast screenshots
+- Keyboard shortcuts and basic interaction flows
+- Playwright tests that only need deterministic mocked data
+
+The browser mode exists because it is much faster than rebuilding or relaunching the native app for every CSS or component change.
+
+## Browser/Vite: What Does Not Prove Anything
+
+Do not treat `http://localhost:1420` as proof for:
+
+- Agent runs, resumed conversations, model/effort propagation, or live steering
+- Embedded terminal behavior, tmux sessions, PTY resize/input, shell commands
+- Git/worktree operations that depend on the real filesystem
+- MCP server configuration or CLI discovery
+- Native file picker/dialog behavior
+- Real SQLite persistence and migrations
+- Updater behavior
+- WebView-only styling differences, including native form controls and scrollbars
+
+Those need a Tauri runtime.
+
+## Tauri Dev App
+
+Use `pnpm tauri dev` when the question is “does the app work?”
+
+This starts Vite and launches the Tauri shell around it. The frontend is still hot-reloaded from Vite, but `window.__TAURI_INTERNALS__` exists and IPC calls go to the Rust backend.
+
+Use this for manual testing of:
+
+- Agent chat and resume behavior
+- Terminal panel and tmux-backed sessions
+- Worktree/git/file tracking
+- Native app/WebView visual differences
+- Settings that touch real config or local resources
+
+## Native WebDriver
+
+Use WebDriverIO when you need automated coverage against the real app. The app is still backed by Vite during these tests, so step 2 starts the dev server, but the browser is not opened directly. `tauri-driver` launches and drives the native Tauri binary.
+
+```bash
+pnpm build:webdriver
+pnpm dev
+KAITENCODE_DATA_DIR=/tmp/kaitencode-wdio tauri-driver --port 4444
+pnpm test:webdriver
+```
+
+Use this for screenshots and IPC regressions where Playwright browser mocks are not enough.
+
+## Production Build
+
+Use `pnpm tauri build` for full release verification. Do not use `cargo build --release` for a full app rebuild after frontend changes because it can skip the Vite build and asset embedding path.
+
+```bash
+pnpm tauri build
+```
+
+After building, launch the generated app/binary and verify startup, asset loading, and native WebView behavior.
+
+## Practical Decision Tree
+
+- “Does the UI look right?” Use `pnpm dev`, then confirm important native visual differences with `pnpm tauri dev`.
+- “Does the agent/terminal/filesystem work?” Use `pnpm tauri dev`.
+- “Can CI catch this layout regression?” Add or update Playwright browser tests.
+- “Can CI catch this real IPC/native regression?” Add or update WebDriverIO tests.
+- “Can users install and launch this?” Use `pnpm tauri build`.

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -88,14 +88,36 @@ fn checkpoint_wal(conn: &Connection) {
     let _ = conn.execute_batch("PRAGMA wal_checkpoint(FULL);");
 }
 
-/// Read the API port from ~/.kaitencode/api.port, falling back to the legacy
-/// ~/.bentoya/api.port during the migration window.
-fn read_api_port() -> Option<u16> {
+#[derive(Debug)]
+struct ApiDiscovery {
+    port: u16,
+    token: Option<String>,
+}
+
+/// Read API discovery from ~/.kaitencode/api.port, falling back to the legacy
+/// ~/.bentoya/api.port during the migration window. Newer app versions write
+/// JSON with both port and bearer token; older versions wrote just the port.
+fn read_api_discovery() -> Option<ApiDiscovery> {
     let home = dirs::home_dir()?;
-    let port_str = std::fs::read_to_string(home.join(".kaitencode").join("api.port"))
+    let raw = std::fs::read_to_string(home.join(".kaitencode").join("api.port"))
         .or_else(|_| std::fs::read_to_string(home.join(".bentoya").join("api.port")))
         .ok()?;
-    port_str.trim().parse().ok()
+    let trimmed = raw.trim();
+    if let Ok(port) = trimmed.parse::<u16>() {
+        return Some(ApiDiscovery { port, token: None });
+    }
+
+    let value = serde_json::from_str::<Value>(trimmed).ok()?;
+    let port = value.get("port")?.as_u64()?;
+    let port = u16::try_from(port).ok()?;
+    let token = value
+        .get("token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_string);
+
+    Some(ApiDiscovery { port, token })
 }
 
 /// Check if the KaitenCode app is running and its API is reachable.
@@ -103,11 +125,11 @@ fn read_api_port() -> Option<u16> {
 /// from a different process on a stale port.
 #[cfg(not(test))]
 fn is_app_running() -> bool {
-    let port = match read_api_port() {
-        Some(p) => p,
+    let discovery = match read_api_discovery() {
+        Some(discovery) => discovery,
         None => return false,
     };
-    let url = format!("http://127.0.0.1:{}/api/health", port);
+    let url = format!("http://127.0.0.1:{}/api/health", discovery.port);
     match ureq::get(&url).call() {
         Ok(resp) => resp
             .into_body()
@@ -135,9 +157,13 @@ fn require_app() -> Result<(), Value> {
 
 /// Call the Tauri app's HTTP API. Returns the response JSON or None if app isn't running.
 fn api_call(endpoint: &str, body: &Value) -> Option<Value> {
-    let port = read_api_port()?;
-    let url = format!("http://127.0.0.1:{}{}", port, endpoint);
-    let resp = ureq::post(&url).send_json(body).ok()?;
+    let discovery = read_api_discovery()?;
+    let token = discovery.token?;
+    let url = format!("http://127.0.0.1:{}{}", discovery.port, endpoint);
+    let resp = ureq::post(&url)
+        .header("Authorization", &format!("Bearer {token}"))
+        .send_json(body)
+        .ok()?;
     resp.into_body().read_json().ok()
 }
 
@@ -871,6 +897,7 @@ fn handle_create_task(conn: &Connection, args: &Value) -> Value {
     };
 
     let model = args.get("model").and_then(|v| v.as_str());
+    let trigger_prompt = args.get("trigger_prompt").and_then(|v| v.as_str());
 
     // Route through app API (triggers pipeline + updates UI)
     if let Some(resp) = api_call(
@@ -880,6 +907,8 @@ fn handle_create_task(conn: &Connection, args: &Value) -> Value {
             "column_id": col_id,
             "title": title,
             "description": description,
+            "model": model,
+            "trigger_prompt": trigger_prompt,
         }),
     ) {
         if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@tauri-apps/api": "^2.3.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",
-        "@tauri-apps/plugin-fs": "^2.5.0",
         "@tauri-apps/plugin-shell": "^2.2.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.16.0",
@@ -54,7 +53,7 @@
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.24.1",
-        "vite": "^6.2.0",
+        "vite": "^6.4.2",
         "vitest": "^4.0.18",
         "webdriverio": "^9.27.0"
       }
@@ -162,7 +161,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -535,7 +533,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -576,7 +573,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -598,7 +594,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1832,6 +1827,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2595,6 +2603,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
@@ -2880,15 +2952,6 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
-    "node_modules/@tauri-apps/plugin-fs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.0.tgz",
-      "integrity": "sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
-      }
-    },
     "node_modules/@tauri-apps/plugin-shell": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
@@ -2986,7 +3049,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3146,7 +3210,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3163,7 +3226,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3174,7 +3236,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3289,7 +3350,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3444,9 +3504,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3855,7 +3915,6 @@
       "integrity": "sha512-yT6EAyvEqm+wFD11fg89BMxvFkYLgnIVCihfJx+k73Gm3utL/DfZQpSheQdwrlQzu5p7jHi/JwOD76740F5Peg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
@@ -3900,7 +3959,6 @@
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -4130,8 +4188,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
@@ -4164,7 +4221,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4273,19 +4329,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/archiver": {
@@ -4579,9 +4622,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4619,9 +4662,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4669,7 +4712,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5560,7 +5602,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5951,7 +5994,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6268,7 +6310,6 @@
       "integrity": "sha512-5ot+Apo0bEvMD/nqzWymQpgyWnOdu0kVpmahLx5T7NzUc6RyifucZ24Gsfr6F6C8yRGBhmoFh7ZeY+W9kteEBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^4.0.16",
         "deep-eql": "^5.0.2",
@@ -6367,9 +6408,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.7.tgz",
+      "integrity": "sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==",
       "dev": true,
       "funding": [
         {
@@ -6383,9 +6424,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
-      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "dev": true,
       "funding": [
         {
@@ -6395,9 +6436,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.4.0",
-        "strnum": "^2.2.3"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6548,9 +6591,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7214,9 +7257,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7699,7 +7742,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -8731,6 +8773,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9409,19 +9452,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -9635,19 +9665,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mocha/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -9810,9 +9827,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -10259,9 +10276,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
-      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "dev": true,
       "funding": [
         {
@@ -10330,9 +10347,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10403,9 +10420,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -10423,7 +10440,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10463,6 +10480,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10478,6 +10496,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10603,22 +10622,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10628,7 +10636,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10641,7 +10648,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -11271,13 +11279,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {
@@ -11764,9 +11772,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "dev": true,
       "funding": [
         {
@@ -12561,7 +12569,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12595,9 +12602,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.0.tgz",
+      "integrity": "sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12816,12 +12823,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12897,7 +12903,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -13045,23 +13050,12 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/webdriver/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/webdriverio": {
       "version": "9.27.0",
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.27.0.tgz",
       "integrity": "sha512-Y4FbMf4bKBXpPB0lYpglzQ2GfDDe6uojmMZl85uPyrDx18NW7mqN84ZawGoIg/FRvcLaVhcOzc98WOPo725Rag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
@@ -13325,9 +13319,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13354,6 +13348,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kaitencode",
   "private": true,
   "version": "0.1.0",
+  "packageManager": "pnpm@9.15.9",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,15 +11,16 @@
     "prepare": "husky",
     "precommit": "lint-staged",
     "sync:updater-endpoint": "node scripts/sync-updater-endpoint.js",
-    "tauri": "node scripts/sync-updater-endpoint.js && tauri",
+    "tauri": "tauri",
     "type-check": "tsc --noEmit",
     "lint": "eslint src/",
+    "test:ipc": "node scripts/check-ipc-registration.js",
     "format": "prettier --write 'src/**/*.{ts,tsx,css}'",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:webdriver": "npx wdio run wdio.conf.mjs",
+    "test:webdriver": "pnpm exec wdio run wdio.conf.mjs",
     "build:webdriver": "cd src-tauri && cargo build --features webdriver"
   },
   "dependencies": {
@@ -27,7 +29,6 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@tauri-apps/api": "^2.3.0",
     "@tauri-apps/plugin-dialog": "^2.7.0",
-    "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-shell": "^2.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.16.0",
@@ -68,8 +69,39 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0",
+    "vite": "^6.4.2",
     "vitest": "^4.0.18",
     "webdriverio": "^9.27.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "basic-ftp": "5.3.1",
+      "fast-xml-builder": "1.1.7",
+      "fast-xml-parser": "5.8.0",
+      "flatted": "3.4.2",
+      "ip-address": "10.2.0",
+      "picomatch": "4.0.4",
+      "postcss": "8.5.15",
+      "serialize-javascript": "7.0.5",
+      "undici": "7.24.0",
+      "vite": "6.4.2",
+      "ws": "8.20.1",
+      "brace-expansion@^1.1.7": "1.1.14",
+      "brace-expansion@^5.0.0": "5.0.6"
+    }
+  },
+  "overrides": {
+    "basic-ftp": "5.3.1",
+    "fast-xml-builder": "1.1.7",
+    "fast-xml-parser": "5.8.0",
+    "flatted": "3.4.2",
+    "ip-address": "10.2.0",
+    "picomatch": "4.0.4",
+    "postcss": "8.5.15",
+    "serialize-javascript": "7.0.5",
+    "undici": "7.24.0",
+    "ws": "8.20.1",
+    "brace-expansion@^1.1.7": "1.1.14",
+    "brace-expansion@^5.0.0": "5.0.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,21 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  basic-ftp: 5.3.1
+  fast-xml-builder: 1.1.7
+  fast-xml-parser: 5.8.0
+  flatted: 3.4.2
+  ip-address: 10.2.0
+  picomatch: 4.0.4
+  postcss: 8.5.15
+  serialize-javascript: 7.0.5
+  undici: 7.24.0
+  vite: 6.4.2
+  ws: 8.20.1
+  brace-expansion@^1.1.7: 1.1.14
+  brace-expansion@^5.0.0: 5.0.6
+
 importers:
 
   .:
@@ -23,9 +38,6 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.0
         version: 2.7.0
-      '@tauri-apps/plugin-fs':
-        specifier: ^2.5.0
-        version: 2.5.0
       '@tauri-apps/plugin-shell':
         specifier: ^2.2.0
         version: 2.3.5
@@ -71,7 +83,7 @@ importers:
         version: 1.58.2
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.1(vite@6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.1(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tauri-apps/cli':
         specifier: ^2.4.0
         version: 2.10.0
@@ -92,7 +104,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.7.0(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -142,8 +154,8 @@ importers:
         specifier: ^8.24.1
         version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       vite:
-        specifier: ^6.2.0
-        version: 6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: 6.4.2
+        version: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -874,6 +886,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1141,7 +1156,7 @@ packages:
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7
+      vite: 6.4.2
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
@@ -1219,9 +1234,6 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.7.0':
     resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
-
-  '@tauri-apps/plugin-fs@2.5.0':
-    resolution: {integrity: sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ==}
 
   '@tauri-apps/plugin-shell@2.3.5':
     resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
@@ -1408,12 +1420,13 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: 6.4.2
 
   '@vitest/coverage-v8@4.0.18':
     resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
@@ -1431,7 +1444,7 @@ packages:
     resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: 6.4.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1704,8 +1717,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   bidi-js@1.0.3:
@@ -1718,14 +1731,14 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2231,11 +2244,11 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.7:
+    resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
 
-  fast-xml-parser@5.5.9:
-    resolution: {integrity: sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==}
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
     hasBin: true
 
   fd-slicer@1.1.0:
@@ -2245,7 +2258,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2281,8 +2294,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2508,8 +2521,8 @@ packages:
       '@types/node':
         optional: true
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   is-alphabetical@2.0.1:
@@ -3035,8 +3048,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3166,8 +3179,8 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  path-expression-matcher@1.2.0:
-    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
@@ -3194,12 +3207,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -3217,8 +3226,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3272,9 +3281,6 @@ packages:
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
-
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -3431,8 +3437,9 @@ packages:
     resolution: {integrity: sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==}
     engines: {node: '>=18'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -3575,8 +3582,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.2.2:
-    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -3703,12 +3710,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
-    engines: {node: '>=18.17'}
-
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.0:
+    resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -3761,8 +3764,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -3922,8 +3925,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3937,6 +3940,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -4605,6 +4612,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@nodable/entities@2.1.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4810,12 +4819,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.1(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -4867,10 +4876,6 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.10.0
 
   '@tauri-apps/plugin-dialog@2.7.0':
-    dependencies:
-      '@tauri-apps/api': 2.10.1
-
-  '@tauri-apps/plugin-fs@2.5.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 
@@ -5106,7 +5111,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5114,7 +5119,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5141,13 +5146,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.0.18(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -5413,7 +5418,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   archiver-utils@5.0.2:
     dependencies:
@@ -5507,7 +5512,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.3.1: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -5517,7 +5522,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -5526,7 +5531,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5600,7 +5605,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.22.0
+      undici: 7.24.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -5835,7 +5840,7 @@ snapshots:
       '@zip.js/zip.js': 2.8.26
       decamelize: 6.0.1
       edge-paths: 3.0.5
-      fast-xml-parser: 5.5.9
+      fast-xml-parser: 5.8.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       which: 6.0.1
@@ -6124,23 +6129,25 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.7:
     dependencies:
-      path-expression-matcher: 1.2.0
+      path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.9:
+  fast-xml-parser@5.8.0:
     dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.2.0
-      strnum: 2.2.2
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.7
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
 
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   figures@6.1.0:
     dependencies:
@@ -6170,12 +6177,12 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -6235,7 +6242,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -6413,7 +6420,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -6516,7 +6523,7 @@ snapshots:
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       pretty-format: 30.3.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -6536,7 +6543,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jiti@2.6.1: {}
 
@@ -6565,7 +6572,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6990,7 +6997,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   mimic-fn@4.0.0: {}
 
@@ -7000,11 +7007,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@5.1.9:
     dependencies:
@@ -7033,7 +7040,7 @@ snapshots:
       log-symbols: 4.1.0
       minimatch: 5.1.9
       ms: 2.1.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 6.5.1
@@ -7061,7 +7068,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -7212,7 +7219,7 @@ snapshots:
 
   path-exists@5.0.0: {}
 
-  path-expression-matcher@1.2.0: {}
+  path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
@@ -7231,9 +7238,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -7245,9 +7250,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.6:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7302,10 +7307,6 @@ snapshots:
   punycode@2.3.1: {}
 
   query-selector-shadow-dom@1.0.1: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -7375,7 +7376,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   readdirp@4.1.2: {}
 
@@ -7501,9 +7502,7 @@ snapshots:
     dependencies:
       type-fest: 4.41.0
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   setimmediate@1.0.5: {}
 
@@ -7552,7 +7551,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -7650,7 +7649,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.2.2: {}
+  strnum@2.3.0: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -7716,8 +7715,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@1.2.0: {}
 
@@ -7783,9 +7782,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@6.24.1: {}
-
-  undici@7.22.0: {}
+  undici@7.24.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -7853,12 +7850,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -7872,7 +7869,7 @@ snapshots:
   vitest@4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -7883,13 +7880,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
@@ -7935,8 +7932,8 @@ snapshots:
       '@wdio/utils': 9.27.0
       deepmerge-ts: 7.1.5
       https-proxy-agent: 7.0.6
-      undici: 6.24.1
-      ws: 8.20.0
+      undici: 7.24.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -8041,9 +8038,11 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/scripts/check-ipc-registration.js
+++ b/scripts/check-ipc-registration.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const frontendDirs = ['src']
+const sourceExtensions = new Set(['.ts', '.tsx'])
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walk(fullPath, files)
+    } else if (sourceExtensions.has(path.extname(entry.name))) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+const invokedCommands = new Set()
+const invokedCommandFiles = new Map()
+for (const dir of frontendDirs) {
+  for (const file of walk(path.join(root, dir))) {
+    const source = fs.readFileSync(file, 'utf8')
+    for (const match of source.matchAll(/invoke(?:<[^>]+>)?\(\s*['"]([^'"]+)['"]/g)) {
+      invokedCommands.add(match[1])
+      const relative = path.relative(root, file)
+      const files = invokedCommandFiles.get(match[1]) ?? new Set()
+      files.add(relative)
+      invokedCommandFiles.set(match[1], files)
+    }
+  }
+}
+
+const libRs = read('src-tauri/src/lib.rs')
+const handlerStart = libRs.indexOf('tauri::generate_handler![')
+const handlerEnd = libRs.indexOf('])\n        .setup', handlerStart)
+if (handlerStart === -1 || handlerEnd === -1) {
+  console.error('Could not locate tauri::generate_handler! block in src-tauri/src/lib.rs')
+  process.exit(1)
+}
+
+const handler = libRs.slice(handlerStart, handlerEnd)
+const registeredCommands = new Set()
+const devOnlyCommands = new Set(['seed_demo_data'])
+const devOnlyRegisteredCommands = new Set()
+const handlerLines = handler.split('\n')
+for (let i = 0; i < handlerLines.length; i++) {
+  const line = handlerLines[i]
+  const match = line.match(/(?:commands::(?:\w+::)+|models::)([a-zA-Z0-9_]+)/)
+  if (!match) continue
+
+  const command = match[1]
+  registeredCommands.add(command)
+  const prev = handlerLines
+    .slice(Math.max(0, i - 2), i)
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)
+  if (prev.some((candidate) => candidate.includes('cfg(debug_assertions)'))) {
+    devOnlyRegisteredCommands.add(command)
+  }
+}
+
+for (const command of devOnlyCommands) {
+  if (!devOnlyRegisteredCommands.has(command)) {
+    console.error(`Dev-only IPC command '${command}' must be registered behind #[cfg(debug_assertions)].`)
+    process.exit(1)
+  }
+}
+
+const missing = [...invokedCommands]
+  .filter((command) => !registeredCommands.has(command) && !devOnlyCommands.has(command))
+  .sort()
+
+if (missing.length > 0) {
+  console.error('Frontend invokes missing from Tauri generate_handler!:')
+  for (const command of missing) {
+    console.error(`  - ${command}`)
+  }
+  process.exit(1)
+}
+
+const unknownDevOnlyInvokes = [...devOnlyCommands]
+  .filter((command) => invokedCommands.has(command))
+  .filter((command) => {
+    const files = [...(invokedCommandFiles.get(command) ?? [])]
+    return files.some((file) => file !== 'src/lib/ipc/workspace.ts' && file !== 'src/components/layout/workspace-setup.tsx')
+  })
+
+if (unknownDevOnlyInvokes.length > 0) {
+  console.error('Dev-only IPC command invoked from unexpected frontend files:')
+  for (const command of unknownDevOnlyInvokes) {
+    console.error(`  - ${command}: ${[...(invokedCommandFiles.get(command) ?? [])].join(', ')}`)
+  }
+  process.exit(1)
+}
+
+console.log(`IPC registration check passed (${invokedCommands.size} frontend command(s)).`)

--- a/scripts/sync-updater-endpoint.js
+++ b/scripts/sync-updater-endpoint.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 // Writes the canonical KaitenCode GitHub releases URL into
-// src-tauri/tauri.conf.json's updater.endpoints.
+// src-tauri/tauri.conf.json's updater.endpoints and, when provided by CI,
+// injects the updater public key required to produce signed updater artifacts.
 //
-// Run via package.json scripts (also chained from `tauri:build`).
+// Run via package.json scripts before Tauri commands.
 
 import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -11,21 +12,50 @@ import { dirname, join } from 'node:path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const confPath = join(__dirname, '..', 'src-tauri', 'tauri.conf.json')
 const endpoint = 'https://github.com/ANonABento/kaitencode/releases/latest/download/latest.json'
+const pubkey = process.env.TAURI_UPDATER_PUBKEY?.trim() ?? ''
+const requirePubkey = process.env.REQUIRE_TAURI_UPDATER_PUBKEY === '1'
 
 function main() {
+  if (requirePubkey && !pubkey) {
+    throw new Error('TAURI_UPDATER_PUBKEY is required when REQUIRE_TAURI_UPDATER_PUBKEY=1')
+  }
+
   const conf = JSON.parse(readFileSync(confPath, 'utf8'))
   const current = conf?.plugins?.updater?.endpoints?.[0]
-
-  if (current === endpoint) {
-    console.log(`[sync-updater-endpoint] already up to date: ${endpoint}`)
-    return
-  }
+  const currentPubkey = conf?.plugins?.updater?.pubkey ?? ''
+  const currentUpdaterArtifacts = conf?.bundle?.createUpdaterArtifacts ?? false
 
   conf.plugins ??= {}
   conf.plugins.updater ??= { pubkey: '', endpoints: [] }
+  conf.bundle ??= {}
+
   conf.plugins.updater.endpoints = [endpoint]
+
+  if (pubkey) {
+    conf.plugins.updater.pubkey = pubkey
+    conf.bundle.createUpdaterArtifacts = true
+  } else {
+    conf.bundle.createUpdaterArtifacts = false
+  }
+
+  const nextPubkey = conf.plugins.updater.pubkey ?? ''
+  const nextUpdaterArtifacts = conf.bundle.createUpdaterArtifacts
+  const changed =
+    current !== endpoint ||
+    currentPubkey !== nextPubkey ||
+    currentUpdaterArtifacts !== nextUpdaterArtifacts
+
+  if (!changed) {
+    console.log(
+      `[sync-updater-endpoint] already up to date: ${endpoint}; updater artifacts ${nextUpdaterArtifacts ? 'enabled' : 'disabled'}`,
+    )
+    return
+  }
+
   writeFileSync(confPath, JSON.stringify(conf, null, 2) + '\n')
-  console.log(`[sync-updater-endpoint] ${current ?? '(empty)'} → ${endpoint}`)
+  console.log(
+    `[sync-updater-endpoint] endpoint ${current ?? '(empty)'} → ${endpoint}; updater artifacts ${nextUpdaterArtifacts ? 'enabled' : 'disabled'}`,
+  )
 }
 
 main()

--- a/site/index.html
+++ b/site/index.html
@@ -61,7 +61,7 @@
   <!-- Navigation -->
   <nav aria-label="Main navigation">
     <a href="/" class="logo">
-      <div class="logo-placeholder"></div>
+      <div class="logo-mark" aria-hidden="true">K</div>
       KaitenCode
     </a>
     <div class="nav-right">
@@ -97,13 +97,6 @@
           </svg>
           <span>macOS</span>
         </a>
-        <a href="https://github.com/ANonABento/kaitencode/releases/latest" aria-label="Download KaitenCode for Windows" rel="noopener noreferrer">
-          <!-- Windows icon from MDI -->
-          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M3 12V6.75l6-1.32v6.48zm17-9v8.75l-10 .15V5.21zM3 13l6 .09v6.81l-6-1.15zm17 .25V22l-10-1.91V13.1z"/>
-          </svg>
-          <span>Windows</span>
-        </a>
         <a href="https://github.com/ANonABento/kaitencode/releases/latest" aria-label="Download KaitenCode for Linux" rel="noopener noreferrer">
           <!-- Linux/Tux icon -->
           <svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true">
@@ -137,7 +130,6 @@
               </div>
               <div class="window-title">KaitenCode</div>
             </div>
-            <!-- App content placeholder -->
             <div class="app-content-preview">
               <div class="preview-sidebar">
                 <div class="preview-workspace active"></div>
@@ -277,27 +269,24 @@
               <span class="feature-desc">Navigate without mouse</span>
             </div>
 
-            <!-- Voice (coming soon) -->
-            <div class="compartment feature-cell coming-soon">
+            <div class="compartment feature-cell">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                <rect x="9" y="2" width="6" height="12" rx="3"/>
-                <path d="M5 10a7 7 0 0014 0"/>
-                <path d="M12 18v4M8 22h8"/>
+                <path d="M4 7h16M4 12h10M4 17h7"/>
+                <path d="M17 14l3 3-3 3"/>
               </svg>
-              <span class="feature-label">Voice input</span>
-              <span class="feature-tag">Soon</span>
+              <span class="feature-label">Runtime modes</span>
+              <span class="feature-desc">Headless or terminal</span>
             </div>
 
-            <!-- Extensions (coming soon) -->
-            <div class="compartment feature-cell coming-soon">
+            <div class="compartment feature-cell">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <rect x="3" y="3" width="8" height="8" rx="1"/>
                 <rect x="13" y="3" width="8" height="8" rx="1"/>
                 <rect x="3" y="13" width="8" height="8" rx="1"/>
                 <path d="M16 16h3M17.5 14.5v3"/>
               </svg>
-              <span class="feature-label">Extensions</span>
-              <span class="feature-tag">Soon</span>
+              <span class="feature-label">MCP tools</span>
+              <span class="feature-desc">Board automation API</span>
             </div>
           </div>
         </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -218,11 +218,17 @@ nav {
   color: var(--color-text);
 }
 
-.logo-placeholder {
+.logo-mark {
   width: 28px;
   height: 28px;
-  background: var(--color-border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-text);
+  color: var(--color-bg);
   border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 700;
 }
 
 .nav-right {

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,6 +1,5 @@
 [env]
-# Required for whisper-rs and ggml which use C++17 std::filesystem
+# Required for macOS packaging and native dependencies that respect the
+# deployment target. Do not set CFLAGS/CXXFLAGS globally here: Linux builds
+# will pass those flags into cc-rs build scripts and fail.
 MACOSX_DEPLOYMENT_TARGET = "10.15"
-# Pass to C++ compiler for cmake builds
-CXXFLAGS = "-mmacosx-version-min=10.15"
-CFLAGS = "-mmacosx-version-min=10.15"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,9 +13,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
-tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
-tauri-plugin-fs = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 serde = { workspace = true }

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,7 +4,5 @@
 <dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>KaitenCode needs microphone access for voice input transcription.</string>
-    <key>NSCameraUsageDescription</key>
-    <string>KaitenCode may use camera for future features.</string>
 </dict>
 </plist>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/nicholasrice/tauri/v2/crates/tauri-utils/schema.json",
+  "$schema": "https://schema.tauri.app/config/2/capability",
   "identifier": "default",
   "description": "Default capability with minimal permissions",
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "shell:allow-open",
     "dialog:allow-open",
-    "fs:allow-read",
     "window-state:default",
     "core:webview:allow-set-webview-zoom"
   ]

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -1,14 +1,17 @@
 //! HTTP API server for external control (MCP bridge).
 //!
-//! Starts an axum server on a random available port. The port is written
-//! to `~/.kaitencode/api.port` so MCP clients can discover it.
+//! When enabled, starts an axum server on a random available port. The port and
+//! a per-process bearer token are written to `~/.kaitencode/api.port` so MCP
+//! clients can discover it.
 //! Mutation endpoints call the same internal functions as Tauri IPC commands.
 
 use crate::db;
 use crate::pipeline;
 use axum::{
+    extract::Request,
     extract::State as AxumState,
-    http::StatusCode,
+    http::{header, StatusCode},
+    middleware::{self, Next},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
@@ -17,11 +20,13 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tauri::AppHandle;
+use uuid::Uuid;
 
 /// Shared state for axum handlers.
 struct ApiState {
     app: AppHandle,
     db: Arc<std::sync::Mutex<rusqlite::Connection>>,
+    token: String,
 }
 
 /// Standard API response.
@@ -51,6 +56,25 @@ fn err_response(status: StatusCode, msg: String) -> impl IntoResponse {
             error: Some(msg),
         }),
     )
+}
+
+async fn require_api_auth(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    req: Request,
+    next: Next,
+) -> impl IntoResponse {
+    let expected = format!("Bearer {}", api.token);
+    let authorized = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == expected);
+
+    if !authorized {
+        return err_response(StatusCode::UNAUTHORIZED, "Unauthorized".to_string()).into_response();
+    }
+
+    next.run(req).await
 }
 
 macro_rules! get_db {
@@ -176,6 +200,7 @@ struct CreateTaskReq {
     title: String,
     description: Option<String>,
     trigger_prompt: Option<String>,
+    model: Option<String>,
 }
 
 async fn create_task(
@@ -202,6 +227,13 @@ async fn create_task(
         let _ = conn.execute(
             "UPDATE tasks SET trigger_prompt = ?1, updated_at = ?2 WHERE id = ?3",
             rusqlite::params![prompt, ts, task.id],
+        );
+    }
+    if let Some(ref model) = req.model {
+        let ts = db::now();
+        let _ = conn.execute(
+            "UPDATE tasks SET model = ?1, updated_at = ?2 WHERE id = ?3",
+            rusqlite::params![model, ts, task.id],
         );
     }
 
@@ -603,8 +635,37 @@ fn port_file_path() -> std::path::PathBuf {
     crate::db::data_dir().join("api.port")
 }
 
-/// Start the HTTP API server on a random port. Writes port to ~/.kaitencode/api.port.
+fn write_api_discovery_file(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(contents.as_bytes())?;
+        file.write_all(b"\n")
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, format!("{contents}\n"))
+    }
+}
+
+/// Start the HTTP API server on a random port. Writes port and token to
+/// ~/.kaitencode/api.port.
 pub fn start(app: AppHandle) {
+    if !local_api_enabled() {
+        let _ = std::fs::remove_file(port_file_path());
+        log::info!("[api] Local HTTP API disabled; set KAITENCODE_LOCAL_API=1 to enable");
+        return;
+    }
+
     // Open a separate DB connection for the API server (WAL allows concurrent access)
     let db = Arc::new(std::sync::Mutex::new(
         rusqlite::Connection::open(crate::db::db_path()).expect("Failed to open DB for API server"),
@@ -615,11 +676,15 @@ pub fn start(app: AppHandle) {
         let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
     }
 
-    let api_state = Arc::new(ApiState { app, db });
+    let token = Uuid::new_v4().to_string();
+    let api_state = Arc::new(ApiState {
+        app,
+        db,
+        token: token.clone(),
+    });
 
     tauri::async_runtime::spawn(async move {
-        let router = Router::new()
-            .route("/api/health", get(health))
+        let protected = Router::new()
             .route("/api/move_task", post(move_task))
             .route("/api/create_task", post(create_task))
             .route("/api/delete_task", post(delete_task))
@@ -641,6 +706,14 @@ pub fn start(app: AppHandle) {
                 "/api/delete_pipeline_template",
                 post(delete_pipeline_template_api),
             )
+            .route_layer(middleware::from_fn_with_state(
+                Arc::clone(&api_state),
+                require_api_auth,
+            ));
+
+        let router = Router::new()
+            .route("/api/health", get(health))
+            .merge(protected)
             .with_state(api_state);
 
         // Bind to random available port
@@ -655,9 +728,14 @@ pub fn start(app: AppHandle) {
         let addr: SocketAddr = listener.local_addr().unwrap();
         log::info!("[api] HTTP API server listening on {}", addr);
 
-        // Write port file
+        // Write discovery file with user-only permissions where the platform supports it.
         let port_path = port_file_path();
-        if let Err(e) = std::fs::write(&port_path, addr.port().to_string()) {
+        let discovery = serde_json::json!({
+            "port": addr.port(),
+            "token": token,
+        })
+        .to_string();
+        if let Err(e) = write_api_discovery_file(&port_path, &discovery) {
             log::error!("[api] Failed to write port file: {}", e);
         }
 
@@ -674,4 +752,40 @@ pub fn start(app: AppHandle) {
 /// Remove the port file (call on app shutdown).
 pub fn cleanup() {
     let _ = std::fs::remove_file(port_file_path());
+}
+
+fn local_api_enabled() -> bool {
+    std::env::var("KAITENCODE_LOCAL_API")
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::local_api_enabled;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn local_api_disabled_by_default() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        std::env::remove_var("KAITENCODE_LOCAL_API");
+        assert!(!local_api_enabled());
+    }
+
+    #[test]
+    fn local_api_accepts_explicit_enable_values() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        for value in ["1", "true", "yes", "on"] {
+            std::env::set_var("KAITENCODE_LOCAL_API", value);
+            assert!(local_api_enabled(), "value {value}");
+        }
+        std::env::remove_var("KAITENCODE_LOCAL_API");
+    }
 }

--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -964,6 +964,45 @@ fn emit_semantic_events_from_provider_json_delta(
     let mut emitted = false;
     for line in delta.lines().filter(|line| !line.trim().is_empty()) {
         for event in runtime_events_from_provider_json_line(adapter, line) {
+            if let Some(session_id) = session_id {
+                match &event {
+                    AgentRuntimeEvent::SessionStarted {
+                        provider_session_id,
+                        model,
+                        ..
+                    } => {
+                        if let Ok(conn) = Connection::open(db::db_path()) {
+                            let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
+                            let _ = db::update_agent_session_runtime(
+                                &conn,
+                                session_id,
+                                Some(adapter_kind_db_key(adapter)),
+                                None,
+                                provider_session_id.as_deref().map(Some),
+                                None,
+                            );
+                            let _ = db::update_agent_session_model(
+                                &conn,
+                                session_id,
+                                model.as_deref(),
+                                None,
+                            );
+                        }
+                    }
+                    AgentRuntimeEvent::AgentStarted { model, .. } if model.is_some() => {
+                        if let Ok(conn) = Connection::open(db::db_path()) {
+                            let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
+                            let _ = db::update_agent_session_model(
+                                &conn,
+                                session_id,
+                                model.as_deref(),
+                                None,
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
             if matches!(
                 event,
                 AgentRuntimeEvent::AgentCompleted { .. }
@@ -1002,6 +1041,20 @@ fn tail_bytes(s: &str, n: usize) -> String {
         i += 1;
     }
     s[i..].to_string()
+}
+
+fn short_commit_hash(hash: &str) -> String {
+    hash.chars().take(7).collect()
+}
+
+fn adapter_kind_db_key(adapter: AgentAdapterKind) -> &'static str {
+    match adapter {
+        AgentAdapterKind::ClaudeCli => "claude_cli",
+        AgentAdapterKind::CodexCli => "codex_cli",
+        AgentAdapterKind::GenericCli => "generic_cli",
+        AgentAdapterKind::Api => "api",
+        AgentAdapterKind::Remote => "remote",
+    }
 }
 
 /// Truncate the log to the trailing SCROLLBACK_MAX_BYTES on a char boundary.
@@ -1248,6 +1301,14 @@ pub fn spawn_cli_trigger_task(
                         None,
                         Some(Some(&tmux_name)),
                     );
+                    let _ = db::update_agent_session_model(
+                        &conn,
+                        &session.id,
+                        task_snapshot
+                            .as_ref()
+                            .and_then(|task| task.model.as_deref()),
+                        None,
+                    );
                     let _ = db::update_task_agent_status(&conn, &task_id, Some("running"), None);
                     let ts = db::now();
                     let _ = conn.execute(
@@ -1289,6 +1350,7 @@ pub fn spawn_cli_trigger_task(
                     };
                     let metadata = serde_json::json!({
                         "cli": cli_command,
+                        "model": task_snapshot.as_ref().and_then(|task| task.model.as_deref()),
                         "workdir": working_dir,
                         "persistentLifecycle": persistent_lifecycle,
                         "resumeAvailable": resume_id.is_some(),
@@ -1840,6 +1902,7 @@ async fn run_trigger_in_tmux(
         (false, false, None) => 1,
     };
     let mut success = effective_exit == 0;
+    let mut auto_commit_hash: Option<String> = None;
 
     // Auto-commit safety net: an agent can exit 0 yet leave its work
     // uncommitted in the worktree — typically because its sandbox blocks
@@ -1861,13 +1924,33 @@ async fn run_trigger_in_tmux(
                                 task_id
                             );
                             match branch_manager::auto_commit_dirty_worktree(worktree_path, &msg) {
-                                Ok(true) => {
+                                Ok(Some(hash)) => {
                                     eprintln!(
-                                        "[bridge] auto-committed dirty worktree for task {} (agent exit 0 but didn't commit)",
-                                        task_id
+                                        "[bridge] auto-committed dirty worktree for task {} at {} (agent exit 0 but didn't commit)",
+                                        task_id, hash
                                     );
+                                    let message = format!(
+                                        "Auto-committed dirty worktree at {}",
+                                        short_commit_hash(&hash)
+                                    );
+                                    let _ = crate::events::persist_and_emit_agent_transcript_event(
+                                        app,
+                                        task_id,
+                                        session_id,
+                                        db::EVENT_COMMAND_OUTPUT,
+                                        Some(&message),
+                                        Some(
+                                            &serde_json::json!({
+                                                "source": "auto_commit",
+                                                "command": "git commit",
+                                                "commit": hash,
+                                            })
+                                            .to_string(),
+                                        ),
+                                    );
+                                    auto_commit_hash = Some(hash);
                                 }
-                                Ok(false) => {
+                                Ok(None) => {
                                     // Dirty was all gitignored — fine, no rescue needed.
                                 }
                                 Err(e) => {
@@ -1914,6 +1997,7 @@ async fn run_trigger_in_tmux(
     let completion_metadata = serde_json::json!({
         "exitCode": effective_exit,
         "timedOut": timed_out,
+        "autoCommitHash": auto_commit_hash,
     })
     .to_string();
     let _ = crate::events::persist_and_emit_agent_transcript_event(

--- a/src-tauri/src/chat/tmux_transport.rs
+++ b/src-tauri/src/chat/tmux_transport.rs
@@ -44,6 +44,25 @@ pub(crate) fn tmux_test_lock_blocking() -> tokio::sync::MutexGuard<'static, ()> 
 const SESSION_PREFIX: &str = "kaitencode_";
 const LEGACY_SESSION_PREFIXES: &[&str] = &["bentoya_"];
 
+fn tmux_server_missing(stderr: &str) -> bool {
+    stderr.contains("no server running")
+        || stderr.contains("error connecting to")
+        || stderr.contains("No such file or directory")
+}
+
+pub fn default_user_shell() -> String {
+    std::env::var("SHELL")
+        .ok()
+        .filter(|shell| !shell.trim().is_empty())
+        .unwrap_or_else(|| {
+            if cfg!(target_os = "macos") {
+                "/bin/zsh".to_string()
+            } else {
+                "/bin/sh".to_string()
+            }
+        })
+}
+
 /// Check if tmux is available on the system.
 /// Returns the version string on success, or an error message.
 pub fn check_tmux() -> Result<String, String> {
@@ -72,7 +91,7 @@ pub fn ensure_tmux_server() -> Result<(), String> {
 
     if !check.status.success() {
         let stderr = String::from_utf8_lossy(&check.stderr);
-        if stderr.contains("no server running") {
+        if tmux_server_missing(&stderr) {
             eprintln!("[tmux] Server not running — auto-starting");
             let start = Command::new("tmux")
                 .args(["new-session", "-d", "-s", "default"])
@@ -177,7 +196,7 @@ pub fn kill_session(task_id: &str) -> Result<(), String> {
         if !output.status.success() {
             // Session might already be dead — not an error
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if !stderr.contains("no server running")
+            if !tmux_server_missing(&stderr)
                 && !stderr.contains("session not found")
                 && !stderr.contains("can't find session")
             {
@@ -316,7 +335,7 @@ impl TmuxTransport {
         // Spawn the shell command inside tmux
         // If command is a shell ($SHELL), tmux uses its default shell
         // If it's something else, pass it as the tmux command
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let shell = default_user_shell();
         if config.command != shell {
             args.push(config.command.clone());
             for arg in &config.args {

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1,4 +1,7 @@
 use serde::Serialize;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc, Mutex,
@@ -14,6 +17,7 @@ use crate::chat::runtime::{
     ManagedRuntimeTurnResult, ProviderRuntimeLine,
 };
 use crate::chat::session::{SessionConfig, SessionState, TransportType};
+use crate::chat::tmux_transport::{capture_scrollback, default_user_shell};
 use crate::db::{self, AgentMessage, AppState};
 use crate::error::AppError;
 
@@ -55,10 +59,140 @@ struct TaskInputCompletion {
 
 const TASK_INPUT_COMPLETION_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 2);
 
+pub(crate) fn validate_agent_cli_path(cli_path: &str) -> Result<String, AppError> {
+    let cli = cli_path.trim();
+    if cli.is_empty() {
+        return Err(AppError::InvalidInput(
+            "Agent CLI path cannot be empty".to_string(),
+        ));
+    }
+
+    if !cli.contains('/') && !cli.contains('\\') {
+        return match cli {
+            "claude" | "codex" => Ok(cli.to_string()),
+            other => Err(AppError::InvalidInput(format!(
+                "Unsupported agent CLI binary: {}",
+                other
+            ))),
+        };
+    }
+
+    let path = Path::new(cli);
+    if !path.exists() || !path.is_file() {
+        return Err(AppError::InvalidInput(format!(
+            "Agent CLI path is not an executable file: {}",
+            cli
+        )));
+    }
+
+    #[cfg(unix)]
+    {
+        let executable = path
+            .metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false);
+        if !executable {
+            return Err(AppError::InvalidInput(format!(
+                "Agent CLI path is not executable: {}",
+                cli
+            )));
+        }
+    }
+
+    let binary_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    if !matches!(binary_name, "claude" | "codex") {
+        return Err(AppError::InvalidInput(format!(
+            "Unsupported agent CLI executable: {}",
+            binary_name
+        )));
+    }
+
+    path.canonicalize()
+        .map(|path| path.to_string_lossy().to_string())
+        .map_err(|e| AppError::InvalidInput(format!("Invalid agent CLI path: {}", e)))
+}
+
+fn canonical_existing_dir(path: &str) -> Result<PathBuf, AppError> {
+    let path_ref = Path::new(path.trim());
+    if path.trim().is_empty() {
+        return Err(AppError::InvalidInput(
+            "Working directory cannot be empty".to_string(),
+        ));
+    }
+    let canonical = path_ref.canonicalize().map_err(|e| {
+        AppError::InvalidInput(format!(
+            "Working directory does not exist: {} ({})",
+            path, e
+        ))
+    })?;
+    if !canonical.is_dir() {
+        return Err(AppError::InvalidInput(format!(
+            "Working directory is not a directory: {}",
+            path
+        )));
+    }
+    Ok(canonical)
+}
+
+fn resolve_task_working_dir(
+    task: &db::Task,
+    workspace: &db::Workspace,
+    requested_working_dir: &str,
+) -> Result<String, AppError> {
+    let requested = canonical_existing_dir(requested_working_dir)?;
+    let workspace_root = canonical_existing_dir(&workspace.repo_path)?;
+    if requested == workspace_root {
+        return Ok(requested.to_string_lossy().to_string());
+    }
+
+    if let Some(worktree_path) = task.worktree_path.as_deref() {
+        let worktree_root = canonical_existing_dir(worktree_path)?;
+        if requested == worktree_root {
+            return Ok(requested.to_string_lossy().to_string());
+        }
+    }
+
+    Err(AppError::InvalidInput(format!(
+        "Working directory must match the task's workspace or worktree: {}",
+        requested_working_dir
+    )))
+}
+
+fn validate_task_launch_inputs(
+    state: &State<'_, AppState>,
+    task_id: &str,
+    working_dir: &str,
+    cli_path: Option<&str>,
+) -> Result<(String, String), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let task = db::get_task(&conn, task_id)?;
+    let workspace = db::get_workspace(&conn, &task.workspace_id)?;
+    let working_dir = resolve_task_working_dir(&task, &workspace, working_dir)?;
+    let cli = validate_agent_cli_path(cli_path.unwrap_or("claude"))?;
+    Ok((working_dir, cli))
+}
+
+fn validate_task_exists(state: &State<'_, AppState>, task_id: &str) -> Result<(), AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let _ = db::get_task(&conn, task_id)?;
+    Ok(())
+}
+
 // ─── PTY Agent Commands (via SessionRegistry) ──────────────────────────────
 
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub async fn start_agent(
+    state: State<'_, AppState>,
     task_id: String,
     _agent_type: String,
     working_dir: String,
@@ -67,7 +201,9 @@ pub async fn start_agent(
     app_handle: AppHandle,
     session_registry: State<'_, SharedSessionRegistry>,
 ) -> Result<AgentInfo, String> {
-    let cli = cli_path.unwrap_or_else(|| "claude".to_string());
+    let (working_dir, cli) =
+        validate_task_launch_inputs(&state, &task_id, &working_dir, cli_path.as_deref())
+            .map_err(|e| e.to_string())?;
 
     let mut registry = session_registry.lock().await;
 
@@ -262,7 +398,10 @@ pub async fn send_task_input(
     model: Option<String>,
     effort_level: Option<String>,
 ) -> Result<(), AppError> {
-    let model = model.unwrap_or_else(|| "sonnet".to_string());
+    let (working_dir, cli_path) =
+        validate_task_launch_inputs(&state, &task_id, &working_dir, Some(&cli_path))?;
+    let requested_model = model;
+    let requested_effort_level = effort_level;
     let is_user_input = matches!(source.as_str(), "chat" | "voice" | "command");
 
     let (
@@ -275,6 +414,8 @@ pub async fn send_task_input(
         adapter_kind,
         column_name,
         pipeline_state,
+        model,
+        effort_level,
     ) = {
         let conn = state
             .db
@@ -284,6 +425,22 @@ pub async fn send_task_input(
         let column_name = db::get_column(&conn, &previous_task.column_id)
             .ok()
             .map(|column| column.name);
+
+        let agent_type = agent_type_from_cli_path(&cli_path);
+        let agent_session = db::get_or_create_agent_session_for_task(
+            &conn,
+            &task_id,
+            agent_type,
+            Some(&working_dir),
+        )?;
+        let model = requested_model
+            .clone()
+            .or_else(|| agent_session.model.clone())
+            .or_else(|| previous_task.model.clone())
+            .unwrap_or_else(|| "sonnet".to_string());
+        let effort_level = requested_effort_level
+            .clone()
+            .or_else(|| agent_session.effort_level.clone());
 
         db::insert_agent_message(
             &conn,
@@ -301,13 +458,6 @@ pub async fn send_task_input(
             crate::pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_user_input");
         }
 
-        let agent_type = agent_type_from_cli_path(&cli_path);
-        let agent_session = db::get_or_create_agent_session_for_task(
-            &conn,
-            &task_id,
-            agent_type,
-            Some(&working_dir),
-        )?;
         let tmux_name = tmux_session_name_for_task(&task_id);
         let runtime_mode = normalize_agent_runtime_mode(
             previous_task
@@ -324,6 +474,12 @@ pub async fn send_task_input(
             Some(&runtime_mode),
             None,
             Some(Some(&tmux_name)),
+        )?;
+        let _ = db::update_agent_session_model(
+            &conn,
+            &agent_session.id,
+            Some(&model),
+            effort_level.as_deref(),
         )?;
         let should_launch_prompt_command = matches!(source.as_str(), "chat" | "voice")
             && previous_task.agent_status.as_deref() != Some("running");
@@ -386,6 +542,8 @@ pub async fn send_task_input(
             adapter_kind,
             column_name,
             previous_task.pipeline_state,
+            model,
+            effort_level,
         )
     };
 
@@ -542,6 +700,7 @@ pub async fn send_task_input(
             task_id.clone(),
             session_id,
             completion,
+            working_dir.clone(),
             pre_command_scrollback.unwrap_or_default(),
         );
     }
@@ -641,6 +800,7 @@ fn spawn_managed_task_turn(
     let model_for_queue = model.clone();
     let effort_level_for_queue = effort_level.clone();
     let working_dir_for_queue = working_dir.clone();
+    let working_dir_for_auto_commit = working_dir.clone();
 
     tokio::spawn(async move {
         let result = run_managed_runtime_turn(
@@ -656,7 +816,8 @@ fn spawn_managed_task_turn(
                 let session_id = session_id.clone();
                 move |event| {
                     if let AgentRuntimeEvent::SessionStarted {
-                        provider_session_id: Some(provider_session_id),
+                        provider_session_id,
+                        model,
                         ..
                     } = &event
                     {
@@ -667,7 +828,13 @@ fn spawn_managed_task_turn(
                                 &session_id,
                                 None,
                                 Some("managed"),
-                                Some(Some(provider_session_id)),
+                                provider_session_id.as_deref().map(Some),
+                                None,
+                            );
+                            let _ = db::update_agent_session_model(
+                                &conn,
+                                &session_id,
+                                model.as_deref(),
                                 None,
                             );
                         }
@@ -683,9 +850,26 @@ fn spawn_managed_task_turn(
         )
         .await;
 
-        let should_replay_queue = managed_turn_completed_successfully(&result);
-        let success = should_replay_queue;
-        let spawned_queued_turn = if should_replay_queue {
+        let mut success = managed_turn_completed_successfully(&result);
+        if success {
+            match auto_commit_completed_worktree(
+                &app,
+                &task_id,
+                Some(&session_id),
+                &working_dir_for_auto_commit,
+            ) {
+                Ok(_) => {}
+                Err(err) => {
+                    eprintln!(
+                        "[agent] auto-commit FAILED for managed task turn {}: {}",
+                        task_id, err
+                    );
+                    success = false;
+                }
+            }
+        }
+
+        let spawned_queued_turn = if success {
             spawn_next_queued_managed_turn(
                 app_for_queue,
                 task_id_for_queue,
@@ -704,10 +888,14 @@ fn spawn_managed_task_turn(
             let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
             if !spawned_queued_turn {
                 let (session_status, task_status, exit_code) = match &result {
-                    Ok(turn) if turn.exit_code == Some(0) => {
-                        ("completed", "completed", Some(0_i64))
+                    Ok(turn) if success => {
+                        ("completed", "completed", turn.exit_code.map(i64::from))
                     }
-                    Ok(turn) => ("failed", "failed", turn.exit_code.map(i64::from)),
+                    Ok(turn) => (
+                        "failed",
+                        "failed",
+                        Some(i64::from(turn.exit_code.unwrap_or(1).max(1))),
+                    ),
                     Err(_) => ("failed", "failed", Some(1_i64)),
                 };
                 let _ = db::update_agent_session(
@@ -750,6 +938,47 @@ fn managed_turn_completed_successfully(
     result: &Result<ManagedRuntimeTurnResult, AgentRuntimeError>,
 ) -> bool {
     matches!(result, Ok(turn) if turn.exit_code == Some(0))
+}
+
+fn auto_commit_completed_worktree(
+    app: &AppHandle,
+    task_id: &str,
+    session_id: Option<&str>,
+    worktree_path: &str,
+) -> Result<Option<String>, String> {
+    if !crate::git::branch_manager::worktree_is_dirty(worktree_path)? {
+        return Ok(None);
+    }
+
+    let msg = format!(
+        "auto-commit: kaitencode rescued uncommitted work for task {} (agent exited 0 without committing)",
+        task_id
+    );
+    let commit_hash = crate::git::branch_manager::auto_commit_dirty_worktree(worktree_path, &msg)?;
+    if let Some(hash) = commit_hash.as_deref() {
+        let short_hash: String = hash.chars().take(7).collect();
+        eprintln!(
+            "[agent] auto-committed dirty managed turn worktree for task {} at {}",
+            task_id, hash
+        );
+        let message = format!("Auto-committed dirty worktree at {}", short_hash);
+        let _ = crate::events::persist_and_emit_agent_transcript_event(
+            app,
+            task_id,
+            session_id,
+            db::EVENT_COMMAND_OUTPUT,
+            Some(&message),
+            Some(
+                &serde_json::json!({
+                    "source": "auto_commit",
+                    "command": "git commit",
+                    "commit": hash,
+                })
+                .to_string(),
+            ),
+        );
+    }
+    Ok(commit_hash)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -909,6 +1138,7 @@ fn spawn_task_input_completion_watcher(
     task_id: String,
     session_id: String,
     completion: TaskInputCompletion,
+    working_dir: String,
     pre_command_scrollback: String,
 ) {
     tokio::spawn(async move {
@@ -969,7 +1199,7 @@ fn spawn_task_input_completion_watcher(
         if let Some(handle) = semantic_flusher {
             handle.abort();
         }
-        let exit_code = if timed_out {
+        let mut exit_code = if timed_out {
             124
         } else {
             std::fs::read_to_string(&exit_path)
@@ -978,7 +1208,23 @@ fn spawn_task_input_completion_watcher(
                 .unwrap_or(1)
         };
         let _ = std::fs::remove_file(&exit_path);
-        let success = exit_code == 0;
+        let mut success = exit_code == 0;
+        let mut auto_commit_hash: Option<String> = None;
+        if success {
+            match auto_commit_completed_worktree(&app, &task_id, Some(&session_id), &working_dir) {
+                Ok(hash) => {
+                    auto_commit_hash = hash;
+                }
+                Err(err) => {
+                    eprintln!(
+                        "[agent] auto-commit FAILED for terminal task turn {}: {}",
+                        task_id, err
+                    );
+                    success = false;
+                    exit_code = 1;
+                }
+            }
+        }
         let final_semantic_emitted = completion
             .semantic_log_path
             .as_deref()
@@ -1020,6 +1266,7 @@ fn spawn_task_input_completion_watcher(
         let metadata = serde_json::json!({
             "exitCode": exit_code,
             "timedOut": timed_out,
+            "autoCommitHash": auto_commit_hash,
         })
         .to_string();
 
@@ -1277,6 +1524,7 @@ pub async fn kill_task_session(
 #[allow(clippy::too_many_arguments)]
 pub async fn switch_agent_transport(
     app: AppHandle,
+    state: State<'_, AppState>,
     session_registry: State<'_, SharedSessionRegistry>,
     task_id: String,
     transport_type: String,
@@ -1327,12 +1575,22 @@ pub async fn switch_agent_transport(
             }
         }
     } else if target_type == TransportType::Pty {
-        let cli = cli_path.unwrap_or_else(|| "claude".to_string());
+        let requested_working_dir = working_dir.as_deref().ok_or_else(|| {
+            AppError::InvalidInput(
+                "Working directory is required to start PTY transport".to_string(),
+            )
+        })?;
+        let (validated_working_dir, cli) = validate_task_launch_inputs(
+            &state,
+            &task_id,
+            requested_working_dir,
+            cli_path.as_deref(),
+        )?;
         let config = SessionConfig {
             cli_path: cli,
             model: "sonnet".to_string(),
             system_prompt: String::new(),
-            working_dir,
+            working_dir: Some(validated_working_dir),
             effort_level: None,
         };
 
@@ -1351,22 +1609,29 @@ pub async fn switch_agent_transport(
     Ok(())
 }
 
-/// Ensure a PTY session exists for a task. Spawns a bare shell if none exists.
+/// Ensure a PTY session exists for a task. Spawns a bare shell if none exists
+/// unless `allow_spawn` is false.
 ///
 /// Called by the terminal view on mount. Uses a single managed bridge per task:
 /// - Session alive + bridge alive → return scrollback (no new bridge)
 /// - Session alive + bridge dead → start new managed bridge
-/// - Session dead or missing → spawn fresh shell + managed bridge
+/// - Session dead or missing + allow_spawn=true → spawn fresh shell + managed bridge
+/// - Session dead or missing + allow_spawn=false → return cached/tmux scrollback only
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub async fn ensure_pty_session(
     app: AppHandle,
+    state: State<'_, AppState>,
     session_registry: State<'_, SharedSessionRegistry>,
     task_id: String,
     working_dir: String,
     cols: u16,
     rows: u16,
+    allow_spawn: Option<bool>,
 ) -> Result<AgentInfo, String> {
+    validate_task_exists(&state, &task_id).map_err(|e| e.to_string())?;
     let mut registry = session_registry.lock().await;
+    let allow_spawn = allow_spawn.unwrap_or(true);
 
     // Case 1: Session is alive
     let session_alive = registry
@@ -1418,12 +1683,43 @@ pub async fn ensure_pty_session(
         });
     }
 
-    // Case 2: Session dead or missing — spawn fresh
+    // Case 2: Session dead or missing, but caller only wants to attach.
+    // Clean up a dead registry entry so future attach-only views can restore
+    // the last cached terminal contents without reviving the task.
+    if !allow_spawn {
+        registry.remove(&task_id);
+        let cached_scrollback = registry.take_scrollback(&task_id);
+        let tmux_scrollback = capture_scrollback(&task_id);
+        let scrollback = if !tmux_scrollback.is_empty() {
+            tmux_scrollback
+        } else {
+            cached_scrollback
+        };
+
+        return Ok(AgentInfo {
+            task_id,
+            agent_type: "shell".to_string(),
+            status: "Missing".to_string(),
+            pid: None,
+            working_dir,
+            scrollback: if scrollback.is_empty() {
+                None
+            } else {
+                Some(scrollback)
+            },
+        });
+    }
+
+    // Case 3: Session dead or missing — spawn fresh
+    let (working_dir, _) =
+        validate_task_launch_inputs(&state, &task_id, &working_dir, Some("claude"))
+            .map_err(|e| e.to_string())?;
+
     // Remove dead session (caches scrollback + cancels old bridge)
     registry.remove(&task_id);
     let cached_scrollback = registry.take_scrollback(&task_id);
 
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let shell = default_user_shell();
     let config = SessionConfig {
         cli_path: shell,
         model: String::new(),
@@ -1702,6 +1998,26 @@ mod tests {
         assert_eq!(normalize_agent_runtime_mode(Some("managed")), "managed");
         assert_eq!(normalize_agent_runtime_mode(Some("terminal")), "terminal");
         assert_eq!(normalize_agent_runtime_mode(Some("surprise")), "terminal");
+    }
+
+    #[test]
+    fn validate_agent_cli_path_accepts_known_bare_binaries() {
+        assert_eq!(validate_agent_cli_path("claude").unwrap(), "claude");
+        assert_eq!(validate_agent_cli_path(" codex ").unwrap(), "codex");
+    }
+
+    #[test]
+    fn validate_agent_cli_path_rejects_unknown_bare_binary() {
+        let err = validate_agent_cli_path("sh").expect_err("unknown binary should fail");
+        assert!(err.to_string().contains("Unsupported agent CLI binary"));
+    }
+
+    #[test]
+    fn validate_agent_cli_path_rejects_non_file_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = validate_agent_cli_path(tmp.path().to_str().unwrap())
+            .expect_err("directory should fail");
+        assert!(err.to_string().contains("not an executable file"));
     }
 
     fn script_path_from_launcher(command: &str) -> String {

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -946,6 +946,16 @@ fn auto_commit_completed_worktree(
     session_id: Option<&str>,
     worktree_path: &str,
 ) -> Result<Option<String>, String> {
+    // SAFETY: only auto-commit when the path is an actual git worktree
+    // (where `.git` is a file containing `gitdir: …`), not the user's
+    // primary checkout. A task without worktree_path runs in the workspace
+    // repo root; staging+committing there would mix the user's WIP with
+    // agent output on whatever branch HEAD currently points at.
+    let git_marker = std::path::Path::new(worktree_path).join(".git");
+    if !git_marker.is_file() {
+        return Ok(None);
+    }
+
     if !crate::git::branch_manager::worktree_is_dirty(worktree_path)? {
         return Ok(None);
     }

--- a/src-tauri/src/commands/checklist.rs
+++ b/src-tauri/src/commands/checklist.rs
@@ -1,6 +1,7 @@
 use crate::db::{self, AppState, Checklist, ChecklistCategory, ChecklistItem};
 use crate::error::AppError;
 use serde::{Deserialize, Serialize};
+use std::path::{Component, Path, PathBuf};
 use tauri::State;
 
 /// Response containing the full checklist with categories and items
@@ -25,12 +26,76 @@ fn validate_detect_type(detect_type: Option<&str>) -> Result<(), AppError> {
     }
 }
 
-fn validate_detect_config(detect_config: Option<&str>) -> Result<(), AppError> {
+fn validate_detect_config(
+    detect_type: Option<&str>,
+    detect_config: Option<&str>,
+) -> Result<(), AppError> {
     if let Some(config) = detect_config {
-        serde_json::from_str::<serde_json::Value>(config)
+        let value = serde_json::from_str::<serde_json::Value>(config)
             .map_err(|e| AppError::InvalidInput(format!("Invalid detection config JSON: {}", e)))?;
+        if matches!(detect_type, Some("command-succeeds")) {
+            let command = value
+                .get("command")
+                .and_then(|command| command.as_str())
+                .map(str::trim)
+                .unwrap_or("");
+            if command.is_empty() {
+                return Err(AppError::InvalidInput(
+                    "command-succeeds detection requires a command".to_string(),
+                ));
+            }
+            if value
+                .get("allowUnsafeCommand")
+                .and_then(|enabled| enabled.as_bool())
+                != Some(true)
+            {
+                return Err(AppError::InvalidInput(
+                    "command-succeeds detection requires allowUnsafeCommand=true".to_string(),
+                ));
+            }
+        }
     }
     Ok(())
+}
+
+fn validate_detection_pattern(pattern: &str) -> Result<(), AppError> {
+    let path = Path::new(pattern);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)))
+    {
+        return Err(AppError::InvalidInput(format!(
+            "Checklist detection pattern must stay inside the workspace: {}",
+            pattern
+        )));
+    }
+    Ok(())
+}
+
+fn detection_glob_pattern(repo_root: &Path, pattern: &str) -> Result<String, AppError> {
+    validate_detection_pattern(pattern)?;
+    Ok(repo_root.join(pattern).to_string_lossy().to_string())
+}
+
+fn first_glob_match_inside(repo_root: &Path, full_pattern: &str) -> bool {
+    let Ok(paths) = glob::glob(full_pattern) else {
+        return false;
+    };
+    paths.filter_map(Result::ok).any(|path| {
+        path.canonicalize()
+            .map(|canonical| canonical.starts_with(repo_root))
+            .unwrap_or(false)
+    })
+}
+
+fn first_glob_file_inside(repo_root: &Path, full_pattern: &str) -> Option<PathBuf> {
+    let paths = glob::glob(full_pattern).ok()?;
+    paths.filter_map(Result::ok).find(|path| {
+        path.canonicalize()
+            .map(|canonical| canonical.starts_with(repo_root) && canonical.is_file())
+            .unwrap_or(false)
+    })
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -182,17 +247,21 @@ pub fn update_checklist_item(
             "Position must be non-negative".to_string(),
         ));
     }
-    if let Some(Some(ref value)) = updates.detect_type {
-        validate_detect_type(Some(value))?;
-    }
-    if let Some(Some(ref value)) = updates.detect_config {
-        validate_detect_config(Some(value))?;
-    }
-
     let conn = state
         .db
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    let current = db::get_checklist_item(&conn, &item_id)?;
+    let effective_detect_type = match updates.detect_type.as_ref() {
+        Some(value) => value.as_deref(),
+        None => current.detect_type.as_deref(),
+    };
+    let effective_detect_config = match updates.detect_config.as_ref() {
+        Some(value) => value.as_deref(),
+        None => current.detect_config.as_deref(),
+    };
+    validate_detect_type(effective_detect_type)?;
+    validate_detect_config(effective_detect_type, effective_detect_config)?;
 
     Ok(db::update_checklist_item_details(
         &conn,
@@ -338,7 +407,7 @@ pub fn create_checklist_item(
         ));
     }
     validate_detect_type(detect_type.as_deref())?;
-    validate_detect_config(detect_config.as_deref())?;
+    validate_detect_config(detect_type.as_deref(), detect_config.as_deref())?;
 
     let conn = state
         .db
@@ -419,6 +488,11 @@ pub fn create_workspace_checklist(
             for (item_idx, item) in cat.items.iter().enumerate() {
                 // Use create_checklist_item_with_detect if detection config is provided
                 if item.detect_type.is_some() || item.detect_config.is_some() {
+                    validate_detect_type(item.detect_type.as_deref())?;
+                    validate_detect_config(
+                        item.detect_type.as_deref(),
+                        item.detect_config.as_deref(),
+                    )?;
                     db::create_checklist_item_with_detect(
                         &conn,
                         &category.id,
@@ -530,17 +604,17 @@ pub struct DetectionResult {
 pub async fn run_checklist_detection(
     state: State<'_, AppState>,
     workspace_id: String,
-    repo_path: String,
+    _repo_path: String,
 ) -> Result<Vec<DetectionResult>, AppError> {
-    use glob::glob;
     use std::process::Command;
 
     // Get all checklist items with detection configured
-    let items = {
+    let (items, repo_path) = {
         let conn = state
             .db
             .lock()
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let workspace = db::get_workspace(&conn, &workspace_id)?;
 
         // Get the workspace's checklist
         let checklist = db::get_workspace_checklist(&conn, &workspace_id)?;
@@ -555,8 +629,11 @@ pub async fn run_checklist_detection(
             let items = db::list_checklist_items(&conn, &cat.id)?;
             all_items.extend(items);
         }
-        all_items
+        (all_items, workspace.repo_path)
     };
+    let repo_root = PathBuf::from(&repo_path)
+        .canonicalize()
+        .map_err(|e| AppError::InvalidInput(format!("Workspace repo path is invalid: {}", e)))?;
 
     // Filter to items with detection configured
     let detectable: Vec<_> = items
@@ -585,10 +662,8 @@ pub async fn run_checklist_detection(
                     .and_then(|p| p.as_str())
                     .unwrap_or("*");
 
-                let full_pattern = format!("{}/{}", repo_path, pattern);
-                let found = glob(&full_pattern)
-                    .map(|mut paths: glob::Paths| paths.next().is_some())
-                    .unwrap_or(false);
+                let full_pattern = detection_glob_pattern(&repo_root, pattern)?;
+                let found = first_glob_match_inside(&repo_root, &full_pattern);
 
                 (
                     found,
@@ -606,10 +681,8 @@ pub async fn run_checklist_detection(
                     .and_then(|p| p.as_str())
                     .unwrap_or("*");
 
-                let full_pattern = format!("{}/{}", repo_path, pattern);
-                let found = glob(&full_pattern)
-                    .map(|mut paths: glob::Paths| paths.next().is_some())
-                    .unwrap_or(false);
+                let full_pattern = detection_glob_pattern(&repo_root, pattern)?;
+                let found = first_glob_match_inside(&repo_root, &full_pattern);
 
                 (
                     !found,
@@ -633,11 +706,8 @@ pub async fn run_checklist_detection(
                     .unwrap_or("");
 
                 // Find first matching file and check content
-                let full_pattern = format!("{}/{}", repo_path, pattern);
-                let file_path = glob(&full_pattern)
-                    .ok()
-                    .and_then(|mut paths| paths.next())
-                    .and_then(|p| p.ok());
+                let full_pattern = detection_glob_pattern(&repo_root, pattern)?;
+                let file_path = first_glob_file_inside(&repo_root, &full_pattern);
 
                 let found = if let Some(path) = file_path {
                     std::fs::read_to_string(&path)
@@ -657,36 +727,52 @@ pub async fn run_checklist_detection(
                 )
             }
             "command-succeeds" => {
+                let allow_unsafe_command = detect_config
+                    .as_ref()
+                    .and_then(|c| c.get("allowUnsafeCommand"))
+                    .and_then(|p| p.as_bool())
+                    .unwrap_or(false);
                 let command = detect_config
                     .as_ref()
                     .and_then(|c| c.get("command"))
                     .and_then(|p| p.as_str())
-                    .unwrap_or("true");
+                    .unwrap_or("")
+                    .trim();
 
-                // Run command in a blocking thread
-                let repo_path_clone = repo_path.clone();
-                let command_clone = command.to_string();
-                let result = tokio::task::spawn_blocking(move || {
-                    Command::new("sh")
-                        .args(["-c", &command_clone])
-                        .current_dir(&repo_path_clone)
-                        .output()
-                })
-                .await;
+                if !allow_unsafe_command || command.is_empty() {
+                    (
+                        false,
+                        Some(
+                            "Command detection requires explicit allowUnsafeCommand=true"
+                                .to_string(),
+                        ),
+                    )
+                } else {
+                    // Run command in a blocking thread
+                    let repo_path_clone = repo_path.clone();
+                    let command_clone = command.to_string();
+                    let result = tokio::task::spawn_blocking(move || {
+                        Command::new("sh")
+                            .args(["-c", &command_clone])
+                            .current_dir(&repo_path_clone)
+                            .output()
+                    })
+                    .await;
 
-                match result {
-                    Ok(Ok(output)) => {
-                        let success = output.status.success();
-                        (
-                            success,
-                            if success {
-                                Some(format!("Command succeeded: {}", command))
-                            } else {
-                                Some(format!("Command failed: {}", command))
-                            },
-                        )
+                    match result {
+                        Ok(Ok(output)) => {
+                            let success = output.status.success();
+                            (
+                                success,
+                                if success {
+                                    Some(format!("Command succeeded: {}", command))
+                                } else {
+                                    Some(format!("Command failed: {}", command))
+                                },
+                            )
+                        }
+                        _ => (false, Some(format!("Command error: {}", command))),
                     }
-                    _ => (false, Some(format!("Command error: {}", command))),
                 }
             }
             _ => (false, Some("Unknown detection type".to_string())),
@@ -709,4 +795,58 @@ pub async fn run_checklist_detection(
     }
 
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        detection_glob_pattern, first_glob_match_inside, validate_detect_config,
+        validate_detection_pattern,
+    };
+
+    #[test]
+    fn detection_pattern_rejects_absolute_and_parent_paths() {
+        assert!(validate_detection_pattern("/etc/passwd").is_err());
+        assert!(validate_detection_pattern("../secret").is_err());
+        assert!(validate_detection_pattern("src/../../secret").is_err());
+    }
+
+    #[test]
+    fn detection_pattern_allows_relative_globs() {
+        assert!(validate_detection_pattern("src/**/*.rs").is_ok());
+        assert!(validate_detection_pattern("package.json").is_ok());
+    }
+
+    #[test]
+    fn detection_glob_only_counts_matches_inside_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+        std::fs::write(repo.join("src/lib.rs"), "test").unwrap();
+
+        let repo_root = repo.canonicalize().unwrap();
+        let pattern = detection_glob_pattern(&repo_root, "src/*.rs").unwrap();
+
+        assert!(first_glob_match_inside(&repo_root, &pattern));
+    }
+
+    #[test]
+    fn command_detection_config_requires_explicit_unsafe_opt_in() {
+        let err =
+            validate_detect_config(Some("command-succeeds"), Some(r#"{"command":"npm test"}"#))
+                .expect_err("command checks must be explicit");
+        assert!(err.to_string().contains("allowUnsafeCommand=true"));
+
+        validate_detect_config(
+            Some("command-succeeds"),
+            Some(r#"{"command":"npm test","allowUnsafeCommand":true}"#),
+        )
+        .expect("explicit command check should be allowed");
+    }
+
+    #[test]
+    fn non_command_detection_config_does_not_require_unsafe_opt_in() {
+        validate_detect_config(Some("file-exists"), Some(r#"{"pattern":"README.md"}"#))
+            .expect("file checks should not require command opt-in");
+    }
 }

--- a/src-tauri/src/commands/cli_detect.rs
+++ b/src-tauri/src/commands/cli_detect.rs
@@ -1,10 +1,11 @@
 //! CLI detection commands for finding installed AI coding assistants
 
 use serde::{Deserialize, Serialize};
+use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
 const CLI_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -14,17 +15,55 @@ fn command_output_with_timeout(
     args: &[&str],
     timeout: Duration,
 ) -> std::io::Result<Option<Output>> {
-    let mut child = Command::new(program).args(args).spawn()?;
-    let started = Instant::now();
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
 
+    // Drain stdout/stderr in dedicated threads so a child that writes more
+    // than the OS pipe buffer (~64 KiB) cannot block on write while we are
+    // polling try_wait(). Threads exit when the pipes close (on child exit
+    // or after we kill the child below).
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stdout_handle = stdout.map(|mut s| {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = s.read_to_end(&mut buf);
+            buf
+        })
+    });
+    let stderr_handle = stderr.map(|mut s| {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = s.read_to_end(&mut buf);
+            buf
+        })
+    });
+
+    let started = Instant::now();
     loop {
-        if child.try_wait()?.is_some() {
-            return child.wait_with_output().map(Some);
+        if let Some(status) = child.try_wait()? {
+            let stdout = stdout_handle
+                .and_then(|h| h.join().ok())
+                .unwrap_or_default();
+            let stderr = stderr_handle
+                .and_then(|h| h.join().ok())
+                .unwrap_or_default();
+            return Ok(Some(Output {
+                status,
+                stdout,
+                stderr,
+            }));
         }
 
         if started.elapsed() >= timeout {
             let _ = child.kill();
             let _ = child.wait();
+            let _ = stdout_handle.and_then(|h| h.join().ok());
+            let _ = stderr_handle.and_then(|h| h.join().ok());
             return Ok(None);
         }
 

--- a/src-tauri/src/commands/cli_detect.rs
+++ b/src-tauri/src/commands/cli_detect.rs
@@ -1,8 +1,36 @@
 //! CLI detection commands for finding installed AI coding assistants
 
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+const CLI_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+fn command_output_with_timeout(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> std::io::Result<Option<Output>> {
+    let mut child = Command::new(program).args(args).spawn()?;
+    let started = Instant::now();
+
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output().map(Some);
+        }
+
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(None);
+        }
+
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -45,7 +73,11 @@ fn get_search_paths() -> Vec<PathBuf> {
         // Standard PATH locations
         PathBuf::from("/usr/local/bin"),
         PathBuf::from("/usr/bin"),
+        PathBuf::from("/bin"),
         PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/snap/bin"),
+        PathBuf::from("/var/lib/flatpak/exports/bin"),
+        PathBuf::from(format!("{}/.local/share/flatpak/exports/bin", home)),
         // User-specific locations
         PathBuf::from(format!("{}/.local/bin", home)),
         PathBuf::from(format!("{}/bin", home)),
@@ -71,7 +103,7 @@ fn get_search_paths() -> Vec<PathBuf> {
 /// Try to find a CLI tool by name
 fn find_cli(name: &str) -> Option<String> {
     // First try `which` command
-    if let Ok(output) = Command::new("which").arg(name).output() {
+    if let Ok(Some(output)) = command_output_with_timeout("which", &[name], CLI_PROBE_TIMEOUT) {
         if output.status.success() {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !path.is_empty() && std::path::Path::new(&path).exists() {
@@ -93,7 +125,9 @@ fn find_cli(name: &str) -> Option<String> {
 
 /// Get version string from a CLI tool
 fn get_cli_version(path: &str, args: &[&str]) -> Option<String> {
-    let output = Command::new(path).args(args).output().ok()?;
+    let output = command_output_with_timeout(path, args, CLI_PROBE_TIMEOUT)
+        .ok()
+        .flatten()?;
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -255,8 +289,27 @@ pub fn get_cli_capabilities(cli_id: String) -> CliCapabilities {
 #[tauri::command]
 pub fn verify_cli_path(path: String) -> DetectedCli {
     let path_obj = std::path::Path::new(&path);
+    let binary_name = path_obj
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+    let (id, name) = match binary_name {
+        "claude" => ("claude", "Claude Code"),
+        "codex" => ("codex", "Codex CLI"),
+        _ => ("custom", "Custom CLI"),
+    };
 
-    if !path_obj.exists() {
+    if !path_obj.exists() || !path_obj.is_file() {
+        return DetectedCli {
+            id: id.to_string(),
+            name: name.to_string(),
+            path,
+            version: None,
+            is_available: false,
+        };
+    }
+
+    if !matches!(binary_name, "claude" | "codex") {
         return DetectedCli {
             id: "custom".to_string(),
             name: "Custom CLI".to_string(),
@@ -266,20 +319,34 @@ pub fn verify_cli_path(path: String) -> DetectedCli {
         };
     }
 
+    #[cfg(unix)]
+    {
+        let executable = path_obj
+            .metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false);
+        if !executable {
+            return DetectedCli {
+                id: id.to_string(),
+                name: name.to_string(),
+                path,
+                version: None,
+                is_available: false,
+            };
+        }
+    }
+
     // Try to get version
     let version = get_cli_version(&path, &["--version"]);
-
-    // Try to determine which CLI it is based on the binary name
-    let binary_name = path_obj
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown");
-
-    let (id, name) = match binary_name {
-        "claude" => ("claude", "Claude Code"),
-        "codex" => ("codex", "Codex CLI"),
-        _ => ("custom", "Custom CLI"),
-    };
+    if version.is_none() {
+        return DetectedCli {
+            id: id.to_string(),
+            name: name.to_string(),
+            path,
+            version: None,
+            is_available: false,
+        };
+    }
 
     DetectedCli {
         id: id.to_string(),
@@ -287,6 +354,57 @@ pub fn verify_cli_path(path: String) -> DetectedCli {
         path,
         version,
         is_available: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn verify_cli_path_rejects_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let detected = verify_cli_path(temp.path().to_string_lossy().to_string());
+        assert!(!detected.is_available);
+    }
+
+    #[test]
+    fn verify_cli_path_rejects_non_executable_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("claude");
+        fs::write(&path, "#!/bin/sh\necho claude").unwrap();
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&path).unwrap().permissions();
+            permissions.set_mode(0o644);
+            fs::set_permissions(&path, permissions).unwrap();
+        }
+
+        let detected = verify_cli_path(path.to_string_lossy().to_string());
+        assert!(!detected.is_available);
+    }
+
+    #[test]
+    fn verify_cli_path_rejects_unknown_executable_without_running_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("not-an-agent");
+        let marker = temp.path().join("marker");
+        fs::write(
+            &path,
+            format!("#!/bin/sh\ntouch {}\necho nope\n", marker.display()),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&path, permissions).unwrap();
+        }
+
+        let detected = verify_cli_path(path.to_string_lossy().to_string());
+        assert!(!detected.is_available);
+        assert!(!marker.exists());
     }
 }
 
@@ -314,13 +432,17 @@ pub async fn check_cli_update(cli_id: String) -> Result<CliUpdateInfo, String> {
     let path = find_cli(binary).ok_or_else(|| format!("{} CLI not found", binary))?;
 
     // Get current version — run async to handle paths with spaces
-    let version_output = tokio::process::Command::new(&path)
-        .arg("--version")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .await
-        .ok();
+    let version_output = tokio::time::timeout(
+        CLI_PROBE_TIMEOUT,
+        tokio::process::Command::new(&path)
+            .arg("--version")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    .ok()
+    .and_then(Result::ok);
 
     let current_version = version_output
         .and_then(|o| {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,8 +1,12 @@
+use crate::db::{self, AppState};
 use crate::error::AppError;
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::UNIX_EPOCH;
+use tauri::{AppHandle, State};
+use tauri_plugin_dialog::DialogExt;
 
 /// File entry returned to the frontend
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -14,146 +18,117 @@ pub struct FileEntry {
     pub modified_at: i64,
 }
 
+/// Dialog-selected attachment data returned to the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentFile {
+    pub path: String,
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
 /// File categories for grouping
 const CATEGORY_CONTEXT: &str = "context";
 const CATEGORY_TICKETS: &str = "tickets";
 const CATEGORY_NOTES: &str = "notes";
+const MAX_ATTACHMENT_BYTES: u64 = 500 * 1024 * 1024;
+const SUPPORTED_ATTACHMENT_EXTENSIONS: &[&str] = &[
+    "png", "jpg", "jpeg", "gif", "webp", "pdf", "txt", "md", "csv", "html", "css", "js", "jsx",
+    "ts", "tsx", "json", "xml", "yaml", "yml", "toml", "env", "sh", "bash", "py", "rb", "go", "rs",
+    "c", "cpp", "h", "hpp", "java", "swift", "kt", "scala", "sql", "graphql", "prisma",
+];
 
-/// Recursively scan a directory for markdown files
-fn scan_dir_for_md(dir: &Path, files: &mut Vec<FileEntry>, category: &str) {
-    if let Ok(entries) = fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                scan_dir_for_md(&path, files, category);
-            } else if let Some(ext) = path.extension() {
-                if ext == "md" {
-                    let modified_at = entry
-                        .metadata()
-                        .ok()
-                        .and_then(|m| m.modified().ok())
-                        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                        .map(|d| d.as_secs() as i64)
-                        .unwrap_or(0);
-
-                    let name = path
-                        .file_name()
-                        .map(|s| s.to_string_lossy().to_string())
-                        .unwrap_or_default();
-
-                    files.push(FileEntry {
-                        path: path.to_string_lossy().to_string(),
-                        name,
-                        category: category.to_string(),
-                        modified_at,
-                    });
-                }
-            }
-        }
-    }
-}
-
-/// Scan workspace for relevant markdown files
-/// Scans: *.md in root, .context/**/*.md, .tickets/**/*.md
-#[tauri::command]
-pub fn scan_workspace_files(repo_path: String) -> Result<Vec<FileEntry>, AppError> {
-    let root = PathBuf::from(&repo_path);
+fn canonical_workspace_root(repo_path: &str) -> Result<PathBuf, AppError> {
+    let root = PathBuf::from(repo_path);
     if !root.exists() {
         return Err(AppError::InvalidInput(format!(
             "Repository path does not exist: {}",
             repo_path
         )));
     }
-
-    let mut files: Vec<FileEntry> = Vec::new();
-
-    // Scan root for *.md files (notes category)
-    if let Ok(entries) = fs::read_dir(&root) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_file() {
-                if let Some(ext) = path.extension() {
-                    if ext == "md" {
-                        let modified_at = entry
-                            .metadata()
-                            .ok()
-                            .and_then(|m| m.modified().ok())
-                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                            .map(|d| d.as_secs() as i64)
-                            .unwrap_or(0);
-
-                        let name = path
-                            .file_name()
-                            .map(|s| s.to_string_lossy().to_string())
-                            .unwrap_or_default();
-
-                        files.push(FileEntry {
-                            path: path.to_string_lossy().to_string(),
-                            name,
-                            category: CATEGORY_NOTES.to_string(),
-                            modified_at,
-                        });
-                    }
-                }
-            }
-        }
+    if !root.is_dir() {
+        return Err(AppError::InvalidInput(format!(
+            "Repository path is not a directory: {}",
+            repo_path
+        )));
     }
 
-    // Scan .context directory
-    let context_dir = root.join(".context");
-    if context_dir.exists() && context_dir.is_dir() {
-        scan_dir_for_md(&context_dir, &mut files, CATEGORY_CONTEXT);
-    }
-
-    // Scan .tickets directory
-    let tickets_dir = root.join(".tickets");
-    if tickets_dir.exists() && tickets_dir.is_dir() {
-        scan_dir_for_md(&tickets_dir, &mut files, CATEGORY_TICKETS);
-    }
-
-    // Sort by modified_at descending (most recent first)
-    files.sort_by_key(|f| std::cmp::Reverse(f.modified_at));
-
-    Ok(files)
+    root.canonicalize()
+        .map_err(|e| AppError::InvalidInput(format!("Failed to resolve repository path: {}", e)))
 }
 
-/// Read content of a file
-#[tauri::command]
-pub fn read_file_content(file_path: String) -> Result<String, AppError> {
-    let path = PathBuf::from(&file_path);
+fn canonical_registered_workspace_root(
+    conn: &Connection,
+    workspace_id: &str,
+) -> Result<PathBuf, AppError> {
+    let workspace = db::get_workspace(conn, workspace_id)?;
+    canonical_workspace_root(&workspace.repo_path)
+}
+
+fn state_workspace_root(state: State<AppState>, workspace_id: &str) -> Result<PathBuf, AppError> {
+    let conn = state
+        .db
+        .lock()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    canonical_registered_workspace_root(&conn, workspace_id)
+}
+
+fn ensure_relative_workspace_path(file_path: &str) -> Result<PathBuf, AppError> {
+    let path = PathBuf::from(file_path);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)))
+    {
+        return Err(AppError::InvalidInput(
+            "File path must be relative to the selected workspace".to_string(),
+        ));
+    }
+    Ok(path)
+}
+
+fn ensure_path_in_workspace(root: &Path, path: &Path) -> Result<PathBuf, AppError> {
+    let canonical_path = path
+        .canonicalize()
+        .map_err(|e| AppError::InvalidInput(format!("Failed to resolve file path: {}", e)))?;
+
+    if !canonical_path.starts_with(root) {
+        return Err(AppError::InvalidInput(
+            "File is outside the selected workspace".to_string(),
+        ));
+    }
+
+    Ok(canonical_path)
+}
+
+fn read_file_content_in_root(root: &Path, file_path: &str) -> Result<String, AppError> {
+    let relative = ensure_relative_workspace_path(file_path)?;
+    let path = root.join(relative);
     if !path.exists() {
         return Err(AppError::InvalidInput(format!(
             "File does not exist: {}",
             file_path
         )));
     }
+    if !path.is_file() {
+        return Err(AppError::InvalidInput(format!(
+            "Path is not a file: {}",
+            file_path
+        )));
+    }
+
+    let path = ensure_path_in_workspace(root, &path)?;
 
     fs::read_to_string(&path)
         .map_err(|e| AppError::InvalidInput(format!("Failed to read file: {}", e)))
 }
 
-/// Create a new markdown note file
-#[tauri::command]
-pub fn create_note_file(
-    repo_path: String,
-    filename: String,
-    content: String,
+fn create_note_file_in_root(
+    root: &Path,
+    filename: &str,
+    content: &str,
 ) -> Result<FileEntry, AppError> {
-    let root = PathBuf::from(&repo_path);
-    if !root.exists() {
-        return Err(AppError::InvalidInput(format!(
-            "Repository path does not exist: {}",
-            repo_path
-        )));
-    }
-
-    // Ensure filename ends with .md
-    let filename = if filename.ends_with(".md") {
-        filename
-    } else {
-        format!("{}.md", filename)
-    };
-
+    let filename = validate_note_filename(filename)?;
     let file_path = root.join(&filename);
 
     // Don't overwrite existing files
@@ -164,7 +139,7 @@ pub fn create_note_file(
         )));
     }
 
-    fs::write(&file_path, &content)
+    fs::write(&file_path, content)
         .map_err(|e| AppError::InvalidInput(format!("Failed to create file: {}", e)))?;
 
     let modified_at = file_path
@@ -176,9 +151,279 @@ pub fn create_note_file(
         .unwrap_or(0);
 
     Ok(FileEntry {
-        path: file_path.to_string_lossy().to_string(),
+        path: filename.clone(),
         name: filename,
         category: CATEGORY_NOTES.to_string(),
         modified_at,
     })
+}
+
+fn file_entry(root: &Path, path: &Path, category: &str) -> Option<FileEntry> {
+    let modified_at = path
+        .metadata()
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let relative = path.strip_prefix(root).ok()?.to_string_lossy().to_string();
+
+    Some(FileEntry {
+        path: relative,
+        name,
+        category: category.to_string(),
+        modified_at,
+    })
+}
+
+fn validate_note_filename(filename: &str) -> Result<String, AppError> {
+    let trimmed = filename.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput("Filename is required".to_string()));
+    }
+
+    let normalized = if trimmed.ends_with(".md") {
+        trimmed.to_string()
+    } else {
+        format!("{}.md", trimmed)
+    };
+
+    let path = Path::new(&normalized);
+    if path.is_absolute()
+        || path.components().count() != 1
+        || normalized == ".md"
+        || normalized.contains(std::path::MAIN_SEPARATOR)
+        || normalized.contains('/')
+        || normalized.contains('\\')
+    {
+        return Err(AppError::InvalidInput(
+            "Filename must be a markdown file name, not a path".to_string(),
+        ));
+    }
+
+    Ok(normalized)
+}
+
+fn validate_attachment_path(path: &Path) -> Result<(), AppError> {
+    if !path.exists() {
+        return Err(AppError::InvalidInput(format!(
+            "File does not exist: {}",
+            path.display()
+        )));
+    }
+    if !path.is_file() {
+        return Err(AppError::InvalidInput(format!(
+            "Path is not a file: {}",
+            path.display()
+        )));
+    }
+
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| AppError::InvalidInput("Unsupported file type".to_string()))?;
+
+    if !SUPPORTED_ATTACHMENT_EXTENSIONS.contains(&extension.as_str()) {
+        return Err(AppError::InvalidInput(format!(
+            "Unsupported file type: .{}",
+            extension
+        )));
+    }
+
+    let size = path
+        .metadata()
+        .map_err(|e| AppError::InvalidInput(format!("Failed to inspect file: {}", e)))?
+        .len();
+    if size > MAX_ATTACHMENT_BYTES {
+        return Err(AppError::InvalidInput(format!(
+            "File is too large: {} bytes",
+            size
+        )));
+    }
+
+    Ok(())
+}
+
+fn read_attachment_path(path: &Path) -> Result<AttachmentFile, AppError> {
+    validate_attachment_path(path)?;
+    let bytes = fs::read(path)
+        .map_err(|e| AppError::InvalidInput(format!("Failed to read file: {}", e)))?;
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned());
+
+    Ok(AttachmentFile {
+        path: path.to_string_lossy().into_owned(),
+        name,
+        bytes,
+    })
+}
+
+/// Recursively scan a directory for markdown files
+fn scan_dir_for_md(root: &Path, dir: &Path, files: &mut Vec<FileEntry>, category: &str) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                scan_dir_for_md(root, &path, files, category);
+            } else if let Some(ext) = path.extension() {
+                if ext == "md" {
+                    if let Some(entry) = file_entry(root, &path, category) {
+                        files.push(entry);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Scan workspace for relevant markdown files
+/// Scans: *.md in root, .context/**/*.md, .tickets/**/*.md
+#[tauri::command]
+pub fn scan_workspace_files(
+    state: State<AppState>,
+    workspace_id: String,
+) -> Result<Vec<FileEntry>, AppError> {
+    let root = state_workspace_root(state, &workspace_id)?;
+
+    let mut files: Vec<FileEntry> = Vec::new();
+
+    // Scan root for *.md files (notes category)
+    if let Ok(entries) = fs::read_dir(&root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                if let Some(ext) = path.extension() {
+                    if ext == "md" {
+                        if let Some(entry) = file_entry(&root, &path, CATEGORY_NOTES) {
+                            files.push(entry);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Scan .context directory
+    let context_dir = root.join(".context");
+    if context_dir.exists() && context_dir.is_dir() {
+        scan_dir_for_md(&root, &context_dir, &mut files, CATEGORY_CONTEXT);
+    }
+
+    // Scan .tickets directory
+    let tickets_dir = root.join(".tickets");
+    if tickets_dir.exists() && tickets_dir.is_dir() {
+        scan_dir_for_md(&root, &tickets_dir, &mut files, CATEGORY_TICKETS);
+    }
+
+    // Sort by modified_at descending (most recent first)
+    files.sort_by_key(|f| std::cmp::Reverse(f.modified_at));
+
+    Ok(files)
+}
+
+/// Read content of a file
+#[tauri::command]
+pub fn read_file_content(
+    state: State<AppState>,
+    workspace_id: String,
+    file_path: String,
+) -> Result<String, AppError> {
+    let root = state_workspace_root(state, &workspace_id)?;
+    read_file_content_in_root(&root, &file_path)
+}
+
+/// Open the native file picker and read the selected attachment files.
+#[tauri::command]
+pub async fn pick_attachment_files(app: AppHandle) -> Result<Vec<AttachmentFile>, AppError> {
+    let selected = app
+        .dialog()
+        .file()
+        .add_filter("Supported Files", SUPPORTED_ATTACHMENT_EXTENSIONS)
+        .blocking_pick_files();
+
+    let Some(selected) = selected else {
+        return Ok(Vec::new());
+    };
+
+    selected
+        .into_iter()
+        .map(|file_path| {
+            let path = file_path.into_path().map_err(|e| {
+                AppError::InvalidInput(format!("Failed to resolve selected file path: {}", e))
+            })?;
+            read_attachment_path(&path)
+        })
+        .collect()
+}
+
+/// Create a new markdown note file
+#[tauri::command]
+pub fn create_note_file(
+    state: State<AppState>,
+    workspace_id: String,
+    filename: String,
+    content: String,
+) -> Result<FileEntry, AppError> {
+    let root = state_workspace_root(state, &workspace_id)?;
+    create_note_file_in_root(&root, &filename, &content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_file_content_rejects_paths_outside_workspace() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        fs::create_dir(&repo).unwrap();
+        let outside = temp.path().join("outside.md");
+        fs::write(&outside, "secret").unwrap();
+
+        let err = read_file_content_in_root(&repo, outside.to_str().unwrap()).unwrap_err();
+
+        assert!(err.to_string().contains("relative"));
+    }
+
+    #[test]
+    fn create_note_file_rejects_path_traversal_filename() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        fs::create_dir(&repo).unwrap();
+
+        let err = create_note_file_in_root(&repo, "../escape", "content").unwrap_err();
+
+        assert!(err.to_string().contains("not a path"));
+        assert!(!temp.path().join("escape.md").exists());
+    }
+
+    #[test]
+    fn create_note_file_creates_markdown_in_workspace_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        fs::create_dir(&repo).unwrap();
+
+        let created = create_note_file_in_root(&repo, "notes", "hello").unwrap();
+
+        assert_eq!(created.name, "notes.md");
+        assert_eq!(fs::read_to_string(repo.join("notes.md")).unwrap(), "hello");
+    }
+
+    #[test]
+    fn read_attachment_path_rejects_unsupported_extensions() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("secret.key");
+        fs::write(&path, "secret").unwrap();
+
+        let err = read_attachment_path(&path).unwrap_err();
+
+        assert!(err.to_string().contains("Unsupported file type"));
+    }
 }

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,11 +1,80 @@
+use crate::db::{self, AppState};
 use crate::git::{branch_manager, change_tracker, conflict_detector};
+use git2::Repository;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use tauri::State;
+
+fn canonical_git_dir(repo_path: &str) -> Result<PathBuf, String> {
+    let path = Path::new(repo_path.trim());
+    if repo_path.trim().is_empty() {
+        return Err("Repository path cannot be empty".to_string());
+    }
+    if !path.exists() {
+        return Err(format!("Repository path does not exist: {}", repo_path));
+    }
+    if !path.is_dir() {
+        return Err(format!("Repository path is not a directory: {}", repo_path));
+    }
+    Repository::discover(path).map_err(|_| {
+        format!(
+            "Repository path is not inside a git repository: {}",
+            repo_path
+        )
+    })?;
+    path.canonicalize()
+        .map_err(|e| format!("Failed to canonicalize repository path: {}", e))
+}
+
+fn collect_allowed_repo_roots(conn: &Connection) -> Result<Vec<PathBuf>, String> {
+    let mut roots = Vec::new();
+    let workspaces = db::list_workspaces(conn).map_err(|e| e.to_string())?;
+    for workspace in workspaces {
+        if let Ok(path) = canonical_git_dir(&workspace.repo_path) {
+            roots.push(path);
+        }
+        let tasks = db::list_tasks(conn, &workspace.id).map_err(|e| e.to_string())?;
+        for task in tasks {
+            if let Some(worktree_path) = task.worktree_path.as_deref() {
+                if let Ok(path) = canonical_git_dir(worktree_path) {
+                    roots.push(path);
+                }
+            }
+        }
+    }
+    Ok(roots)
+}
+
+fn repo_path_is_allowed(candidate: &Path, allowed_roots: &[PathBuf]) -> bool {
+    allowed_roots.iter().any(|root| candidate == root)
+}
+
+fn registered_repo_path(state: &State<'_, AppState>, repo_path: String) -> Result<String, String> {
+    let candidate = canonical_git_dir(&repo_path)?;
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    let allowed_roots = collect_allowed_repo_roots(&conn)?;
+    if repo_path_is_allowed(&candidate, &allowed_roots) {
+        return Ok(candidate.to_string_lossy().to_string());
+    }
+
+    Err(format!(
+        "Repository path is not a registered workspace or task worktree: {}",
+        repo_path
+    ))
+}
+
+fn validated_git_repo_path(repo_path: String) -> Result<String, String> {
+    canonical_git_dir(&repo_path).map(|path| path.to_string_lossy().to_string())
+}
 
 #[tauri::command]
 pub async fn create_task_branch(
+    state: State<'_, AppState>,
     repo_path: String,
     task_slug: String,
     base_branch: Option<String>,
 ) -> Result<String, String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
     tokio::task::spawn_blocking(move || {
         branch_manager::create_task_branch(&repo_path, &task_slug, base_branch.as_deref())
     })
@@ -14,7 +83,12 @@ pub async fn create_task_branch(
 }
 
 #[tauri::command]
-pub async fn switch_branch(repo_path: String, branch: String) -> Result<(), String> {
+pub async fn switch_branch(
+    state: State<'_, AppState>,
+    repo_path: String,
+    branch: String,
+) -> Result<(), String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
     tokio::task::spawn_blocking(move || branch_manager::switch_branch(&repo_path, &branch))
         .await
         .map_err(|e| e.to_string())?
@@ -22,6 +96,7 @@ pub async fn switch_branch(repo_path: String, branch: String) -> Result<(), Stri
 
 #[tauri::command]
 pub async fn get_current_branch(repo_path: String) -> Result<String, String> {
+    let repo_path = validated_git_repo_path(repo_path)?;
     tokio::task::spawn_blocking(move || branch_manager::get_current_branch(&repo_path))
         .await
         .map_err(|e| e.to_string())?
@@ -29,15 +104,22 @@ pub async fn get_current_branch(repo_path: String) -> Result<String, String> {
 
 #[tauri::command]
 pub async fn list_task_branches(
+    state: State<'_, AppState>,
     repo_path: String,
 ) -> Result<Vec<branch_manager::BranchInfo>, String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
     tokio::task::spawn_blocking(move || branch_manager::list_task_branches(&repo_path))
         .await
         .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub async fn delete_task_branch(repo_path: String, branch: String) -> Result<bool, String> {
+pub async fn delete_task_branch(
+    state: State<'_, AppState>,
+    repo_path: String,
+    branch: String,
+) -> Result<bool, String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
     tokio::task::spawn_blocking(move || branch_manager::delete_task_branch(&repo_path, &branch))
         .await
         .map_err(|e| e.to_string())?
@@ -45,22 +127,64 @@ pub async fn delete_task_branch(repo_path: String, branch: String) -> Result<boo
 
 #[tauri::command]
 pub async fn get_changes(
+    state: State<'_, AppState>,
     repo_path: String,
     branch: String,
+    base_branch: Option<String>,
 ) -> Result<change_tracker::ChangeSummary, String> {
-    tokio::task::spawn_blocking(move || change_tracker::get_changes(&repo_path, &branch))
-        .await
-        .map_err(|e| e.to_string())?
+    let repo_path = registered_repo_path(&state, repo_path)?;
+    tokio::task::spawn_blocking(move || {
+        change_tracker::get_changes(&repo_path, &branch, base_branch.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
 pub async fn get_diff(
+    state: State<'_, AppState>,
     repo_path: String,
     branch: String,
+    base_branch: Option<String>,
     file_path: Option<String>,
 ) -> Result<String, String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
     tokio::task::spawn_blocking(move || {
-        change_tracker::get_diff(&repo_path, &branch, file_path.as_deref())
+        change_tracker::get_diff(
+            &repo_path,
+            &branch,
+            base_branch.as_deref(),
+            file_path.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_commit_changes(
+    state: State<'_, AppState>,
+    repo_path: String,
+    commit_hash: String,
+) -> Result<change_tracker::ChangeSummary, String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
+    tokio::task::spawn_blocking(move || {
+        change_tracker::get_commit_changes(&repo_path, &commit_hash)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_commit_diff(
+    state: State<'_, AppState>,
+    repo_path: String,
+    commit_hash: String,
+    file_path: Option<String>,
+) -> Result<String, String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
+    tokio::task::spawn_blocking(move || {
+        change_tracker::get_commit_diff_text(&repo_path, &commit_hash, file_path.as_deref())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -68,19 +192,67 @@ pub async fn get_diff(
 
 #[tauri::command]
 pub async fn get_conflict_matrix(
+    state: State<'_, AppState>,
     repo_path: String,
+    base_branch: Option<String>,
 ) -> Result<conflict_detector::ConflictMatrix, String> {
-    tokio::task::spawn_blocking(move || conflict_detector::get_conflict_matrix(&repo_path))
-        .await
-        .map_err(|e| e.to_string())?
+    let repo_path = registered_repo_path(&state, repo_path)?;
+    tokio::task::spawn_blocking(move || {
+        conflict_detector::get_conflict_matrix(&repo_path, base_branch.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
 pub async fn get_commits(
+    state: State<'_, AppState>,
     repo_path: String,
     branch: String,
+    base_branch: Option<String>,
 ) -> Result<Vec<change_tracker::CommitInfo>, String> {
-    tokio::task::spawn_blocking(move || change_tracker::get_commits(&repo_path, &branch))
+    let repo_path = registered_repo_path(&state, repo_path)?;
+    tokio::task::spawn_blocking(move || {
+        change_tracker::get_commits(&repo_path, &branch, base_branch.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_commit_info(
+    state: State<'_, AppState>,
+    repo_path: String,
+    commit_hash: String,
+) -> Result<change_tracker::CommitInfo, String> {
+    let repo_path = registered_repo_path(&state, repo_path)?;
+    tokio::task::spawn_blocking(move || change_tracker::get_commit_info(&repo_path, &commit_hash))
         .await
         .map_err(|e| e.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::repo_path_is_allowed;
+    use std::path::PathBuf;
+
+    #[test]
+    fn repo_path_is_allowed_requires_exact_registered_root() {
+        let root = PathBuf::from("/tmp/workspace");
+        let child = root.join("nested");
+
+        assert!(repo_path_is_allowed(&root, std::slice::from_ref(&root)));
+        assert!(!repo_path_is_allowed(&child, &[root]));
+    }
+
+    #[test]
+    fn repo_path_is_allowed_accepts_registered_worktree_root() {
+        let workspace = PathBuf::from("/tmp/workspace");
+        let worktree = PathBuf::from("/tmp/workspace/.worktrees/task-1");
+
+        assert!(repo_path_is_allowed(
+            &worktree,
+            &[workspace, worktree.clone()]
+        ));
+    }
 }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -30,14 +30,16 @@ pub struct PrStatusResponse {
 pub async fn fetch_pr_status(
     state: State<'_, AppState>,
     task_id: String,
-    repo_path: String,
+    _repo_path: String,
 ) -> Result<PrStatusResponse, AppError> {
-    let task = {
+    let (task, repo_path) = {
         let conn = state
             .db
             .lock()
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-        db::get_task(&conn, &task_id)?
+        let task = db::get_task(&conn, &task_id)?;
+        let workspace = db::get_workspace(&conn, &task.workspace_id)?;
+        (task, workspace.repo_path)
     };
 
     let pr_number = task

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod pipeline;
 pub mod pipeline_template;
 pub mod script;
 pub mod siege;
+pub mod system;
 pub mod task;
 pub mod terminal;
 pub mod updater;
@@ -27,8 +28,3 @@ pub mod workspace;
 
 // Re-export models commands (they live in models module, not commands)
 pub use crate::models;
-
-#[tauri::command]
-pub fn greet(name: &str) -> String {
-    format!("Hello, {}! Welcome to KaitenCode.", name)
-}

--- a/src-tauri/src/commands/orchestrator/stream.rs
+++ b/src-tauri/src/commands/orchestrator/stream.rs
@@ -99,6 +99,7 @@ pub(super) async fn stream_orchestrator_chat(
             let cli = cli_path
                 .clone()
                 .unwrap_or_else(|| DEFAULT_CLI_PATH.to_string());
+            let cli = crate::commands::agent::validate_agent_cli_path(&cli)?;
             stream_via_unified_cli(
                 app.clone(),
                 state.clone(),

--- a/src-tauri/src/commands/siege.rs
+++ b/src-tauri/src/commands/siege.rs
@@ -73,6 +73,20 @@ pub struct SiegeEvent {
 
 // ─── GitHub CLI Helpers ─────────────────────────────────────────────────────
 
+fn validate_siege_cli_path(cli_path: Option<String>) -> Result<String, String> {
+    let cli =
+        crate::commands::agent::validate_agent_cli_path(cli_path.as_deref().unwrap_or("claude"))
+            .map_err(|e| e.to_string())?;
+    let binary_name = cli.rsplit('/').next().unwrap_or(&cli);
+    if binary_name != "claude" {
+        return Err(format!(
+            "Siege loop requires Claude CLI, got {}",
+            binary_name
+        ));
+    }
+    Ok(cli)
+}
+
 /// Fetch PR status and comments using gh CLI
 fn fetch_pr_status(repo_path: &str, pr_number: i64) -> Result<PrStatus, AppError> {
     // Get PR state and review decision
@@ -309,7 +323,7 @@ pub async fn start_siege(
     let prompt = build_comment_prompt(&pr_status);
 
     // Spawn agent via SessionRegistry with PTY transport
-    let cli = cli_path.unwrap_or_else(|| "claude".to_string());
+    let cli = validate_siege_cli_path(cli_path)?;
     let pid = {
         let mut registry = session_registry.lock().await;
 
@@ -560,7 +574,7 @@ pub async fn continue_siege(
     let prompt = build_comment_prompt(&check_result.pr_status);
 
     // Spawn agent via SessionRegistry
-    let cli = cli_path.unwrap_or_else(|| "claude".to_string());
+    let cli = validate_siege_cli_path(cli_path)?;
     let pid = {
         let mut registry = session_registry.lock().await;
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-use std::process::{Command, Output};
+use std::io::Read;
+use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
 const PREREQUISITE_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -29,17 +30,53 @@ fn command_output_with_timeout(
     version_args: &[&str],
     timeout: Duration,
 ) -> std::io::Result<Option<Output>> {
-    let mut child = Command::new(binary).args(version_args).spawn()?;
-    let started = Instant::now();
+    let mut child = Command::new(binary)
+        .args(version_args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
 
+    // Drain pipes in threads so the child cannot block on write while we
+    // poll try_wait(); threads exit when the pipes close.
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stdout_handle = stdout.map(|mut s| {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = s.read_to_end(&mut buf);
+            buf
+        })
+    });
+    let stderr_handle = stderr.map(|mut s| {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = s.read_to_end(&mut buf);
+            buf
+        })
+    });
+
+    let started = Instant::now();
     loop {
-        if child.try_wait()?.is_some() {
-            return child.wait_with_output().map(Some);
+        if let Some(status) = child.try_wait()? {
+            let stdout = stdout_handle
+                .and_then(|h| h.join().ok())
+                .unwrap_or_default();
+            let stderr = stderr_handle
+                .and_then(|h| h.join().ok())
+                .unwrap_or_default();
+            return Ok(Some(Output {
+                status,
+                stdout,
+                stderr,
+            }));
         }
 
         if started.elapsed() >= timeout {
             let _ = child.kill();
             let _ = child.wait();
+            let _ = stdout_handle.and_then(|h| h.join().ok());
+            let _ = stderr_handle.and_then(|h| h.join().ok());
             return Ok(None);
         }
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,0 +1,124 @@
+use serde::{Deserialize, Serialize};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+const PREREQUISITE_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimePrerequisite {
+    pub id: String,
+    pub name: String,
+    pub required: bool,
+    pub available: bool,
+    pub version: Option<String>,
+    pub install_hint: String,
+}
+
+fn first_line(output: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(output)
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn command_output_with_timeout(
+    binary: &str,
+    version_args: &[&str],
+    timeout: Duration,
+) -> std::io::Result<Option<Output>> {
+    let mut child = Command::new(binary).args(version_args).spawn()?;
+    let started = Instant::now();
+
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output().map(Some);
+        }
+
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(None);
+        }
+
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn check_tool(
+    id: &str,
+    name: &str,
+    required: bool,
+    binary: &str,
+    version_args: &[&str],
+    install_hint: &str,
+) -> RuntimePrerequisite {
+    let output = command_output_with_timeout(binary, version_args, PREREQUISITE_PROBE_TIMEOUT);
+    let (available, version) = match output {
+        Ok(Some(output)) if output.status.success() => {
+            let version = first_line(&output.stdout).or_else(|| first_line(&output.stderr));
+            (true, version)
+        }
+        _ => (false, None),
+    };
+
+    RuntimePrerequisite {
+        id: id.to_string(),
+        name: name.to_string(),
+        required,
+        available,
+        version,
+        install_hint: install_hint.to_string(),
+    }
+}
+
+#[tauri::command]
+pub fn check_runtime_prerequisites() -> Vec<RuntimePrerequisite> {
+    vec![
+        check_tool(
+            "git",
+            "Git",
+            true,
+            "git",
+            &["--version"],
+            "Install Git from https://git-scm.com/downloads or your OS package manager.",
+        ),
+        check_tool(
+            "tmux",
+            "tmux",
+            true,
+            "tmux",
+            &["-V"],
+            "Install tmux with Homebrew on macOS (`brew install tmux`) or your Linux package manager.",
+        ),
+        check_tool(
+            "gh",
+            "GitHub CLI",
+            false,
+            "gh",
+            &["--version"],
+            "Install GitHub CLI from https://cli.github.com/ for PR automation.",
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_prerequisites_include_required_tools() {
+        let checks = check_runtime_prerequisites();
+        assert!(checks
+            .iter()
+            .any(|check| check.id == "git" && check.required));
+        assert!(checks
+            .iter()
+            .any(|check| check.id == "tmux" && check.required));
+        assert!(checks
+            .iter()
+            .any(|check| check.id == "gh" && !check.required));
+    }
+}

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -910,16 +910,18 @@ pub struct CreatePrResult {
 pub async fn create_pr(
     state: State<'_, AppState>,
     task_id: String,
-    repo_path: String,
+    _repo_path: String,
     base_branch: Option<String>,
 ) -> Result<CreatePrResult, AppError> {
     // Get the task to retrieve title, description, and branch
-    let task = {
+    let (task, repo_path) = {
         let conn = state
             .db
             .lock()
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-        db::get_task(&conn, &task_id)?
+        let task = db::get_task(&conn, &task_id)?;
+        let workspace = db::get_workspace(&conn, &task.workspace_id)?;
+        (task, workspace.repo_path)
     };
 
     // Verify task has a branch
@@ -1061,23 +1063,39 @@ pub struct GenerateTestChecklistResult {
     pub diff_summary: String,
 }
 
+fn validate_claude_cli_path(cli_path: Option<String>) -> Result<String, AppError> {
+    let cli =
+        crate::commands::agent::validate_agent_cli_path(cli_path.as_deref().unwrap_or("claude"))?;
+    let binary_name = cli.rsplit('/').next().unwrap_or(&cli);
+    if binary_name != "claude" {
+        return Err(AppError::InvalidInput(format!(
+            "Test checklist generation requires Claude CLI, got {}",
+            binary_name
+        )));
+    }
+    Ok(cli)
+}
+
 /// Generate test checklist items from PR diff using Claude CLI
 #[tauri::command(rename_all = "camelCase")]
 pub async fn generate_test_checklist(
     state: State<'_, AppState>,
     task_id: String,
-    repo_path: String,
+    _repo_path: String,
     cli_path: Option<String>,
 ) -> Result<GenerateTestChecklistResult, AppError> {
     // Get task to check PR number
-    let pr_number = {
+    let (pr_number, repo_path) = {
         let conn = state
             .db
             .lock()
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
         let task = db::get_task(&conn, &task_id)?;
-        task.pr_number
-            .ok_or_else(|| AppError::InvalidInput("Task has no PR associated".to_string()))?
+        let workspace = db::get_workspace(&conn, &task.workspace_id)?;
+        let pr_number = task
+            .pr_number
+            .ok_or_else(|| AppError::InvalidInput("Task has no PR associated".to_string()))?;
+        (pr_number, workspace.repo_path)
     };
 
     // Get PR diff using gh CLI
@@ -1144,7 +1162,7 @@ Return ONLY the JSON array, no other text."#,
     );
 
     // Call Claude CLI to generate test items
-    let cli = cli_path.unwrap_or_else(|| "claude".to_string());
+    let cli = validate_claude_cli_path(cli_path)?;
     let items = tokio::task::spawn_blocking({
         let cli = cli.clone();
         let repo_path = repo_path.clone();

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use tauri::AppHandle;
+use tauri::{utils::config::Updater, AppHandle};
 use tauri_plugin_updater::UpdaterExt;
 
 use crate::error::AppError;
@@ -12,8 +12,80 @@ pub struct UpdateInfo {
     pub date: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateStatus {
+    pub configured: bool,
+    pub reason: Option<String>,
+    pub endpoint_count: usize,
+    pub artifacts_enabled: bool,
+}
+
+fn update_status_from_parts(
+    has_pubkey: bool,
+    endpoint_count: usize,
+    artifacts_enabled: bool,
+) -> UpdateStatus {
+    let reason = if !has_pubkey {
+        Some("Application updates are not configured for this build: missing updater public key.")
+    } else if endpoint_count == 0 {
+        Some("Application updates are not configured for this build: no update endpoint is set.")
+    } else if !artifacts_enabled {
+        Some("Application updates are disabled for this build because updater artifacts were not generated.")
+    } else {
+        None
+    };
+
+    UpdateStatus {
+        configured: reason.is_none(),
+        reason: reason.map(str::to_string),
+        endpoint_count,
+        artifacts_enabled,
+    }
+}
+
+fn update_status(app: &AppHandle) -> UpdateStatus {
+    let config = app.config();
+    let updater_config = config.plugins.0.get("updater");
+    let pubkey = updater_config
+        .and_then(|value| value.get("pubkey"))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .trim();
+    let endpoint_count = updater_config
+        .and_then(|value| value.get("endpoints"))
+        .and_then(|value| value.as_array())
+        .map(|endpoints| {
+            endpoints
+                .iter()
+                .filter(|value| value.as_str().is_some())
+                .count()
+        })
+        .unwrap_or(0);
+    let artifacts_enabled = matches!(config.bundle.create_updater_artifacts, Updater::Bool(true));
+
+    update_status_from_parts(!pubkey.is_empty(), endpoint_count, artifacts_enabled)
+}
+
+fn require_updates_configured(app: &AppHandle) -> Result<(), AppError> {
+    let status = update_status(app);
+    if status.configured {
+        Ok(())
+    } else {
+        Err(AppError::CommandError(status.reason.unwrap_or_else(|| {
+            "Application updates are not configured for this build.".to_string()
+        })))
+    }
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn get_update_status(app: AppHandle) -> UpdateStatus {
+    update_status(&app)
+}
+
 #[tauri::command(rename_all = "camelCase")]
 pub async fn check_for_update(app: AppHandle) -> Result<Option<UpdateInfo>, AppError> {
+    require_updates_configured(&app)?;
     let updater = app.updater_builder().build()?;
     let update = updater.check().await?;
 
@@ -26,6 +98,7 @@ pub async fn check_for_update(app: AppHandle) -> Result<Option<UpdateInfo>, AppE
 
 #[tauri::command(rename_all = "camelCase")]
 pub async fn install_update(app: AppHandle) -> Result<(), AppError> {
+    require_updates_configured(&app)?;
     let updater = app.updater_builder().build()?;
     let update = updater.check().await?;
     let update = update.ok_or_else(|| AppError::CommandError("No update available".to_string()))?;
@@ -33,4 +106,35 @@ pub async fn install_update(app: AppHandle) -> Result<(), AppError> {
     update.download_and_install(|_, _| {}, || {}).await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_status_explains_missing_pubkey_first() {
+        let status = update_status_from_parts(false, 1, true);
+
+        assert!(!status.configured);
+        assert_eq!(status.endpoint_count, 1);
+        assert!(status.artifacts_enabled);
+        assert!(status.reason.unwrap().contains("public key"));
+    }
+
+    #[test]
+    fn update_status_explains_disabled_artifacts() {
+        let status = update_status_from_parts(true, 1, false);
+
+        assert!(!status.configured);
+        assert!(status.reason.unwrap().contains("artifacts"));
+    }
+
+    #[test]
+    fn update_status_is_configured_when_all_parts_exist() {
+        let status = update_status_from_parts(true, 1, true);
+
+        assert!(status.configured);
+        assert!(status.reason.is_none());
+    }
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,11 +1,18 @@
+use crate::config::DEFAULT_BASE_BRANCH;
 use crate::db::{self, AppState, Column, Workspace};
 use crate::error::AppError;
+use git2::{BranchType, Repository};
+use serde_json::Value;
+use std::path::Path;
 use tauri::State;
 
 struct DefaultColumn {
     name: &'static str,
     icon: &'static str,
     color: Option<&'static str>,
+    trigger_config: &'static str,
+    exit_config: &'static str,
+    auto_advance: bool,
 }
 
 // Semantic column colors — keep in sync with COLUMN_COLORS in column-config-constants.ts
@@ -21,40 +28,226 @@ const DEFAULT_COLUMNS: &[DefaultColumn] = &[
         name: "Backlog",
         icon: "inbox",
         color: Some(column_colors::GRAY),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
     },
     DefaultColumn {
         name: "Working",
         icon: "play",
         color: Some(column_colors::BLUE),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
     },
     DefaultColumn {
         name: "Review",
         icon: "eye",
         color: Some(column_colors::AMBER),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
     },
     DefaultColumn {
         name: "Done",
         icon: "check",
         color: Some(column_colors::GREEN),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
     },
 ];
+
+const STANDARD_COLUMNS: &[DefaultColumn] = &[
+    DefaultColumn {
+        name: "Backlog",
+        icon: "inbox",
+        color: Some(column_colors::GRAY),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "In Progress",
+        icon: "play",
+        color: Some(column_colors::BLUE),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "Review",
+        icon: "eye",
+        color: Some(column_colors::AMBER),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "Done",
+        icon: "check",
+        color: Some(column_colors::GREEN),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+];
+
+const FULL_CI_COLUMNS: &[DefaultColumn] = &[
+    DefaultColumn {
+        name: "Backlog",
+        icon: "inbox",
+        color: Some(column_colors::GRAY),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "Spec",
+        icon: "file-text",
+        color: Some(column_colors::BLUE),
+        trigger_config: "agent:plan",
+        exit_config: "file:spec.md",
+        auto_advance: true,
+    },
+    DefaultColumn {
+        name: "Build",
+        icon: "hammer",
+        color: Some(column_colors::BLUE),
+        trigger_config: "agent:code",
+        exit_config: "cmd:npm run build",
+        auto_advance: true,
+    },
+    DefaultColumn {
+        name: "Test",
+        icon: "flask-conical",
+        color: Some(column_colors::AMBER),
+        trigger_config: "cmd:npm test",
+        exit_config: "exit:0",
+        auto_advance: true,
+    },
+    DefaultColumn {
+        name: "Review",
+        icon: "eye",
+        color: Some(column_colors::AMBER),
+        trigger_config: "agent:review",
+        exit_config: "pr:approved",
+        auto_advance: true,
+    },
+    DefaultColumn {
+        name: "Deploy",
+        icon: "rocket",
+        color: Some(column_colors::GREEN),
+        trigger_config: "cmd:npm run deploy",
+        exit_config: "exit:0",
+        auto_advance: true,
+    },
+    DefaultColumn {
+        name: "Notify",
+        icon: "bell",
+        color: Some("#FBBF24"),
+        trigger_config: "",
+        exit_config: "notification:sent",
+        auto_advance: true,
+    },
+    DefaultColumn {
+        name: "Done",
+        icon: "check",
+        color: Some(column_colors::GREEN),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+];
+
+const QUICK_FIX_COLUMNS: &[DefaultColumn] = &[
+    DefaultColumn {
+        name: "Todo",
+        icon: "bug",
+        color: Some(column_colors::GRAY),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "Fixing",
+        icon: "wrench",
+        color: Some(column_colors::BLUE),
+        trigger_config: "agent:code",
+        exit_config: "cmd:npm test",
+        auto_advance: true,
+    },
+    DefaultColumn {
+        name: "Done",
+        icon: "check",
+        color: Some(column_colors::GREEN),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+];
+
+const SPIKE_COLUMNS: &[DefaultColumn] = &[
+    DefaultColumn {
+        name: "Questions",
+        icon: "circle-help",
+        color: Some(column_colors::GRAY),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "Research",
+        icon: "search",
+        color: Some(column_colors::BLUE),
+        trigger_config: "agent:research",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "Prototype",
+        icon: "flask-conical",
+        color: Some(column_colors::AMBER),
+        trigger_config: "agent:code",
+        exit_config: "",
+        auto_advance: false,
+    },
+    DefaultColumn {
+        name: "Findings",
+        icon: "lightbulb",
+        color: Some("#FBBF24"),
+        trigger_config: "",
+        exit_config: "",
+        auto_advance: false,
+    },
+];
+
+fn columns_for_template(template_id: Option<&str>) -> &'static [DefaultColumn] {
+    match template_id {
+        Some("standard") | None => STANDARD_COLUMNS,
+        Some("full-ci") => FULL_CI_COLUMNS,
+        Some("quick-fix") => QUICK_FIX_COLUMNS,
+        Some("spike") => SPIKE_COLUMNS,
+        Some(_) => DEFAULT_COLUMNS,
+    }
+}
 
 #[tauri::command]
 pub fn create_workspace(
     state: State<AppState>,
     name: String,
     repo_path: String,
+    template_id: Option<String>,
+    default_agent_cli: Option<String>,
 ) -> Result<Workspace, AppError> {
     if name.trim().is_empty() {
         return Err(AppError::InvalidInput(
             "Workspace name cannot be empty".to_string(),
         ));
     }
-    if repo_path.trim().is_empty() {
-        return Err(AppError::InvalidInput(
-            "Repository path cannot be empty".to_string(),
-        ));
-    }
+    let repo_path = validate_workspace_repo_path(&repo_path)?;
+    let workspace_config =
+        new_workspace_config(&repo_path, default_agent_cli.as_deref().map(str::trim))?;
 
     let conn = state
         .db
@@ -64,16 +257,66 @@ pub fn create_workspace(
         .unchecked_transaction()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
-    let ws = db::insert_workspace(&conn, name.trim(), repo_path.trim())?;
+    let mut ws = db::insert_workspace(&conn, name.trim(), &repo_path)?;
+    if workspace_config != "{}" {
+        ws = db::update_workspace(
+            &conn,
+            &ws.id,
+            None,
+            None,
+            None,
+            None,
+            Some(&workspace_config),
+        )?;
+    }
 
-    // Auto-create default columns with icons and colors
-    for (i, col) in DEFAULT_COLUMNS.iter().enumerate() {
-        db::insert_column_with_style(&conn, &ws.id, col.name, i as i64, col.icon, col.color)?;
+    // Auto-create columns from the selected onboarding template.
+    for (i, col) in columns_for_template(template_id.as_deref())
+        .iter()
+        .enumerate()
+    {
+        let created =
+            db::insert_column_with_style(&conn, &ws.id, col.name, i as i64, col.icon, col.color)?;
+        if !col.trigger_config.is_empty() || !col.exit_config.is_empty() || col.auto_advance {
+            let triggers = serde_json::json!({
+                "triggerConfig": col.trigger_config,
+                "exitConfig": col.exit_config,
+                "autoAdvance": col.auto_advance,
+            })
+            .to_string();
+            db::update_column(
+                &conn,
+                &created.id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(&triggers),
+            )?;
+        }
     }
 
     tx.commit()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(ws)
+}
+
+fn new_workspace_config(
+    repo_path: &str,
+    default_agent_cli: Option<&str>,
+) -> Result<String, AppError> {
+    let mut config = Value::Object(Default::default());
+    if let Some(cli) = default_agent_cli.filter(|cli| !cli.is_empty()) {
+        if let Some(obj) = config.as_object_mut() {
+            obj.insert(
+                "defaultAgentCli".to_string(),
+                Value::String(cli.to_string()),
+            );
+        }
+    }
+
+    workspace_config_with_detected_base_branch(&config.to_string(), repo_path)
 }
 
 #[tauri::command]
@@ -111,6 +354,29 @@ pub fn update_workspace(
             ));
         }
     }
+    let repo_path = match repo_path.as_deref() {
+        Some(path) => Some(validate_workspace_repo_path(path)?),
+        None => None,
+    };
+    let config_update = match (repo_path.as_deref(), config.as_deref()) {
+        (Some(path), Some(config)) => {
+            Some(workspace_config_with_detected_base_branch(config, path)?)
+        }
+        (Some(path), None) => {
+            let conn = state
+                .db
+                .lock()
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let current = db::get_workspace(&conn, &id)?;
+            drop(conn);
+            Some(workspace_config_with_detected_base_branch(
+                &current.config,
+                path,
+            )?)
+        }
+        (None, Some(config)) => Some(config.to_string()),
+        (None, None) => None,
+    };
 
     let conn = state
         .db
@@ -123,8 +389,131 @@ pub fn update_workspace(
         repo_path.as_deref(),
         tab_order,
         is_active,
-        config.as_deref(),
+        config_update.as_deref(),
     )?)
+}
+
+fn validate_workspace_repo_path(repo_path: &str) -> Result<String, AppError> {
+    let path = repo_path.trim();
+    if path.is_empty() {
+        return Err(AppError::InvalidInput(
+            "Repository path cannot be empty".to_string(),
+        ));
+    }
+
+    let path_ref = Path::new(path);
+    if !path_ref.exists() {
+        return Err(AppError::InvalidInput(format!(
+            "Repository path does not exist: {}",
+            path
+        )));
+    }
+    if !path_ref.is_dir() {
+        return Err(AppError::InvalidInput(format!(
+            "Repository path is not a directory: {}",
+            path
+        )));
+    }
+    let repo = Repository::discover(path_ref).map_err(|_| {
+        AppError::InvalidInput(format!(
+            "Repository path is not inside a git repository: {}",
+            path
+        ))
+    })?;
+    let workdir = repo.workdir().ok_or_else(|| {
+        AppError::InvalidInput(format!(
+            "Repository path must be inside a non-bare git worktree: {}",
+            path
+        ))
+    })?;
+    let canonical = workdir.canonicalize().map_err(|e| {
+        AppError::InvalidInput(format!(
+            "Failed to canonicalize repository path {}: {}",
+            workdir.display(),
+            e
+        ))
+    })?;
+
+    Ok(canonical.to_string_lossy().into_owned())
+}
+
+fn detect_workspace_default_base_branch(repo_path: &str) -> Result<String, AppError> {
+    let repo = Repository::discover(Path::new(repo_path))
+        .map_err(|e| AppError::CommandError(format!("Failed to open git repository: {}", e)))?;
+
+    if let Ok(remote_head) = repo.find_reference("refs/remotes/origin/HEAD") {
+        if let Some(target) = remote_head.symbolic_target() {
+            if let Some(branch) = target.strip_prefix("refs/remotes/origin/") {
+                let branch = branch.trim();
+                if !branch.is_empty() && branch != "HEAD" {
+                    return Ok(branch.to_string());
+                }
+            }
+        }
+    }
+
+    for name in ["main", "master"] {
+        if repo.find_branch(name, BranchType::Local).is_ok() {
+            return Ok(name.to_string());
+        }
+    }
+
+    if let Ok(head) = repo.head() {
+        if let Some(branch) = head.shorthand().map(str::trim) {
+            if !branch.is_empty() && branch != "HEAD" {
+                return Ok(branch.to_string());
+            }
+        }
+    }
+
+    Ok(DEFAULT_BASE_BRANCH.to_string())
+}
+
+fn workspace_config_has_base_branch(config: &Value) -> bool {
+    let has_non_empty_string = |value: Option<&Value>| {
+        value
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+    };
+
+    has_non_empty_string(config.get("defaultBaseBranch"))
+        || has_non_empty_string(config.get("default_base_branch"))
+        || config.get("git").is_some_and(|git| {
+            has_non_empty_string(git.get("defaultBaseBranch"))
+                || has_non_empty_string(git.get("default_base_branch"))
+        })
+}
+
+fn workspace_config_with_detected_base_branch(
+    config_json: &str,
+    repo_path: &str,
+) -> Result<String, AppError> {
+    let mut config = serde_json::from_str::<Value>(config_json)
+        .unwrap_or_else(|_| Value::Object(Default::default()));
+    if !config.is_object() {
+        config = Value::Object(Default::default());
+    }
+
+    if workspace_config_has_base_branch(&config) {
+        return serde_json::to_string(&config).map_err(|e| {
+            AppError::CommandError(format!("Failed to encode workspace config: {}", e))
+        });
+    }
+
+    let detected = detect_workspace_default_base_branch(repo_path)?;
+    if detected == DEFAULT_BASE_BRANCH {
+        return serde_json::to_string(&config).map_err(|e| {
+            AppError::CommandError(format!("Failed to encode workspace config: {}", e))
+        });
+    }
+
+    if let Some(obj) = config.as_object_mut() {
+        obj.insert("defaultBaseBranch".to_string(), Value::String(detected));
+    }
+
+    serde_json::to_string(&config)
+        .map_err(|e| AppError::CommandError(format!("Failed to encode workspace config: {}", e)))
 }
 
 #[tauri::command]
@@ -258,7 +647,8 @@ pub fn reorder_workspaces(state: State<AppState>, ids: Vec<String>) -> Result<()
     Ok(())
 }
 
-/// Seed demo workspace with sample tasks for testing
+/// Seed a sample workspace for local development.
+#[cfg(debug_assertions)]
 #[tauri::command]
 pub fn seed_demo_data(state: State<AppState>, repo_path: String) -> Result<Workspace, AppError> {
     let conn = state
@@ -428,4 +818,193 @@ pub fn seed_demo_data(state: State<AppState>, repo_path: String) -> Result<Works
     tx.commit()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     Ok(db::get_workspace(&conn, &ws.id)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        columns_for_template, detect_workspace_default_base_branch, new_workspace_config,
+        validate_workspace_repo_path, workspace_config_with_detected_base_branch,
+    };
+    use git2::Repository;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo_with_branch(repo: &Path, branch: &str) {
+        git(repo, &["init", "-q", "-b", branch]);
+        git(repo, &["config", "user.email", "test@example.com"]);
+        git(repo, &["config", "user.name", "Test User"]);
+        std::fs::write(repo.join("README.md"), "test\n").expect("write readme");
+        git(repo, &["add", "README.md"]);
+        git(repo, &["commit", "-q", "-m", "initial"]);
+    }
+
+    #[test]
+    fn columns_for_template_uses_selected_onboarding_template() {
+        let quick_fix = columns_for_template(Some("quick-fix"));
+
+        assert_eq!(quick_fix.len(), 3);
+        assert_eq!(quick_fix[0].name, "Todo");
+        assert_eq!(quick_fix[1].trigger_config, "agent:code");
+        assert_eq!(quick_fix[1].exit_config, "cmd:npm test");
+        assert!(quick_fix[1].auto_advance);
+    }
+
+    #[test]
+    fn new_workspace_config_stores_default_agent_cli() {
+        let dir = tempdir().expect("tempdir");
+        init_repo_with_branch(dir.path(), "main");
+
+        let config = new_workspace_config(dir.path().to_str().expect("utf8"), Some("codex"))
+            .expect("workspace config");
+
+        let parsed: serde_json::Value = serde_json::from_str(&config).expect("json");
+        assert_eq!(
+            parsed
+                .get("defaultAgentCli")
+                .and_then(serde_json::Value::as_str),
+            Some("codex")
+        );
+    }
+
+    #[test]
+    fn validate_workspace_repo_path_requires_existing_directory() {
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join("missing");
+
+        let err = validate_workspace_repo_path(missing.to_str().expect("utf8"))
+            .expect_err("missing path should fail");
+
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn validate_workspace_repo_path_requires_git_repository() {
+        let dir = tempdir().expect("tempdir");
+
+        let err = validate_workspace_repo_path(dir.path().to_str().expect("utf8"))
+            .expect_err("plain directory should fail");
+
+        assert!(err.to_string().contains("not inside a git repository"));
+    }
+
+    #[test]
+    fn validate_workspace_repo_path_normalizes_git_subdirectory_to_worktree_root() {
+        let dir = tempdir().expect("tempdir");
+        Repository::init(dir.path()).expect("init repo");
+        let nested = dir.path().join("nested");
+        std::fs::create_dir_all(&nested).expect("nested");
+
+        let validated = validate_workspace_repo_path(nested.to_str().expect("utf8"))
+            .expect("repo subdirectory should pass");
+
+        assert_eq!(
+            validated,
+            dir.path()
+                .canonicalize()
+                .expect("canonical root")
+                .to_string_lossy()
+                .into_owned()
+        );
+    }
+
+    #[test]
+    fn detect_workspace_default_base_branch_uses_current_branch_when_main_missing() {
+        let dir = tempdir().expect("tempdir");
+        init_repo_with_branch(dir.path(), "develop");
+
+        let detected = detect_workspace_default_base_branch(dir.path().to_str().expect("utf8"))
+            .expect("detect branch");
+
+        assert_eq!(detected, "develop");
+    }
+
+    #[test]
+    fn workspace_config_sets_detected_non_main_base_branch() {
+        let dir = tempdir().expect("tempdir");
+        init_repo_with_branch(dir.path(), "master");
+
+        let config =
+            workspace_config_with_detected_base_branch("{}", dir.path().to_str().expect("utf8"))
+                .expect("workspace config");
+
+        let parsed: serde_json::Value = serde_json::from_str(&config).expect("json");
+        assert_eq!(
+            parsed
+                .get("defaultBaseBranch")
+                .and_then(serde_json::Value::as_str),
+            Some("master")
+        );
+    }
+
+    #[test]
+    fn detect_workspace_default_base_branch_prefers_origin_head() {
+        let dir = tempdir().expect("tempdir");
+        init_repo_with_branch(dir.path(), "main");
+        git(dir.path(), &["branch", "develop"]);
+        git(
+            dir.path(),
+            &["update-ref", "refs/remotes/origin/develop", "HEAD"],
+        );
+        git(
+            dir.path(),
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/develop",
+            ],
+        );
+
+        let detected = detect_workspace_default_base_branch(dir.path().to_str().expect("utf8"))
+            .expect("detect branch");
+
+        assert_eq!(detected, "develop");
+    }
+
+    #[test]
+    fn workspace_config_leaves_main_as_implicit_default() {
+        let dir = tempdir().expect("tempdir");
+        init_repo_with_branch(dir.path(), "main");
+
+        let config =
+            workspace_config_with_detected_base_branch("{}", dir.path().to_str().expect("utf8"))
+                .expect("workspace config");
+
+        assert_eq!(config, "{}");
+    }
+
+    #[test]
+    fn workspace_config_preserves_explicit_base_branch() {
+        let dir = tempdir().expect("tempdir");
+        init_repo_with_branch(dir.path(), "master");
+
+        let config = workspace_config_with_detected_base_branch(
+            r#"{"defaultBaseBranch":"release"}"#,
+            dir.path().to_str().expect("utf8"),
+        )
+        .expect("workspace config");
+
+        let parsed: serde_json::Value = serde_json::from_str(&config).expect("json");
+        assert_eq!(
+            parsed
+                .get("defaultBaseBranch")
+                .and_then(serde_json::Value::as_str),
+            Some("release")
+        );
+    }
 }

--- a/src-tauri/src/db/agent_session.rs
+++ b/src-tauri/src/db/agent_session.rs
@@ -216,6 +216,26 @@ pub fn update_agent_session_cli_for_adapter(
     get_agent_session(conn, id)
 }
 
+pub fn update_agent_session_model(
+    conn: &Connection,
+    id: &str,
+    model: Option<&str>,
+    effort_level: Option<&str>,
+) -> SqlResult<AgentSession> {
+    let current = get_agent_session(conn, id)?;
+    let ts = now();
+    conn.execute(
+        "UPDATE agent_sessions SET model = ?1, effort_level = ?2, updated_at = ?3 WHERE id = ?4",
+        params![
+            model.or(current.model.as_deref()),
+            effort_level.or(current.effort_level.as_deref()),
+            ts,
+            id,
+        ],
+    )?;
+    get_agent_session(conn, id)
+}
+
 /// Resolve the resume id for a given adapter on an agent session.
 ///
 /// Lookup order:

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -59,6 +59,7 @@ pub struct Task {
     pub agent_mode: Option<String>,
     pub agent_status: Option<String>,
     pub queued_at: Option<String>,
+    #[serde(rename = "branch")]
     pub branch_name: Option<String>,
     /// Batch identifier used to group related pipeline PRs.
     pub batch_id: Option<String>,

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 
-use crate::db;
+use crate::db::{self, AppState};
+use tauri::Manager;
 
 // ─── Event channel name helpers ────────────────────────────────────────────
 
@@ -135,17 +136,40 @@ pub fn persist_and_emit_agent_transcript_event(
     content: Option<&str>,
     metadata_json: Option<&str>,
 ) -> Option<db::AgentTranscriptEvent> {
-    let conn = rusqlite::Connection::open(db::db_path()).ok()?;
-    let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
-    let event = db::insert_agent_transcript_event(
-        &conn,
-        task_id,
-        session_id,
-        event_type,
-        content,
-        metadata_json,
-    )
-    .ok()?;
+    // Use the shared AppState mutex instead of opening a new sqlite handle
+    // per call. Streaming agents emit hundreds of events/sec; the previous
+    // pattern fanned out to thousands of concurrent fresh connections under
+    // load and contended for the WAL writer lock.
+    let state = app.try_state::<AppState>()?;
+    let event = {
+        let conn = match state.db.lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                eprintln!(
+                    "[events] transcript persist for task {} failed: db mutex poisoned: {}",
+                    task_id, e
+                );
+                return None;
+            }
+        };
+        match db::insert_agent_transcript_event(
+            &conn,
+            task_id,
+            session_id,
+            event_type,
+            content,
+            metadata_json,
+        ) {
+            Ok(event) => event,
+            Err(e) => {
+                eprintln!(
+                    "[events] transcript persist for task {} event_type={} failed: {}",
+                    task_id, event_type, e
+                );
+                return None;
+            }
+        }
+    };
     emit_agent_transcript_event(
         app,
         AgentTranscriptEventPayload {

--- a/src-tauri/src/git/branch_manager.rs
+++ b/src-tauri/src/git/branch_manager.rs
@@ -8,6 +8,7 @@ const WORKTREE_PREFIX: &str = "kaitencode-";
 const LEGACY_WORKTREE_PREFIXES: &[&str] = &["bentoya-"];
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BranchInfo {
     pub name: String,
     pub is_head: bool,
@@ -588,16 +589,19 @@ pub fn worktree_is_dirty(worktree_path: &str) -> Result<bool, String> {
 }
 
 /// If the worktree is dirty, stage everything and create a single commit
-/// with the supplied message. Returns `Ok(true)` if a commit was made,
-/// `Ok(false)` if there was nothing to commit.
+/// with the supplied message. Returns the new commit hash if a commit was
+/// made, or `None` if there was nothing to commit.
 ///
 /// Used as the "auto-commit safety net" after a Working-stage agent exits
 /// successfully but forgot to commit its own output. We disable gpg signing
 /// (`-c commit.gpgsign=false`) since this is an automated commit and the
 /// host's signing config may prompt interactively.
-pub fn auto_commit_dirty_worktree(worktree_path: &str, message: &str) -> Result<bool, String> {
+pub fn auto_commit_dirty_worktree(
+    worktree_path: &str,
+    message: &str,
+) -> Result<Option<String>, String> {
     if !worktree_is_dirty(worktree_path)? {
-        return Ok(false);
+        return Ok(None);
     }
     let add = std::process::Command::new("git")
         .args(["add", "-A"])
@@ -628,11 +632,26 @@ pub fn auto_commit_dirty_worktree(worktree_path: &str, message: &str) -> Result<
         // `add -A` (e.g. only untracked-and-ignored files). Treat that
         // exact case as "no commit made" rather than an error.
         if stderr.contains("nothing to commit") || stderr.contains("nothing added to commit") {
-            return Ok(false);
+            return Ok(None);
         }
         return Err(format!("git commit failed: {}", stderr.trim()));
     }
-    Ok(true)
+    let rev_parse = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| format!("git rev-parse spawn failed: {}", e))?;
+    if !rev_parse.status.success() {
+        return Err(format!(
+            "git rev-parse HEAD failed: {}",
+            String::from_utf8_lossy(&rev_parse.stderr).trim()
+        ));
+    }
+    Ok(Some(
+        String::from_utf8_lossy(&rev_parse.stdout)
+            .trim()
+            .to_string(),
+    ))
 }
 
 /// List all KaitenCode worktrees in a repo, including legacy names.
@@ -1237,7 +1256,7 @@ mod tests {
 
         let committed =
             auto_commit_dirty_worktree(tmp.to_str().unwrap(), "auto").expect("auto-commit");
-        assert!(!committed);
+        assert!(committed.is_none());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
@@ -1259,7 +1278,10 @@ mod tests {
         let committed =
             auto_commit_dirty_worktree(tmp.to_str().unwrap(), "auto: rescued agent output")
                 .expect("auto-commit");
-        assert!(committed, "expected a commit when worktree is dirty");
+        assert!(
+            committed.is_some(),
+            "expected a commit when worktree is dirty"
+        );
 
         // Worktree must now be clean.
         assert!(!worktree_is_dirty(tmp.to_str().unwrap()).unwrap());

--- a/src-tauri/src/git/change_tracker.rs
+++ b/src-tauri/src/git/change_tracker.rs
@@ -1,7 +1,10 @@
+use std::collections::HashSet;
+
 use git2::{BranchType, Diff, DiffFormat, DiffOptions, Patch, Repository};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FileChange {
     pub path: String,
     pub status: String,
@@ -10,6 +13,7 @@ pub struct FileChange {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ChangeSummary {
     pub files: Vec<FileChange>,
     pub total_additions: usize,
@@ -28,14 +32,77 @@ fn find_base_branch(repo: &Repository) -> Result<String, git2::Error> {
     Ok(head.shorthand().unwrap_or("HEAD").to_string())
 }
 
+fn resolve_base_branch(repo: &Repository, base_branch: Option<&str>) -> Result<String, String> {
+    match base_branch.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(value) => Ok(value.to_string()),
+        None => find_base_branch(repo).map_err(|e| e.to_string()),
+    }
+}
+
+fn get_branch_tree<'a>(repo: &'a Repository, branch: &str) -> Result<git2::Tree<'a>, String> {
+    let task_branch = repo
+        .find_branch(branch, BranchType::Local)
+        .map_err(|e| format!("Branch '{}' not found: {}", branch, e))?;
+
+    task_branch
+        .get()
+        .peel_to_commit()
+        .map_err(|e| e.to_string())?
+        .tree()
+        .map_err(|e| e.to_string())
+}
+
+fn get_commit<'a>(repo: &'a Repository, commit_hash: &str) -> Result<git2::Commit<'a>, String> {
+    repo.revparse_single(commit_hash)
+        .map_err(|e| format!("Commit '{}' not found: {}", commit_hash, e))?
+        .peel_to_commit()
+        .map_err(|e| format!("Reference '{}' is not a commit: {}", commit_hash, e))
+}
+
+fn get_commit_diff<'a>(
+    repo: &'a Repository,
+    commit_hash: &str,
+    file_path: Option<&str>,
+) -> Result<Diff<'a>, String> {
+    let commit = get_commit(repo, commit_hash)?;
+    let new_tree = commit.tree().map_err(|e| e.to_string())?;
+    let old_tree = if commit.parent_count() > 0 {
+        Some(
+            commit
+                .parent(0)
+                .map_err(|e| e.to_string())?
+                .tree()
+                .map_err(|e| e.to_string())?,
+        )
+    } else {
+        None
+    };
+
+    let mut opts = DiffOptions::new();
+    if let Some(path) = file_path {
+        opts.pathspec(path);
+    }
+
+    repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), Some(&mut opts))
+        .map_err(|e| e.to_string())
+}
+
+fn head_matches_branch(repo: &Repository, branch: &str) -> bool {
+    repo.head()
+        .ok()
+        .and_then(|head| head.shorthand().map(|value| value == branch))
+        .unwrap_or(false)
+}
+
 /// Compute a tree-to-tree diff between the base branch and a task branch,
 /// optionally filtered to a single file path.
 fn get_branch_diff<'a>(
     repo: &'a Repository,
     branch: &str,
+    base_branch: Option<&str>,
     file_path: Option<&str>,
 ) -> Result<Diff<'a>, String> {
-    let base_name = find_base_branch(repo).map_err(|e| e.to_string())?;
+    let base_name = resolve_base_branch(repo, base_branch)?;
 
     let base_branch = repo
         .find_branch(&base_name, BranchType::Local)
@@ -47,15 +114,7 @@ fn get_branch_diff<'a>(
         .tree()
         .map_err(|e| e.to_string())?;
 
-    let task_branch = repo
-        .find_branch(branch, BranchType::Local)
-        .map_err(|e| format!("Branch '{}' not found: {}", branch, e))?;
-    let task_tree = task_branch
-        .get()
-        .peel_to_commit()
-        .map_err(|e| e.to_string())?
-        .tree()
-        .map_err(|e| e.to_string())?;
+    let task_tree = get_branch_tree(repo, branch)?;
 
     let mut opts = DiffOptions::new();
     if let Some(path) = file_path {
@@ -66,9 +125,33 @@ fn get_branch_diff<'a>(
         .map_err(|e| e.to_string())
 }
 
+fn get_workdir_diff<'a>(
+    repo: &'a Repository,
+    branch: &str,
+    file_path: Option<&str>,
+) -> Result<Option<Diff<'a>>, String> {
+    if !head_matches_branch(repo, branch) {
+        return Ok(None);
+    }
+
+    let task_tree = get_branch_tree(repo, branch)?;
+    let mut opts = DiffOptions::new();
+    opts.include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_typechange(true);
+    if let Some(path) = file_path {
+        opts.pathspec(path);
+    }
+
+    repo.diff_tree_to_workdir_with_index(Some(&task_tree), Some(&mut opts))
+        .map(Some)
+        .map_err(|e| e.to_string())
+}
+
 fn status_label(status: git2::Delta) -> String {
     match status {
         git2::Delta::Added => "added",
+        git2::Delta::Untracked => "added",
         git2::Delta::Deleted => "deleted",
         git2::Delta::Modified => "modified",
         git2::Delta::Renamed => "renamed",
@@ -78,31 +161,29 @@ fn status_label(status: git2::Delta) -> String {
     .to_string()
 }
 
-/// Return a summary of all changed files on a branch vs its base,
-/// including per-file addition/deletion counts.
-pub fn get_changes(repo_path: &str, branch: &str) -> Result<ChangeSummary, String> {
-    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
-    let diff = get_branch_diff(&repo, branch, None)?;
-
-    let stats = diff.stats().map_err(|e| e.to_string())?;
+fn collect_file_changes(
+    diff: &Diff<'_>,
+    files: &mut Vec<FileChange>,
+    seen_paths: &mut HashSet<String>,
+) {
     let num_deltas = diff.deltas().len();
+    let mut file_infos: Vec<(usize, String, String)> = Vec::with_capacity(num_deltas);
 
-    // First pass: collect owned file info from deltas
-    let mut file_infos: Vec<(String, String)> = Vec::with_capacity(num_deltas);
-    for delta in diff.deltas() {
+    for (i, delta) in diff.deltas().enumerate() {
         let path = delta
             .new_file()
             .path()
             .or_else(|| delta.old_file().path())
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
-        file_infos.push((path, status_label(delta.status())));
+        if path.is_empty() || !seen_paths.insert(path.clone()) {
+            continue;
+        }
+        file_infos.push((i, path, status_label(delta.status())));
     }
 
-    // Second pass: get per-file line stats from patches
-    let mut files = Vec::with_capacity(num_deltas);
-    for (i, (path, status)) in file_infos.into_iter().enumerate() {
-        let (additions, deletions) = Patch::from_diff(&diff, i)
+    for (i, path, status) in file_infos {
+        let (additions, deletions) = Patch::from_diff(diff, i)
             .ok()
             .flatten()
             .and_then(|patch| {
@@ -118,22 +199,9 @@ pub fn get_changes(repo_path: &str, branch: &str) -> Result<ChangeSummary, Strin
             deletions,
         });
     }
-
-    Ok(ChangeSummary {
-        total_additions: stats.insertions(),
-        total_deletions: stats.deletions(),
-        total_files: stats.files_changed(),
-        files,
-    })
 }
 
-/// Return a unified diff string for a branch vs its base.
-/// If `file_path` is provided, only that file's diff is returned.
-pub fn get_diff(repo_path: &str, branch: &str, file_path: Option<&str>) -> Result<String, String> {
-    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
-    let diff = get_branch_diff(&repo, branch, file_path)?;
-
-    let mut output = String::new();
+fn print_diff(diff: &Diff<'_>, output: &mut String) -> Result<(), String> {
     diff.print(DiffFormat::Patch, |_delta, _hunk, line| {
         match line.origin() {
             '+' | '-' | ' ' => {
@@ -147,32 +215,132 @@ pub fn get_diff(repo_path: &str, branch: &str, file_path: Option<&str>) -> Resul
         }
         true
     })
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| e.to_string())
+}
+
+/// Return a summary of all changed files on a branch vs its base,
+/// including dirty worktree and untracked files when the task branch is checked out.
+pub fn get_changes(
+    repo_path: &str,
+    branch: &str,
+    base_branch: Option<&str>,
+) -> Result<ChangeSummary, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let branch_diff = get_branch_diff(&repo, branch, base_branch, None)?;
+    let workdir_diff = get_workdir_diff(&repo, branch, None)?;
+
+    let branch_stats = branch_diff.stats().map_err(|e| e.to_string())?;
+    let mut total_additions = branch_stats.insertions();
+    let mut total_deletions = branch_stats.deletions();
+
+    let mut files = Vec::new();
+    let mut seen_paths = HashSet::new();
+    collect_file_changes(&branch_diff, &mut files, &mut seen_paths);
+
+    if let Some(workdir_diff) = workdir_diff {
+        let workdir_stats = workdir_diff.stats().map_err(|e| e.to_string())?;
+        total_additions += workdir_stats.insertions();
+        total_deletions += workdir_stats.deletions();
+        collect_file_changes(&workdir_diff, &mut files, &mut seen_paths);
+    }
+
+    Ok(ChangeSummary {
+        total_additions,
+        total_deletions,
+        total_files: files.len(),
+        files,
+    })
+}
+
+/// Return a unified diff string for a branch vs its base.
+/// If `file_path` is provided, only that file's diff is returned. Dirty
+/// worktree changes are appended when the task branch is checked out.
+pub fn get_diff(
+    repo_path: &str,
+    branch: &str,
+    base_branch: Option<&str>,
+    file_path: Option<&str>,
+) -> Result<String, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let branch_diff = get_branch_diff(&repo, branch, base_branch, file_path)?;
+    let workdir_diff = get_workdir_diff(&repo, branch, file_path)?;
+
+    let mut output = String::new();
+    print_diff(&branch_diff, &mut output)?;
+    if let Some(workdir_diff) = workdir_diff {
+        if !output.is_empty() && workdir_diff.deltas().len() > 0 {
+            output.push('\n');
+        }
+        print_diff(&workdir_diff, &mut output)?;
+    }
 
     Ok(output)
 }
 
-/// Return the list of file paths touched on a branch vs its base.
-pub fn get_files_touched(repo_path: &str, branch: &str) -> Result<Vec<String>, String> {
+pub fn get_commit_changes(repo_path: &str, commit_hash: &str) -> Result<ChangeSummary, String> {
     let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
-    let diff = get_branch_diff(&repo, branch, None)?;
+    let diff = get_commit_diff(&repo, commit_hash, None)?;
+    let stats = diff.stats().map_err(|e| e.to_string())?;
+    let mut files = Vec::new();
+    let mut seen_paths = HashSet::new();
+    collect_file_changes(&diff, &mut files, &mut seen_paths);
 
-    let files: Vec<String> = diff
-        .deltas()
-        .filter_map(|delta| {
-            delta
+    Ok(ChangeSummary {
+        total_additions: stats.insertions(),
+        total_deletions: stats.deletions(),
+        total_files: files.len(),
+        files,
+    })
+}
+
+pub fn get_commit_diff_text(
+    repo_path: &str,
+    commit_hash: &str,
+    file_path: Option<&str>,
+) -> Result<String, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let diff = get_commit_diff(&repo, commit_hash, file_path)?;
+    let mut output = String::new();
+    print_diff(&diff, &mut output)?;
+    Ok(output)
+}
+
+/// Return the list of file paths touched on a branch vs its base, plus dirty
+/// worktree paths when the task branch is checked out.
+pub fn get_files_touched(
+    repo_path: &str,
+    branch: &str,
+    base_branch: Option<&str>,
+) -> Result<Vec<String>, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let branch_diff = get_branch_diff(&repo, branch, base_branch, None)?;
+    let workdir_diff = get_workdir_diff(&repo, branch, None)?;
+
+    let mut seen_paths = HashSet::new();
+    let mut collect_paths = |diff: &Diff<'_>| {
+        for delta in diff.deltas() {
+            if let Some(path) = delta
                 .new_file()
                 .path()
                 .or_else(|| delta.old_file().path())
                 .map(|p| p.to_string_lossy().to_string())
-        })
-        .collect();
+            {
+                seen_paths.insert(path);
+            }
+        }
+    };
 
-    Ok(files)
+    collect_paths(&branch_diff);
+    if let Some(workdir_diff) = &workdir_diff {
+        collect_paths(workdir_diff);
+    }
+
+    Ok(seen_paths.into_iter().collect())
 }
 
 /// A single commit on a task branch.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CommitInfo {
     pub hash: String,
     pub short_hash: String,
@@ -182,10 +350,14 @@ pub struct CommitInfo {
 }
 
 /// Return the list of commits on a task branch that are not on the base branch.
-pub fn get_commits(repo_path: &str, branch: &str) -> Result<Vec<CommitInfo>, String> {
+pub fn get_commits(
+    repo_path: &str,
+    branch: &str,
+    base_branch: Option<&str>,
+) -> Result<Vec<CommitInfo>, String> {
     let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
 
-    let base_name = find_base_branch(&repo).map_err(|e| e.to_string())?;
+    let base_name = resolve_base_branch(&repo, base_branch)?;
 
     let base_branch = repo
         .find_branch(&base_name, BranchType::Local)
@@ -234,4 +406,88 @@ pub fn get_commits(repo_path: &str, branch: &str) -> Result<Vec<CommitInfo>, Str
     }
 
     Ok(commits)
+}
+
+pub fn get_commit_info(repo_path: &str, commit_hash: &str) -> Result<CommitInfo, String> {
+    let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
+    let commit = get_commit(&repo, commit_hash)?;
+    let hash = commit.id().to_string();
+    let short_hash = hash[..7.min(hash.len())].to_string();
+    let message = commit.summary().unwrap_or("").to_string();
+    let author = commit.author().name().unwrap_or("").to_string();
+    let timestamp = commit.time().seconds();
+
+    Ok(CommitInfo {
+        hash,
+        short_hash,
+        message,
+        author,
+        timestamp,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::Path, process::Command};
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn commit_file(repo: &Path, path: &str, contents: &str, message: &str) {
+        fs::write(repo.join(path), contents).expect("write test file");
+        git(repo, &["add", path]);
+        git(repo, &["commit", "-q", "-m", message]);
+    }
+
+    #[test]
+    fn branch_views_honor_explicit_base_branch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path();
+
+        git(repo, &["init", "-q", "-b", "main"]);
+        git(repo, &["config", "user.email", "test@example.com"]);
+        git(repo, &["config", "user.name", "Test User"]);
+
+        commit_file(repo, "base.txt", "base\n", "base");
+        git(repo, &["checkout", "-q", "-b", "develop"]);
+        commit_file(repo, "develop-only.txt", "develop\n", "develop only");
+        git(repo, &["checkout", "-q", "-b", "feature/custom-base"]);
+        commit_file(repo, "feature.txt", "feature\n", "feature");
+
+        let repo_path = repo.to_str().expect("utf8 path");
+        let changes = get_changes(repo_path, "feature/custom-base", Some("develop"))
+            .expect("custom-base changes");
+        let files: Vec<&str> = changes
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect();
+        assert_eq!(files, vec!["feature.txt"]);
+
+        let diff = get_diff(repo_path, "feature/custom-base", Some("develop"), None)
+            .expect("custom-base diff");
+        assert!(diff.contains("feature.txt"));
+        assert!(!diff.contains("develop-only.txt"));
+
+        let commits = get_commits(repo_path, "feature/custom-base", Some("develop"))
+            .expect("custom-base commits");
+        let messages: Vec<&str> = commits
+            .iter()
+            .map(|commit| commit.message.as_str())
+            .collect();
+        assert_eq!(messages, vec!["feature"]);
+    }
 }

--- a/src-tauri/src/git/conflict_detector.rs
+++ b/src-tauri/src/git/conflict_detector.rs
@@ -21,7 +21,10 @@ pub struct ConflictMatrix {
 
 /// Compare all active task branches and return files that are modified
 /// by more than one branch (potential merge conflicts).
-pub fn get_conflict_matrix(repo_path: &str) -> Result<ConflictMatrix, String> {
+pub fn get_conflict_matrix(
+    repo_path: &str,
+    base_branch: Option<&str>,
+) -> Result<ConflictMatrix, String> {
     let repo = Repository::open(repo_path).map_err(|e| e.to_string())?;
     let branches = repo
         .branches(Some(BranchType::Local))
@@ -45,7 +48,7 @@ pub fn get_conflict_matrix(repo_path: &str) -> Result<ConflictMatrix, String> {
     let mut file_map: HashMap<String, HashSet<String>> = HashMap::new();
 
     for branch_name in &task_branches {
-        match get_files_touched(repo_path, branch_name) {
+        match get_files_touched(repo_path, branch_name, base_branch) {
             Ok(files) => {
                 for file in files {
                     file_map

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,9 +91,7 @@ pub fn run() {
 
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
-        .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(state)
         .manage(session_registry);
@@ -132,7 +130,6 @@ pub fn run() {
             }
         })
         .invoke_handler(tauri::generate_handler![
-            commands::greet,
             // Workspace CRUD
             commands::workspace::create_workspace,
             commands::workspace::get_workspace,
@@ -141,6 +138,7 @@ pub fn run() {
             commands::workspace::delete_workspace,
             commands::workspace::clone_workspace,
             commands::workspace::reorder_workspaces,
+            #[cfg(debug_assertions)]
             commands::workspace::seed_demo_data,
             // Column CRUD
             commands::column::create_column,
@@ -198,8 +196,11 @@ pub fn run() {
             commands::git::delete_task_branch,
             commands::git::get_changes,
             commands::git::get_diff,
+            commands::git::get_commit_changes,
+            commands::git::get_commit_diff,
             commands::git::get_conflict_matrix,
             commands::git::get_commits,
+            commands::git::get_commit_info,
             // PTY / Agent commands
             commands::terminal::write_to_pty,
             commands::terminal::resize_pty,
@@ -304,10 +305,18 @@ pub fn run() {
             commands::cli_detect::verify_cli_path,
             commands::cli_detect::get_cli_capabilities,
             commands::cli_detect::check_cli_update,
+            commands::system::check_runtime_prerequisites,
             // Checklist commands
+            commands::checklist::create_checklist,
+            commands::checklist::update_checklist,
+            commands::checklist::delete_checklist,
             commands::checklist::get_workspace_checklist,
             commands::checklist::update_checklist_item,
+            commands::checklist::create_checklist_category,
             commands::checklist::update_checklist_category,
+            commands::checklist::delete_checklist_category,
+            commands::checklist::create_checklist_item,
+            commands::checklist::delete_checklist_item,
             commands::checklist::create_workspace_checklist,
             commands::checklist::delete_workspace_checklist,
             commands::checklist::update_checklist_item_auto_detect,
@@ -317,6 +326,7 @@ pub fn run() {
             commands::files::scan_workspace_files,
             commands::files::read_file_content,
             commands::files::create_note_file,
+            commands::files::pick_attachment_files,
             // Script commands
             commands::script::list_scripts,
             commands::script::get_script,
@@ -339,6 +349,7 @@ pub fn run() {
             models::get_available_models,
             models::refresh_models,
             // Updater commands
+            commands::updater::get_update_status,
             commands::updater::check_for_update,
             commands::updater::install_update,
         ])

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -11,6 +11,7 @@ use crate::git::branch_manager;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
@@ -478,6 +479,65 @@ impl ResolvedStep {
             ResolvedStep::Agent { .. } => "agent",
         }
     }
+}
+
+fn canonical_existing_dir(path: &Path) -> Result<PathBuf, AppError> {
+    let canonical = path.canonicalize().map_err(|e| {
+        AppError::InvalidInput(format!(
+            "Script working directory does not exist: {} ({})",
+            path.display(),
+            e
+        ))
+    })?;
+    if !canonical.is_dir() {
+        return Err(AppError::InvalidInput(format!(
+            "Script working directory is not a directory: {}",
+            path.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn path_is_within(path: &Path, root: &Path) -> bool {
+    path == root || path.starts_with(root)
+}
+
+fn resolve_script_work_dir(
+    requested_work_dir: &str,
+    default_working_dir: &str,
+    workspace_repo_path: &str,
+) -> Result<String, AppError> {
+    let requested = requested_work_dir.trim();
+    if requested.is_empty() {
+        return Err(AppError::InvalidInput(
+            "Script workDir cannot be empty".to_string(),
+        ));
+    }
+
+    let default_dir = Path::new(default_working_dir);
+    let candidate = if Path::new(requested).is_absolute() {
+        PathBuf::from(requested)
+    } else {
+        default_dir.join(requested)
+    };
+    let canonical_candidate = canonical_existing_dir(&candidate)?;
+
+    let mut allowed_roots = vec![canonical_existing_dir(Path::new(workspace_repo_path))?];
+    if default_working_dir != workspace_repo_path {
+        allowed_roots.push(canonical_existing_dir(default_dir)?);
+    }
+
+    if allowed_roots
+        .iter()
+        .any(|root| path_is_within(&canonical_candidate, root))
+    {
+        return Ok(canonical_candidate.to_string_lossy().to_string());
+    }
+
+    Err(AppError::InvalidInput(format!(
+        "Script workDir must stay inside the workspace or task worktree: {}",
+        requested_work_dir
+    )))
 }
 
 // ─── Trigger Resolution ────────────────────────────────────────────────────
@@ -1612,11 +1672,19 @@ fn execute_spawn_cli(
         format!("{}\n\nSee .task.md for full spec.", task.title)
     };
 
-    // Resolve CLI: trigger config > workspace config > global settings
-    let cli_type = cli
+    // Resolve CLI: trigger config > workspace config > global settings.
+    // Stored trigger/workspace config is user-editable JSON, so normalize it
+    // through the same backend allowlist used by direct agent commands before
+    // it reaches the shell launcher.
+    let raw_cli_type = cli
         .filter(|c| !c.trim().is_empty())
         .map(|c| c.to_string())
         .unwrap_or_else(|| pipeline_settings.default_agent_cli.clone());
+    let cli_type = if raw_cli_type.trim() == "auto" {
+        "codex".to_string()
+    } else {
+        crate::commands::agent::validate_agent_cli_path(&raw_cli_type)?
+    };
 
     // Prepend slash command if provided
     let initial_prompt = match command {
@@ -2890,24 +2958,6 @@ fn execute_run_script(
         );
     }
 
-    let ts = db::now();
-    let updated_task = db::update_task_pipeline_state(
-        conn,
-        &task.id,
-        PipelineState::Running.as_str(),
-        Some(&ts),
-        Option::None,
-    )?;
-
-    emit_pipeline(
-        app,
-        EVT_RUNNING,
-        &task.id,
-        &column.id,
-        PipelineState::Running,
-        Some(format!("Running script: {}", script.name)),
-    );
-
     // Parse steps
     let steps: Vec<serde_json::Value> = serde_json::from_str(&script.steps).unwrap_or_default();
 
@@ -2924,7 +2974,7 @@ fn execute_run_script(
     // Resolve all steps into owned data
     let resolved_steps: Vec<ResolvedStep> = steps
         .iter()
-        .map(|step| {
+        .map(|step| -> Result<ResolvedStep, AppError> {
             let step_type = step
                 .get("type")
                 .and_then(|v| v.as_str())
@@ -2944,6 +2994,8 @@ fn execute_run_script(
                         .get("workDir")
                         .and_then(|v| v.as_str())
                         .map(|d| template::interpolate(d, &ctx))
+                        .map(|d| resolve_script_work_dir(&d, &working_dir, &workspace.repo_path))
+                        .transpose()?
                         .unwrap_or_else(|| working_dir.clone());
                     let continue_on_error = step
                         .get("continueOnError")
@@ -2954,14 +3006,14 @@ fn execute_run_script(
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
 
-                    ResolvedStep::Shell {
+                    Ok(ResolvedStep::Shell {
                         name: step_name,
                         is_check: step_type == "check",
                         command,
                         work_dir,
                         continue_on_error,
                         fail_message,
-                    }
+                    })
                 }
                 "agent" => {
                     let prompt = step.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
@@ -2975,24 +3027,42 @@ fn execute_run_script(
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
 
-                    ResolvedStep::Agent {
+                    Ok(ResolvedStep::Agent {
                         name: step_name,
                         prompt,
                         model,
                         command,
-                    }
+                    })
                 }
-                _ => ResolvedStep::Shell {
+                _ => Ok(ResolvedStep::Shell {
                     name: step_name,
                     is_check: false,
                     command: String::new(),
                     work_dir: working_dir.clone(),
                     continue_on_error: true,
                     fail_message: None,
-                },
+                }),
             }
         })
-        .collect();
+        .collect::<Result<Vec<_>, AppError>>()?;
+
+    let ts = db::now();
+    let updated_task = db::update_task_pipeline_state(
+        conn,
+        &task.id,
+        PipelineState::Running.as_str(),
+        Some(&ts),
+        Option::None,
+    )?;
+
+    emit_pipeline(
+        app,
+        EVT_RUNNING,
+        &task.id,
+        &column.id,
+        PipelineState::Running,
+        Some(format!("Running script: {}", script.name)),
+    );
 
     let task_id = task.id.clone();
     let app_handle = app.clone();
@@ -3056,7 +3126,9 @@ fn execute_run_script(
                                 log::warn!(
                                     "[script:{}] stderr: {}",
                                     task_id,
-                                    stderr.chars().take(500).collect::<String>()
+                                    redact_sensitive_log_fragment(
+                                        &stderr.chars().take(500).collect::<String>()
+                                    )
                                 );
                             }
                             if !out.status.success() {
@@ -3152,6 +3224,33 @@ fn execute_run_script(
     });
 
     Ok(updated_task)
+}
+
+fn redact_sensitive_log_fragment(input: &str) -> String {
+    let secret_markers = [
+        "api_key",
+        "apikey",
+        "api-key",
+        "authorization",
+        "bearer ",
+        "token",
+        "secret",
+        "password",
+        "anthropic_api_key",
+        "openai_api_key",
+    ];
+    input
+        .lines()
+        .map(|line| {
+            let lower = line.to_ascii_lowercase();
+            if secret_markers.iter().any(|marker| lower.contains(marker)) {
+                "[redacted sensitive stderr line]"
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 // Note: dependency task interpolation ({dep.<id>.title}) is handled at the
@@ -4050,6 +4149,60 @@ mod tests {
 
         assert_eq!(step_type, "check");
         assert_eq!(fail_message, Some("Lint errors"));
+    }
+
+    #[test]
+    fn test_resolve_script_work_dir_allows_workspace_subdirectory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        let scripts = repo.join("scripts");
+        std::fs::create_dir_all(&scripts).unwrap();
+
+        let resolved = super::resolve_script_work_dir(
+            "scripts",
+            repo.to_str().unwrap(),
+            repo.to_str().unwrap(),
+        )
+        .expect("workspace child should be allowed");
+
+        assert_eq!(resolved, scripts.canonicalize().unwrap().to_string_lossy());
+    }
+
+    #[test]
+    fn test_resolve_script_work_dir_allows_task_worktree_subdirectory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        let worktree = tmp.path().join("worktree");
+        let nested = worktree.join("pkg");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let resolved = super::resolve_script_work_dir(
+            "pkg",
+            worktree.to_str().unwrap(),
+            repo.to_str().unwrap(),
+        )
+        .expect("worktree child should be allowed");
+
+        assert_eq!(resolved, nested.canonicalize().unwrap().to_string_lossy());
+    }
+
+    #[test]
+    fn test_resolve_script_work_dir_rejects_paths_outside_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let err = super::resolve_script_work_dir(
+            outside.to_str().unwrap(),
+            repo.to_str().unwrap(),
+            repo.to_str().unwrap(),
+        )
+        .expect_err("outside path should be rejected");
+
+        assert!(err.to_string().contains("inside the workspace"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/nicholasrice/tauri/v2/crates/tauri-config-schema/schema.json",
+  "$schema": "https://schema.tauri.app/config/2",
   "productName": "KaitenCode",
   "version": "0.1.0",
   "identifier": "com.kaitencode.desktop",
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' blob: data: media:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.anthropic.com https://*.openai.com"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' data: blob:; connect-src 'self' https://*.anthropic.com https://*.openai.com"
     }
   },
   "plugins": {
@@ -33,13 +33,22 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "createUpdaterArtifacts": false,
+    "targets": ["deb", "appimage", "app", "dmg"],
+    "publisher": "KaitenCode",
+    "homepage": "https://github.com/ANonABento/kaitencode",
+    "copyright": "Copyright © 2026 KaitenCode contributors",
+    "license": "MIT",
+    "category": "DeveloperTool",
+    "shortDescription": "AI coding workspace for macOS and Linux",
+    "longDescription": "KaitenCode is a local-first desktop workspace for managing AI-assisted coding tasks, terminals, Git worktrees, pull requests, and project checklists.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png"
     ],
     "macOS": {
+      "signingIdentity": "-",
       "entitlements": "Entitlements.plist",
       "infoPlist": "Info.plist"
     }

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -8,6 +8,30 @@ vi.mock('@/hooks/use-pr-status-polling', () => ({ usePrStatusPolling: vi.fn() })
 vi.mock('@/hooks/use-task-sync', () => ({ useTaskSync: vi.fn() }))
 vi.mock('@/hooks/use-agent-streaming-sync', () => ({ useAgentStreamingSync: vi.fn() }))
 vi.mock('@/hooks/use-cli-path', () => ({ useAutoDetectClis: vi.fn() }))
+vi.mock('@/lib/ipc', () => ({
+  getWorkspace: vi.fn(() => Promise.resolve({
+    id: 'ws-1',
+    name: 'Workspace',
+    repoPath: '/tmp/workspace',
+    tabOrder: 0,
+    isActive: true,
+    activeTaskCount: 0,
+    config: '{}',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  })),
+  updateWorkspaceConfig: vi.fn(() => Promise.resolve({
+    id: 'ws-1',
+    name: 'Workspace',
+    repoPath: '/tmp/workspace',
+    tabOrder: 0,
+    isActive: true,
+    activeTaskCount: 0,
+    config: '{}',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  })),
+}))
 vi.mock('@/components/layout/board', () => ({ Board: () => <div>Board</div> }))
 vi.mock('@/components/layout/workspace-setup', () => ({ WorkspaceSetup: () => <div>Workspace setup</div> }))
 vi.mock('@/components/onboarding/onboarding-wizard', () => ({ OnboardingWizard: () => <div>Onboarding</div> }))

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,7 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 import { usePrStatusPolling } from '@/hooks/use-pr-status-polling'
 import { useTaskSync } from '@/hooks/use-task-sync'
+import { useSettingsSync } from '@/hooks/use-settings-sync'
 import { useAgentStreamingSync } from '@/hooks/use-agent-streaming-sync'
 import { useAutoDetectClis } from '@/hooks/use-cli-path'
 import { useUpdater } from '@/hooks/use-updater'
@@ -76,6 +77,9 @@ function App() {
 
   // Task sync (re-fetches task store when backend mutates tasks)
   useTaskSync(activeWorkspaceId)
+
+  // Settings sync (loads and persists per-workspace settings through SQLite)
+  useSettingsSync()
 
   // Agent streaming sync (routes agent events to streaming store for live card updates)
   useAgentStreamingSync()

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -332,9 +332,10 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
                         else itemRefs.current.delete(idx)
                       }}
                       onClick={() => { executeCommand(cmd) }}
-                      className={`flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                      className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
                         isSelected ? 'bg-surface-hover text-text-primary' : 'text-text-primary hover:bg-surface-hover'
                       }`}
+                      style={{ cursor: 'pointer' }}
                     >
                       <span className="text-text-secondary" aria-hidden="true">
                         {cmd.icon ?? CATEGORY_ICONS[cmd.category]}

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -225,7 +225,8 @@ export const ColumnHeader = memo(function ColumnHeader({
           />
         ) : (
           <h3
-            className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wider text-text-secondary truncate cursor-default select-none"
+            className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wider text-text-secondary truncate select-none"
+            style={{ cursor: 'default' }}
             onDoubleClick={handleNameDoubleClick}
           >
             {name}

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -236,11 +236,11 @@ export const Column = memo(function Column({
         style={style}
         layout
         data-column-id={column.id}
-        className={`flex w-[300px] min-w-[280px] max-w-[360px] shrink-0 flex-col border-r border-border-default bg-surface/30 ${
+        className={`flex h-full min-h-0 w-[300px] min-w-[280px] max-w-[360px] shrink-0 flex-col border-r border-border-default bg-surface/30 ${
           isDragging ? 'opacity-50' : ''
         }`}
       >
-        <div {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing">
+        <div {...attributes} {...listeners} style={{ cursor: isDragging ? 'grabbing' : 'grab' }}>
           <ColumnHeader
             name={column.name}
             icon={column.icon || 'list'}
@@ -262,7 +262,7 @@ export const Column = memo(function Column({
         <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
           <div
             ref={setDroppableRef}
-            className={`flex flex-1 flex-col gap-2 overflow-y-auto px-2 pt-1 pb-2 transition-colors ${
+            className={`flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pt-1 pb-2 transition-colors ${
               isOver ? 'bg-accent/5' : ''
             }`}
           >

--- a/src/components/kanban/spawn-cli-action-editor.tsx
+++ b/src/components/kanban/spawn-cli-action-editor.tsx
@@ -174,7 +174,7 @@ export function SpawnCliActionEditor({
         />
         <details className="mt-1">
           <summary
-            className="cursor-pointer text-xs text-text-secondary hover:text-text-primary"
+            className="text-xs text-text-secondary hover:text-text-primary"
             style={{ cursor: 'pointer' }}
           >
             Available variables

--- a/src/components/kanban/task-card-status.tsx
+++ b/src/components/kanban/task-card-status.tsx
@@ -42,7 +42,7 @@ export function QueuedBanner({
 
   return (
     <Tooltip content={tooltipText} side="top" wrap delay={200}>
-      <div role="status" className="flex items-center gap-1.5 rounded bg-warning/10 px-2 py-1 text-[11px] text-warning cursor-default">
+      <div role="status" style={{ cursor: 'default' }} className="flex items-center gap-1.5 rounded bg-warning/10 px-2 py-1 text-[11px] text-warning">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 shrink-0" aria-hidden="true">
           <path fillRule="evenodd" d="M1 8a7 7 0 1 1 14 0A7 7 0 0 1 1 8Zm7.75-4.25a.75.75 0 0 0-1.5 0V8c0 .414.336.75.75.75h3.25a.75.75 0 0 0 0-1.5h-2.5V3.75Z" clipRule="evenodd" />
         </svg>
@@ -122,7 +122,7 @@ export function PipelineErrorBanner({
           <path fillRule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14Zm.75-8.25a.75.75 0 0 0-1.5 0v3.5a.75.75 0 0 0 1.5 0v-3.5ZM8 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
         </svg>
         <Tooltip content={rawError || parsed.friendlyMessage} side="top" wrap delay={400}>
-          <span className="truncate flex-1 cursor-default">
+          <span style={{ cursor: 'default' }} className="truncate flex-1">
             {parsed.friendlyMessage}
             {task.retryCount > 0 && ` (${String(task.retryCount)} retries)`}
           </span>
@@ -164,7 +164,10 @@ export function PipelineErrorBanner({
           </ul>
           {rawError && (
             <details className="mt-1">
-              <summary className="cursor-pointer text-error/50 hover:text-error/70 transition-colors">
+              <summary
+                className="text-error/50 transition-colors hover:text-error/70"
+                style={{ cursor: 'pointer' }}
+              >
                 Raw error
               </summary>
               <p className="mt-1 break-all text-error/50 font-mono text-[10px] leading-relaxed">

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -474,7 +474,7 @@ export const TaskCard = memo(function TaskCard({
         }
       }}
       tabIndex={0}
-      className={`group relative overflow-hidden rounded-lg border bg-surface/95 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+      className={`group relative shrink-0 overflow-hidden rounded-lg border bg-surface/95 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
         isSelected ? 'border-accent ring-2 ring-accent/40 z-20' :
         isConnectedToHovered ? 'border-amber-400 ring-1 ring-amber-400/50 z-10' :
         isHovered ? 'border-accent ring-1 ring-accent/50 z-10' :

--- a/src/components/kanban/task-context-menu.tsx
+++ b/src/components/kanban/task-context-menu.tsx
@@ -124,9 +124,10 @@ function MenuItemComponent({ item, onClose }: { item: MenuItem; onClose: () => v
     <button
       onClick={handleClick}
       disabled={item.disabled}
+      style={{ cursor: item.disabled ? 'not-allowed' : undefined }}
       className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors ${
         item.disabled
-          ? 'text-text-secondary/50 cursor-not-allowed'
+          ? 'text-text-secondary/50'
           : item.variant === 'danger'
             ? 'text-error hover:bg-error/10'
             : 'text-text-primary hover:bg-surface-hover'
@@ -160,13 +161,35 @@ function SubmenuComponent({
     timeoutRef.current = setTimeout(() => { setIsOpen(false); }, 150)
   }
 
+  const toggleOpen = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    setIsOpen((open) => !open)
+  }
+
   return (
     <div
       className="relative"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <button className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-text-primary hover:bg-surface-hover">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={toggleOpen}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowRight') {
+            event.preventDefault()
+            setIsOpen(true)
+          }
+          if (event.key === 'Escape') {
+            event.preventDefault()
+            setIsOpen(false)
+          }
+        }}
+        style={{ cursor: 'pointer' }}
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-text-primary hover:bg-surface-hover"
+      >
         {item.icon && <span className="text-text-secondary">{item.icon}</span>}
         <span className="flex-1">{item.label}</span>
         {Icons.chevronRight}

--- a/src/components/kanban/task-dependencies-tab.tsx
+++ b/src/components/kanban/task-dependencies-tab.tsx
@@ -212,7 +212,8 @@ export function DependenciesTab({
           type="button"
           onClick={() => { void handleAdd() }}
           disabled={!newTaskId || isValidating}
-          className="w-full rounded-lg bg-accent/10 px-3 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{ cursor: !newTaskId || isValidating ? 'not-allowed' : undefined }}
+          className="w-full rounded-lg bg-accent/10 px-3 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-50"
         >
           {isValidating ? 'Validating...' : 'Add Dependency'}
         </button>

--- a/src/components/layout/add-workspace-dialog.test.tsx
+++ b/src/components/layout/add-workspace-dialog.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { invoke } from '@tauri-apps/api/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AddWorkspaceDialog } from './add-workspace-dialog'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import type { Workspace } from '@/types'
+
+const workspace: Workspace = {
+  id: 'ws-new',
+  name: 'New Workspace',
+  repoPath: '/repo/new',
+  config: '{}',
+  tabOrder: 0,
+  isActive: false,
+  createdAt: '2026-05-20T00:00:00Z',
+  updatedAt: '2026-05-20T00:00:00Z',
+  activeTaskCount: 0,
+}
+
+describe('AddWorkspaceDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      loaded: true,
+    })
+  })
+
+  it('creates and activates the selected workspace', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(workspace)
+    const onClose = vi.fn()
+
+    render(<AddWorkspaceDialog onClose={onClose} />)
+
+    fireEvent.change(screen.getByPlaceholderText('My Project'), {
+      target: { value: 'New Workspace' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('/path/to/repo'), {
+      target: { value: '/repo/new' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+    expect(invoke).toHaveBeenCalledWith('create_workspace', {
+      name: 'New Workspace',
+      repoPath: '/repo/new',
+    })
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe('ws-new')
+  })
+
+  it('shows workspace creation errors inline', async () => {
+    vi.mocked(invoke).mockRejectedValueOnce({
+      kind: 'InvalidInput',
+      message: 'Repository path is not inside a git repository: /repo/broken',
+    })
+
+    render(<AddWorkspaceDialog onClose={vi.fn()} />)
+
+    fireEvent.change(screen.getByPlaceholderText('My Project'), {
+      target: { value: 'Broken Workspace' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('/path/to/repo'), {
+      target: { value: '/repo/broken' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Invalid repository path. Select a local git repository and try again.',
+    )
+  })
+})

--- a/src/components/layout/add-workspace-dialog.tsx
+++ b/src/components/layout/add-workspace-dialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { motion } from 'motion/react'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import { PathPicker } from '@/components/shared/path-picker'
+import { getErrorMessage } from '@/lib/errors'
 
 type AddWorkspaceDialogProps = {
   onClose: () => void
@@ -8,8 +10,10 @@ type AddWorkspaceDialogProps = {
 
 export function AddWorkspaceDialog({ onClose }: AddWorkspaceDialogProps) {
   const add = useWorkspaceStore((s) => s.add)
+  const setActive = useWorkspaceStore((s) => s.setActive)
   const [name, setName] = useState('')
   const [repoPath, setRepoPath] = useState('')
+  const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -22,11 +26,18 @@ export function AddWorkspaceDialog({ onClose }: AddWorkspaceDialogProps) {
     if (!name.trim() || !repoPath.trim() || isSubmitting) return
 
     setIsSubmitting(true)
+    setError(null)
     try {
-      await add(name.trim(), repoPath.trim())
+      const workspace = await add(name.trim(), repoPath.trim())
+      setActive(workspace.id)
       onClose()
-    } catch (err) {
-      console.error('Failed to add workspace:', err)
+    } catch (err: unknown) {
+      const message = getErrorMessage(err)
+      if (message.includes('repo') || message.includes('git')) {
+        setError('Invalid repository path. Select a local git repository and try again.')
+      } else {
+        setError(message)
+      }
     } finally {
       setIsSubmitting(false)
     }
@@ -61,19 +72,26 @@ export function AddWorkspaceDialog({ onClose }: AddWorkspaceDialogProps) {
 
           <div>
             <label className="mb-1 block text-sm text-text-secondary">Repository Path</label>
-            <input
-              type="text"
+            <PathPicker
               value={repoPath}
-              onChange={(e) => { setRepoPath(e.target.value) }}
+              onChange={(path) => {
+                setRepoPath(path)
+                setError(null)
+              }}
+              onError={setError}
               placeholder="/path/to/repo"
-              className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none"
             />
           </div>
+
+          {error && (
+            <p className="text-xs text-error" role="alert">{error}</p>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <button
               type="button"
               onClick={onClose}
+              style={{ cursor: 'pointer' }}
               className="rounded-lg px-4 py-2 text-sm text-text-secondary hover:bg-surface-hover"
             >
               Cancel
@@ -81,6 +99,7 @@ export function AddWorkspaceDialog({ onClose }: AddWorkspaceDialogProps) {
             <button
               type="submit"
               disabled={!name.trim() || !repoPath.trim() || isSubmitting}
+              style={{ cursor: !name.trim() || !repoPath.trim() || isSubmitting ? 'not-allowed' : 'pointer' }}
               className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-bg disabled:opacity-50"
             >
               {isSubmitting ? 'Adding...' : 'Add'}

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -253,11 +253,11 @@ export function Board() {
         onDragOver={onDragOver}
         onDragEnd={onDragEnd}
       >
-        <div className="flex h-full" data-board-container>
+        <div className="flex h-full min-h-0" data-board-container>
           {/* Board + orchestrator panel (left side, shrinks when task panel open) */}
-          <div className="flex flex-1 flex-col overflow-hidden">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {activeWorkspaceId && <UsageBudgetBanner workspaceId={activeWorkspaceId} />}
-            <div className="relative flex flex-1 overflow-x-auto" data-board-scroll>
+            <div className="relative flex min-h-0 flex-1 overflow-x-auto" data-board-scroll>
               <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
                 {sortedColumns.map((col) => (
                   <Column

--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -78,7 +78,7 @@ function SortableTab({
           if (e.key === 'Enter' || e.key === ' ') onSelect()
         }}
         className={`
-          group flex h-8 cursor-pointer items-center justify-center rounded px-3 text-sm
+          group flex h-8 items-center justify-center rounded px-3 text-sm
           transition-colors duration-150
           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bg
           ${
@@ -87,6 +87,7 @@ function SortableTab({
               : 'font-normal text-text-secondary hover:text-text-primary'
           }
         `}
+        style={{ cursor: 'pointer' }}
       >
         <span className="flex items-center">
           <span className="max-w-[64px] truncate text-center sm:max-w-[120px]">{workspace.name}</span>

--- a/src/components/layout/workspace-setup.tsx
+++ b/src/components/layout/workspace-setup.tsx
@@ -1,8 +1,10 @@
 import { useState, useCallback } from 'react'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { seedDemoData } from '@/lib/ipc'
+import { getErrorMessage } from '@/lib/errors'
 
 export function WorkspaceSetup() {
+  const showSampleWorkspace = import.meta.env.DEV
   const [name, setName] = useState('')
   const [repoPath, setRepoPath] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -25,15 +27,10 @@ export function WorkspaceSetup() {
     setError(null)
 
     try {
-      await addWorkspace(trimmedName, trimmedPath)
-      // The workspace store will update, and App will re-render showing the board
-      const workspaces = useWorkspaceStore.getState().workspaces
-      const created = workspaces[workspaces.length - 1]
-      if (created) {
-        setActive(created.id)
-      }
+      const created = await addWorkspace(trimmedName, trimmedPath)
+      setActive(created.id)
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = getErrorMessage(err)
       if (message.includes('repo') || message.includes('git')) {
         setError('Invalid repo path — make sure it points to a git repository')
       } else {
@@ -63,7 +60,7 @@ export function WorkspaceSetup() {
       await loadWorkspaces()
       setActive(workspace.id)
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = getErrorMessage(err)
       setError(message)
     } finally {
       setSeeding(false)
@@ -125,28 +122,34 @@ export function WorkspaceSetup() {
           type="button"
           onClick={() => { void handleCreate() }}
           disabled={creating || seeding}
-          className="w-full rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+          style={{ cursor: creating || seeding ? 'not-allowed' : undefined }}
+          className="w-full rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:opacity-50"
         >
           {creating ? 'Creating...' : 'Create workspace'}
         </button>
 
-        <div className="relative flex items-center py-2">
-          <div className="flex-grow border-t border-border-default" />
-          <span className="mx-3 text-xs text-text-secondary">or</span>
-          <div className="flex-grow border-t border-border-default" />
-        </div>
+        {showSampleWorkspace && (
+          <>
+            <div className="relative flex items-center py-2">
+              <div className="flex-grow border-t border-border-default" />
+              <span className="mx-3 text-xs text-text-secondary">or</span>
+              <div className="flex-grow border-t border-border-default" />
+            </div>
 
-        <button
-          type="button"
-          onClick={() => { void handleSeedDemo() }}
-          disabled={creating || seeding}
-          className="w-full rounded-lg border border-border-default bg-surface px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {seeding ? 'Seeding...' : 'Load Demo Workspace'}
-        </button>
-        <p className="text-center text-xs text-text-secondary">
-          Load sample tasks with PR statuses for testing
-        </p>
+            <button
+              type="button"
+              onClick={() => { void handleSeedDemo() }}
+              disabled={creating || seeding}
+              style={{ cursor: creating || seeding ? 'not-allowed' : undefined }}
+              className="w-full rounded-lg border border-border-default bg-surface px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-surface-hover disabled:opacity-50"
+            >
+              {seeding ? 'Creating sample...' : 'Explore sample workspace'}
+            </button>
+            <p className="text-center text-xs text-text-secondary">
+              Creates a local sample board for development previews.
+            </p>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
 import { motion } from 'motion/react'
-import { getCurrentBranch, detectClis } from '@/lib/ipc'
+import { getCurrentBranch, detectClis, checkRuntimePrerequisites } from '@/lib/ipc'
 import type { DetectedCli } from '@/lib/ipc/cli'
+import type { RuntimePrerequisite } from '@/lib/ipc/system'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { PathPicker } from '@/components/shared/path-picker'
 import { BUILT_IN_TEMPLATES } from '@/types/templates'
 import { useNativeInput } from '@/hooks/use-native-input'
+import { getErrorMessage } from '@/lib/errors'
 
 type OnboardingWizardProps = {
   onComplete: () => void
@@ -22,6 +24,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const [gitStatus, setGitStatus] = useState<GitStatus>(null)
   const [error, setError] = useState<string | null>(null)
   const [detectedClis, setDetectedClis] = useState<DetectedCli[]>([])
+  const [prerequisites, setPrerequisites] = useState<RuntimePrerequisite[]>([])
+  const [checkingPrereqs, setCheckingPrereqs] = useState(false)
 
   const addWorkspace = useWorkspaceStore((s) => s.add)
   const setActive = useWorkspaceStore((s) => s.setActive)
@@ -42,6 +46,21 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
         // CLI detection is non-critical
       })
   }, [])
+
+  const refreshPrerequisites = useCallback(async () => {
+    setCheckingPrereqs(true)
+    try {
+      setPrerequisites(await checkRuntimePrerequisites())
+    } catch {
+      setPrerequisites([])
+    } finally {
+      setCheckingPrereqs(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshPrerequisites()
+  }, [refreshPrerequisites])
 
   // Validate git repo when path changes
   useEffect(() => {
@@ -78,22 +97,23 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     setError(null)
 
     try {
-      await addWorkspace(trimmedName, trimmedPath)
-      const workspaces = useWorkspaceStore.getState().workspaces
-      const created = workspaces[workspaces.length - 1]
-      if (created) {
-        setActive(created.id)
-      }
+      const defaultAgentCli = Array.from(selectedClis)[0]
+      const created = await addWorkspace(trimmedName, trimmedPath, {
+        templateId: template,
+        ...(defaultAgentCli ? { defaultAgentCli } : {}),
+      })
+      setActive(created.id)
       onComplete()
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = getErrorMessage(err)
       setError(message)
     } finally {
       setIsCreating(false)
     }
-  }, [name, repoPath, addWorkspace, setActive, onComplete])
+  }, [name, repoPath, selectedClis, template, addWorkspace, setActive, onComplete])
 
-  const canCreate = repoPath.trim().length > 0 && !isCreating
+  const canCreate = repoPath.trim().length > 0 && gitStatus === 'valid' && !isCreating
+  const missingRequiredPrereqs = prerequisites.filter((item) => item.required && !item.available)
 
   return (
     <motion.div
@@ -140,6 +160,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
             <PathPicker
               value={repoPath}
               onChange={(path) => { setRepoPath(path); setError(null) }}
+              onError={setError}
               placeholder="/Users/you/project"
             />
             {/* Git status */}
@@ -153,7 +174,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
               <div className="mt-1">
                 <p className="text-xs text-error">Not a git repository</p>
                 <p className="text-xs text-text-secondary">
-                  The workspace will be created without git integration.
+                  Select a folder inside a local git repository.
                 </p>
               </div>
             )}
@@ -161,6 +182,47 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 
           {/* Template & Agent — grouped */}
           <div className="space-y-3 rounded-lg border border-border-default bg-bg p-3">
+            <div>
+              <div className="mb-1 flex items-center justify-between gap-2">
+                <label className="block text-xs font-medium text-text-secondary">
+                  System check
+                </label>
+                <button
+                  type="button"
+                  onClick={() => { void refreshPrerequisites() }}
+                  disabled={checkingPrereqs}
+                  style={{ cursor: checkingPrereqs ? 'not-allowed' : 'pointer' }}
+                  className="rounded border border-border-default px-2 py-0.5 text-[11px] text-text-secondary hover:bg-surface-hover disabled:opacity-50"
+                >
+                  {checkingPrereqs ? 'Checking...' : 'Recheck'}
+                </button>
+              </div>
+              <div className="space-y-1">
+                {prerequisites.map((item) => (
+                  <div
+                    key={item.id}
+                    className="flex items-center justify-between gap-3 rounded-md border border-border-default bg-surface px-3 py-1.5 text-xs"
+                    title={item.available ? (item.version ?? item.name) : item.installHint}
+                  >
+                    <span className="text-text-primary">{item.name}</span>
+                    <span className={item.available ? 'text-success' : item.required ? 'text-error' : 'text-yellow-500'}>
+                      {item.available ? (item.version ?? 'Available') : item.required ? 'Required' : 'Optional'}
+                    </span>
+                  </div>
+                ))}
+                {!checkingPrereqs && prerequisites.length === 0 && (
+                  <p className="rounded-md border border-border-default bg-surface px-3 py-1.5 text-xs text-text-secondary">
+                    System check unavailable. You can continue and configure tools later.
+                  </p>
+                )}
+              </div>
+              {missingRequiredPrereqs.length > 0 && (
+                <p className="mt-1 text-xs text-error">
+                  Install {missingRequiredPrereqs.map((item) => item.name).join(', ')} before running agents or terminals.
+                </p>
+              )}
+            </div>
+
             <div>
               <label htmlFor="onboard-template" className="mb-1 block text-xs font-medium text-text-secondary">
                 Template
@@ -188,7 +250,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   {detectedClis.map((cli) => (
                     <label
                       key={cli.id}
-                      className="flex items-center gap-3 rounded-md border border-border-default bg-surface px-3 py-1.5 cursor-pointer hover:bg-surface-hover transition-colors"
+                      className="flex items-center gap-3 rounded-md border border-border-default bg-surface px-3 py-1.5 transition-colors hover:bg-surface-hover"
+                      style={{ cursor: 'pointer' }}
                     >
                       <input
                         type="checkbox"
@@ -225,7 +288,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
             type="button"
             onClick={() => { void handleCreate() }}
             disabled={!canCreate}
-            className="mt-2 w-full rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ cursor: canCreate ? undefined : 'not-allowed' }}
+            className="mt-2 w-full rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-accent/90 disabled:opacity-50"
           >
             {isCreating ? 'Creating workspace...' : 'Create Workspace'}
           </button>

--- a/src/components/panel/agent-panel.test.tsx
+++ b/src/components/panel/agent-panel.test.tsx
@@ -156,8 +156,21 @@ vi.mock('./shared', () => ({
 }))
 
 vi.mock('./terminal-view', () => ({
-  TerminalView: ({ taskId, workingDir }: { taskId: string; workingDir: string }) => (
-    <div data-testid="terminal-view" data-task-id={taskId} data-working-dir={workingDir} />
+  TerminalView: ({
+    taskId,
+    workingDir,
+    allowSpawn,
+  }: {
+    taskId: string
+    workingDir: string
+    allowSpawn?: boolean
+  }) => (
+    <div
+      data-testid="terminal-view"
+      data-task-id={taskId}
+      data-working-dir={workingDir}
+      data-allow-spawn={String(!!allowSpawn)}
+    />
   ),
 }))
 
@@ -251,13 +264,22 @@ describe('AgentPanel session controls', () => {
   })
 
   it('switches to the raw terminal tab without losing task session wiring', () => {
-    renderPanel({ worktreePath: '/tmp/worktree' })
+    renderPanel({ agentStatus: 'running', worktreePath: '/tmp/worktree' })
 
     fireEvent.click(screen.getByRole('button', { name: 'Terminal' }))
 
     const terminal = screen.getByTestId('terminal-view')
     expect(terminal).toHaveAttribute('data-task-id', 't1')
     expect(terminal).toHaveAttribute('data-working-dir', '/tmp/worktree')
+    expect(terminal).toHaveAttribute('data-allow-spawn', 'true')
+  })
+
+  it('does not spawn a terminal session for stopped tasks', () => {
+    renderPanel({ agentStatus: 'completed', worktreePath: '/tmp/worktree' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Terminal' }))
+
+    expect(screen.getByTestId('terminal-view')).toHaveAttribute('data-allow-spawn', 'false')
   })
 
   it('shows Activity, Terminal, and Changes tabs in headless mode without tab badges', () => {

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -1,6 +1,9 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { Task } from '@/types'
+import type { AgentTranscriptEvent } from '@/types/events'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useSettingsStore } from '@/stores/settings-store'
+import { parseWorkspaceConfig } from '@/types/workspace'
 import { useAgentTranscriptStore } from '@/stores/agent-transcript-store'
 import { holdTask, killTaskSession } from '@/lib/ipc/agent'
 import { agentInjectMessage } from '@/lib/ipc/agent-interactive'
@@ -10,6 +13,8 @@ import { useTaskDetail } from '@/hooks/use-task-detail'
 import { TerminalView } from './terminal-view'
 import { InteractiveAgentView } from './interactive-agent-view'
 import { ChatInput, type ChatInputMessage } from './shared'
+import type { ModelId } from './shared/chat-input-types'
+import type { ThinkingLevel } from '@/components/shared/thinking-utils'
 import { AgentTranscript } from './agent-transcript'
 import { useAgentPanelSession } from './use-agent-panel-session'
 import { DiffSection } from '@/components/task-detail/diff-section'
@@ -60,9 +65,29 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
   const workspace = useWorkspaceStore((s) =>
     s.workspaces.find((w) => w.id === task.workspaceId)
   )
+  const globalSettings = useSettingsStore((s) => s.global)
+  const workspaceConfig = useMemo(
+    () => parseWorkspaceConfig(workspace?.config ?? '{}'),
+    [workspace?.config],
+  )
+  const configuredDefaultModel = useMemo(
+    () => resolveConfiguredDefaultModel(
+      workspaceConfig.defaultModel,
+      globalSettings.agent.modelSelection,
+      globalSettings.model.providers.find((provider) => provider.id === 'anthropic')?.defaultModel,
+    ),
+    [globalSettings.agent.modelSelection, globalSettings.model.providers, workspaceConfig.defaultModel],
+  )
   const workingDir = task.worktreePath ?? workspace?.repoPath ?? ''
   const session = useAgentPanelSession(task)
+  const transcriptState = useAgentTranscriptStore((s) => s.getTaskState(task.id))
+  const latestTranscriptCommit = useMemo(
+    () => inferLatestCommitHash(transcriptState.events),
+    [transcriptState.events],
+  )
   const {
+    changeReference,
+    changeReferenceKind,
     changes,
     loading,
     diffByFile,
@@ -70,8 +95,7 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
     diffError,
     commits,
     loadDiff,
-  } = useTaskDetail(task)
-  const transcriptState = useAgentTranscriptStore((s) => s.getTaskState(task.id))
+  } = useTaskDetail(task, { fallbackCommitHash: latestTranscriptCommit })
   const loadTranscript = useAgentTranscriptStore((s) => s.load)
   const subscribeTranscript = useAgentTranscriptStore((s) => s.subscribe)
   const unsubscribeTranscript = useAgentTranscriptStore((s) => s.unsubscribe)
@@ -80,6 +104,10 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
   const [holdBusy, setHoldBusy] = useState(false)
   const [killBusy, setKillBusy] = useState(false)
   const [draftInsertion, setDraftInsertion] = useState<{ id: number; content: string } | null>(null)
+  const inputDefaults = useMemo(
+    () => inferAgentInputDefaults(task, transcriptState.events, configuredDefaultModel),
+    [configuredDefaultModel, task, transcriptState.events],
+  )
 
   const isAgentRunning = task.agentStatus === 'running'
   const stopDisabled = stopBusy || !isAgentRunning
@@ -255,6 +283,8 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
             />
             <ChatInput
               config={{
+                defaultModel: inputDefaults.model,
+                defaultThinkingLevel: inputDefaults.thinkingLevel,
                 placeholder: 'Steer the agent... /commands, @files, !shell',
                 showModelSelector: true,
                 showThinkingSelector: true,
@@ -275,12 +305,17 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
             />
           </div>
         ) : activeView === 'terminal' ? (
-          <TerminalView taskId={task.id} workingDir={workingDir} />
+          <TerminalView
+            taskId={task.id}
+            workingDir={workingDir}
+            allowSpawn={isAgentRunning}
+          />
         ) : (
           <div className="h-full overflow-auto bg-bg p-2" data-testid="agent-panel-changes-view">
             <div className="space-y-2">
               <DiffSection
-                branch={task.branch ?? null}
+                branch={changeReference}
+                referenceKind={changeReferenceKind}
                 changes={changes}
                 loading={loading}
                 diffLoading={diffLoading}
@@ -303,6 +338,87 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
       </div>
     </div>
   )
+}
+
+function inferLatestCommitHash(events: AgentTranscriptEvent[]): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const content = events[i]?.content
+    if (!content) continue
+    const matches = Array.from(content.matchAll(/\b[0-9a-f]{7,40}\b/gi))
+      .map((match) => match[0])
+      .filter((hash) => !/^[0-9]+$/.test(hash))
+    if (matches.length > 0) return matches[matches.length - 1] ?? null
+  }
+  return null
+}
+
+function inferAgentInputDefaults(
+  task: Task,
+  events: AgentTranscriptEvent[],
+  configuredDefaultModel: string,
+): { model: ModelId; thinkingLevel: ThinkingLevel } {
+  let model = task.model?.trim()
+  let effortLevel: string | undefined
+
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]
+    if (!event) continue
+    if (event.eventType !== 'agent_started' && event.eventType !== 'session_started') continue
+    const metadata = parseEventMetadata(event.metadataJson)
+    if (!model) {
+      const metadataModel = metadata.model
+      if (typeof metadataModel === 'string' && metadataModel.trim()) {
+        model = metadataModel.trim()
+      }
+    }
+    if (!effortLevel) {
+      const metadataEffort = metadata.effortLevel ?? metadata.effort_level
+      if (typeof metadataEffort === 'string' && metadataEffort.trim()) {
+        effortLevel = metadataEffort.trim()
+      }
+    }
+    if (model && effortLevel) break
+  }
+
+  return {
+    model: normalizeModelId(model, configuredDefaultModel),
+    thinkingLevel: normalizeThinkingLevel(effortLevel),
+  }
+}
+
+function parseEventMetadata(metadataJson: string | null): Record<string, unknown> {
+  if (!metadataJson) return {}
+  try {
+    const parsed = JSON.parse(metadataJson) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function resolveConfiguredDefaultModel(
+  workspaceDefault: string | undefined,
+  agentModelSelection: string | undefined,
+  providerDefault: string | undefined,
+): string {
+  const workspaceModel = workspaceDefault?.trim()
+  if (workspaceModel) return workspaceModel
+  const agentModel = agentModelSelection?.trim()
+  if (agentModel && agentModel !== 'auto') return agentModel
+  return providerDefault?.trim() || 'sonnet'
+}
+
+function normalizeModelId(model: string | undefined, configuredDefaultModel: string): ModelId {
+  return model?.trim() || configuredDefaultModel
+}
+
+function normalizeThinkingLevel(effortLevel: string | undefined): ThinkingLevel {
+  if (effortLevel === 'none' || effortLevel === 'low' || effortLevel === 'high') {
+    return effortLevel
+  }
+  return 'medium'
 }
 
 // ─── Interactive panel (Phase 2) ────────────────────────────────────────

--- a/src/components/panel/agent-transcript.tsx
+++ b/src/components/panel/agent-transcript.tsx
@@ -1009,6 +1009,8 @@ function hasCommandIdentity(metadata: Record<string, unknown>): boolean {
 
 function formatEndDetail(metadata: Record<string, unknown>): string | undefined {
   const exitCode = stringMeta(metadata, 'exitCode')
+  const autoCommitHash = stringMeta(metadata, 'autoCommitHash')
+  if (autoCommitHash) return `auto-commit ${autoCommitHash.slice(0, 7)}`
   if (!exitCode || exitCode === '0' || exitCode === '130') return undefined
   const error = stringMeta(metadata, 'error')
   return error ?? `exit ${exitCode}`

--- a/src/components/panel/file-preview.tsx
+++ b/src/components/panel/file-preview.tsx
@@ -3,11 +3,12 @@ import ReactMarkdown from 'react-markdown'
 import { readFileContent, type FileEntry } from '@/lib/ipc'
 
 type FilePreviewProps = {
+  workspaceId: string
   file: FileEntry
   onClose: () => void
 }
 
-export function FilePreview({ file, onClose }: FilePreviewProps) {
+export function FilePreview({ workspaceId, file, onClose }: FilePreviewProps) {
   const [content, setContent] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -19,7 +20,7 @@ export function FilePreview({ file, onClose }: FilePreviewProps) {
       try {
         setLoading(true)
         setError(null)
-        const text = await readFileContent(file.path)
+        const text = await readFileContent(workspaceId, file.path)
         if (!cancelled) {
           setContent(text)
         }
@@ -40,7 +41,7 @@ export function FilePreview({ file, onClose }: FilePreviewProps) {
     return () => {
       cancelled = true
     }
-  }, [file.path])
+  }, [workspaceId, file.path])
 
   return (
     <div className="flex flex-col h-full">

--- a/src/components/panel/interactive-agent-view.test.tsx
+++ b/src/components/panel/interactive-agent-view.test.tsx
@@ -23,8 +23,18 @@ vi.mock('@/lib/ipc', () => ({
 }))
 
 vi.mock('./terminal-view', () => ({
-  TerminalView: ({ taskId }: { taskId: string }) => (
-    <div data-testid="terminal-view" data-task-id={taskId} />
+  TerminalView: ({
+    taskId,
+    allowSpawn,
+  }: {
+    taskId: string
+    allowSpawn?: boolean
+  }) => (
+    <div
+      data-testid="terminal-view"
+      data-task-id={taskId}
+      data-allow-spawn={String(!!allowSpawn)}
+    />
   ),
 }))
 
@@ -50,6 +60,7 @@ describe('InteractiveAgentView', () => {
     expect(screen.getByTestId('interactive-agent-control-bar')).toBeInTheDocument()
     expect(screen.getByTestId('interactive-agent-status')).toBeInTheDocument()
     expect(screen.getByTestId('terminal-view').getAttribute('data-task-id')).toBe('task-1')
+    expect(screen.getByTestId('terminal-view')).toHaveAttribute('data-allow-spawn', 'true')
   })
 
   it('Interrupt button calls agentInterrupt', async () => {
@@ -104,6 +115,7 @@ describe('InteractiveAgentView', () => {
       />,
     )
     expect(screen.getByTestId('interactive-agent-status')).toHaveTextContent(/Stopped/)
+    expect(screen.getByTestId('terminal-view')).toHaveAttribute('data-allow-spawn', 'false')
   })
 
   // ─── Phase 5: pause / resume ────────────────────────────────────────
@@ -163,14 +175,27 @@ describe('InteractiveAgentView', () => {
       <InteractiveAgentView
         taskId="task-1"
         workingDir="/tmp"
-        agentStatus="completed"
+        agentStatus="idle"
       />,
     )
-    // Force "stopped" status so the dropdown is enabled (modelLocked = status === 'running').
     const select = screen.getByTestId('interactive-agent-model')
     fireEvent.change(select, { target: { value: 'sonnet' } })
     await waitFor(() => {
       expect(interactiveMocks.agentSwitchModel).toHaveBeenCalledWith('task-1', 'sonnet')
     })
+  })
+
+  it('disables live controls when the agent is stopped', () => {
+    render(
+      <InteractiveAgentView
+        taskId="task-1"
+        workingDir="/tmp"
+        agentStatus="completed"
+      />,
+    )
+
+    expect(screen.getByTestId('interactive-agent-model')).toBeDisabled()
+    expect(screen.getByTestId('interactive-agent-pause')).toBeDisabled()
+    expect(screen.getByTestId('interactive-agent-interrupt')).toBeDisabled()
   })
 })

--- a/src/components/panel/interactive-agent-view.tsx
+++ b/src/components/panel/interactive-agent-view.tsx
@@ -43,14 +43,28 @@ export function InteractiveAgentView({
   agentStatus,
   agentPausedAt,
 }: InteractiveAgentViewProps) {
-  const [liveStatus, setLiveStatus] = useState<LiveStatus>('running')
+  const [liveStatus, setLiveStatus] = useState<LiveStatus>(() => agentStatus === 'running' ? 'running' : 'idle')
   const [restarting, setRestarting] = useState(false)
   const [interrupting, setInterrupting] = useState(false)
   const [switchingModel, setSwitchingModel] = useState(false)
   const [pauseBusy, setPauseBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const lastOutputAtRef = useRef<number>(Date.now())
+  const resetTimeoutsRef = useRef<number[]>([])
   const isPaused = agentPausedAt != null
+
+  const scheduleReset = useCallback((callback: () => void, delayMs: number) => {
+    const timeoutId = window.setTimeout(() => {
+      resetTimeoutsRef.current = resetTimeoutsRef.current.filter((id) => id !== timeoutId)
+      callback()
+    }, delayMs)
+    resetTimeoutsRef.current.push(timeoutId)
+  }, [])
+
+  useEffect(() => () => {
+    resetTimeoutsRef.current.forEach((timeoutId) => { window.clearTimeout(timeoutId) })
+    resetTimeoutsRef.current = []
+  }, [])
 
   // Listen to pty output events to track "is the agent typing right now?"
   // — used to flip the status pill between running and idle. We don't try
@@ -93,15 +107,16 @@ export function InteractiveAgentView({
       : isPaused
         ? 'paused'
         : liveStatus
+  const sessionAvailable = status !== 'stopped'
 
   // Lock the model dropdown mid-response. Paused doesn't count as
   // mid-response since the agent's not generating; but we don't want
   // to send a slash command into a suspended shell either, so also
   // lock when paused.
-  const modelLocked = status === 'running' || isPaused
+  const modelLocked = status === 'running' || isPaused || !sessionAvailable
 
   const handleInterrupt = useCallback(async () => {
-    if (interrupting) return
+    if (interrupting || !sessionAvailable) return
     setInterrupting(true)
     setError(null)
     try {
@@ -109,9 +124,9 @@ export function InteractiveAgentView({
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
-      window.setTimeout(() => { setInterrupting(false) }, 250)
+      scheduleReset(() => { setInterrupting(false) }, 250)
     }
-  }, [interrupting, taskId])
+  }, [interrupting, sessionAvailable, scheduleReset, taskId])
 
   const handleRestart = useCallback(async () => {
     if (restarting) return
@@ -126,9 +141,9 @@ export function InteractiveAgentView({
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       // Generous debounce — the new session needs a moment to land.
-      window.setTimeout(() => { setRestarting(false) }, 1500)
+      scheduleReset(() => { setRestarting(false) }, 1500)
     }
-  }, [restarting, taskId])
+  }, [restarting, scheduleReset, taskId])
 
   const handleModelChange = useCallback(async (next: ModelOption) => {
     if (modelLocked || switchingModel) return
@@ -139,12 +154,12 @@ export function InteractiveAgentView({
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
-      window.setTimeout(() => { setSwitchingModel(false) }, 250)
+      scheduleReset(() => { setSwitchingModel(false) }, 250)
     }
-  }, [modelLocked, switchingModel, taskId])
+  }, [modelLocked, scheduleReset, switchingModel, taskId])
 
   const handlePauseToggle = useCallback(async () => {
-    if (pauseBusy) return
+    if (pauseBusy || !sessionAvailable) return
     setPauseBusy(true)
     setError(null)
     try {
@@ -156,9 +171,9 @@ export function InteractiveAgentView({
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
-      window.setTimeout(() => { setPauseBusy(false) }, 200)
+      scheduleReset(() => { setPauseBusy(false) }, 200)
     }
-  }, [pauseBusy, isPaused, taskId])
+  }, [pauseBusy, sessionAvailable, isPaused, scheduleReset, taskId])
 
   return (
     <div
@@ -171,6 +186,7 @@ export function InteractiveAgentView({
         interrupting={interrupting}
         restarting={restarting}
         switchingModel={switchingModel}
+        sessionAvailable={sessionAvailable}
         isPaused={isPaused}
         pauseBusy={pauseBusy}
         onInterrupt={() => { void handleInterrupt() }}
@@ -187,7 +203,11 @@ export function InteractiveAgentView({
         </div>
       )}
       <div className="min-h-0 flex-1">
-        <TerminalView taskId={taskId} workingDir={workingDir} />
+        <TerminalView
+          taskId={taskId}
+          workingDir={workingDir}
+          allowSpawn={agentStatus === 'running'}
+        />
       </div>
     </div>
   )
@@ -199,6 +219,7 @@ type ControlBarProps = {
   interrupting: boolean
   restarting: boolean
   switchingModel: boolean
+  sessionAvailable: boolean
   isPaused: boolean
   pauseBusy: boolean
   onInterrupt: () => void
@@ -213,6 +234,7 @@ function ControlBar({
   interrupting,
   restarting,
   switchingModel,
+  sessionAvailable,
   isPaused,
   pauseBusy,
   onInterrupt,
@@ -268,26 +290,28 @@ function ControlBar({
         <button
           type="button"
           onClick={onPauseToggle}
-          disabled={pauseBusy}
+          disabled={pauseBusy || !sessionAvailable}
           data-testid="interactive-agent-pause"
           title={
-            isPaused
+            !sessionAvailable
+              ? 'Agent session is stopped'
+              : isPaused
               ? 'Resume the suspended agent process'
               : 'Suspend the agent process (SIGTSTP). In-flight network requests keep going — use Interrupt for a hard stop.'
           }
           className="rounded border border-border-default bg-surface px-2 py-0.5 text-[11px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
-          style={{ cursor: pauseBusy ? 'wait' : 'pointer' }}
+          style={{ cursor: pauseBusy ? 'wait' : sessionAvailable ? 'pointer' : 'not-allowed' }}
         >
           {isPaused ? 'Resume' : 'Pause'}
         </button>
         <button
           type="button"
           onClick={onInterrupt}
-          disabled={interrupting}
+          disabled={interrupting || !sessionAvailable}
           data-testid="interactive-agent-interrupt"
-          title="Send Ctrl+C — aborts current generation, agent stays at prompt"
+          title={sessionAvailable ? 'Send Ctrl+C — aborts current generation, agent stays at prompt' : 'Agent session is stopped'}
           className="rounded border border-border-default bg-surface px-2 py-0.5 text-[11px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
-          style={{ cursor: interrupting ? 'wait' : 'pointer' }}
+          style={{ cursor: interrupting ? 'wait' : sessionAvailable ? 'pointer' : 'not-allowed' }}
         >
           Interrupt
         </button>

--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -7,7 +7,6 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
-import { listen } from '@tauri-apps/api/event'
 import { useUIStore } from '@/stores/ui-store'
 import { useResizablePanel } from '@/hooks/use-resizable-panel'
 import { ResizeHandle } from '@/components/shared/resize-handle'
@@ -15,7 +14,7 @@ import { useTaskStore } from '@/stores/task-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useOrchestratorSessions } from '@/hooks/use-orchestrator-sessions'
 import { useChatSession } from '@/hooks/chat-session'
-import { getChatHistory, type ChatMessage } from '@/lib/ipc'
+import { getChatHistory, listen, type ChatMessage } from '@/lib/ipc'
 import { buildPromptWithAttachments } from '@/types'
 import { useCliPath } from '@/hooks/use-cli-path'
 import { ChatHistory } from './chat-history'
@@ -144,24 +143,21 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
     const unsubscribes: Array<() => void> = []
 
     const setupListeners = async () => {
-      const unsubTaskCreated = await listen('task:created', (event) => {
-        const payload = event.payload as { workspace_id?: string }
+      const unsubTaskCreated = await listen<{ workspace_id?: string }>('task:created', (payload) => {
         if (payload.workspace_id === workspaceId) {
           void loadTasks(workspaceId)
         }
       })
       unsubscribes.push(unsubTaskCreated)
 
-      const unsubTaskUpdated = await listen('task:updated', (event) => {
-        const payload = event.payload as { workspace_id?: string }
+      const unsubTaskUpdated = await listen<{ workspace_id?: string }>('task:updated', (payload) => {
         if (payload.workspace_id === workspaceId) {
           void loadTasks(workspaceId)
         }
       })
       unsubscribes.push(unsubTaskUpdated)
 
-      const unsubTaskDeleted = await listen('task:deleted', (event) => {
-        const payload = event.payload as { workspace_id?: string }
+      const unsubTaskDeleted = await listen<{ workspace_id?: string }>('task:deleted', (payload) => {
         if (payload.workspace_id === workspaceId) {
           void loadTasks(workspaceId)
         }
@@ -320,11 +316,12 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
                 aria-label={sidebarMode === 'history' ? 'Hide history' : 'Show history'}
                 aria-pressed={sidebarMode === 'history'}
                 title="History"
-                className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-colors ${
+                className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
                   sidebarMode === 'history'
                     ? 'bg-surface-hover text-text-primary'
                     : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
                 }`}
+                style={{ cursor: 'pointer' }}
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4" aria-hidden="true">
                   <path fillRule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm.75-13a.75.75 0 0 0-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 0 0 0-1.5h-3.25V5Z" clipRule="evenodd" />
@@ -336,11 +333,12 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
                 aria-label={sidebarMode === 'files' ? 'Hide files' : 'Show files'}
                 aria-pressed={sidebarMode === 'files'}
                 title="Files"
-                className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-colors ${
+                className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
                   sidebarMode === 'files'
                     ? 'bg-surface-hover text-text-primary'
                     : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
                 }`}
+                style={{ cursor: 'pointer' }}
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4" aria-hidden="true">
                   <path d="M3.75 3A1.75 1.75 0 0 0 2 4.75v3.26a3.235 3.235 0 0 1 1.75-.51h12.5c.644 0 1.245.188 1.75.51V6.75A1.75 1.75 0 0 0 16.25 5h-4.836a.25.25 0 0 1-.177-.073L9.823 3.513A1.75 1.75 0 0 0 8.586 3H3.75Z" />
@@ -352,11 +350,12 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
                 onClick={() => { setSidebarMode(sidebarMode === 'dashboard' ? null : 'dashboard') }}
                 aria-label={sidebarMode === 'dashboard' ? 'Hide pipeline dashboard' : 'Show pipeline dashboard'}
                 aria-pressed={sidebarMode === 'dashboard'}
-                className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-colors ${
+                className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
                   sidebarMode === 'dashboard'
                     ? 'bg-surface-hover text-text-primary'
                     : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
                 }`}
+                style={{ cursor: 'pointer' }}
                 title="Pipeline dashboard"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4" aria-hidden="true">
@@ -368,11 +367,12 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
                 onClick={() => { setSidebarMode(sidebarMode === 'v2-dashboard' ? null : 'v2-dashboard') }}
                 aria-label={sidebarMode === 'v2-dashboard' ? 'Hide pipeline v2 dashboard' : 'Show pipeline v2 dashboard'}
                 aria-pressed={sidebarMode === 'v2-dashboard'}
-                className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md transition-colors ${
+                className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
                   sidebarMode === 'v2-dashboard'
                     ? 'bg-surface-hover text-text-primary'
                     : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
                 }`}
+                style={{ cursor: 'pointer' }}
                 title="Pipeline v2 dashboard — column distribution, ETA, cost"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
@@ -398,7 +398,8 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
               type="button"
               onClick={() => { void handleNewChat() }}
               disabled={localMessages.length === 0}
-              className="flex h-6 cursor-pointer items-center gap-1 rounded-md px-2 text-xs text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+              className="flex h-6 items-center gap-1 rounded-md px-2 text-xs text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+              style={{ cursor: localMessages.length === 0 ? 'not-allowed' : 'pointer' }}
             >
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
                 <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
@@ -415,7 +416,8 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
               type="button"
               onClick={() => { setPanelDock(isRightDock ? 'bottom' : 'right') }}
               title={isRightDock ? 'Dock to bottom' : 'Dock to right'}
-              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+              className="flex h-6 w-6 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+              style={{ cursor: 'pointer' }}
             >
               {isRightDock ? (
                 /* Icon: dock bottom */
@@ -435,7 +437,8 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
             onClick={togglePanel}
             aria-label={isPanelCollapsed ? 'Expand orchestrator panel' : 'Collapse orchestrator panel'}
             aria-expanded={!isPanelCollapsed}
-            className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            className="flex h-6 w-6 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            style={{ cursor: 'pointer' }}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/components/panel/panel-input.tsx
+++ b/src/components/panel/panel-input.tsx
@@ -60,7 +60,7 @@ export function PanelInput({ onSendMessage, onCancel, onInputChange, isProcessin
     if (!trimmed || disabled) return
 
     // Get connection settings from active provider
-    const connectionMode = (anthropicProvider?.connectionMode ?? 'api')
+    const connectionMode = (anthropicProvider?.connectionMode ?? 'cli')
     const apiKeyEnvVar = anthropicProvider?.apiKeyEnvVar || 'ANTHROPIC_API_KEY'
     const apiKey = settings.agent.envVars[apiKeyEnvVar] || undefined
     const cliPath = anthropicProvider?.cliPath || 'claude'
@@ -223,9 +223,10 @@ export function PanelInput({ onSendMessage, onCancel, onInputChange, isProcessin
                   : voice.state === 'error'
                     ? 'border-yellow-500 bg-yellow-500/10 text-yellow-500'
                     : !voice.isAvailable
-                      ? 'border-border-default bg-bg text-text-secondary/40 cursor-help'
+                      ? 'border-border-default bg-bg text-text-secondary/40'
                       : 'border-border-default bg-bg text-text-primary hover:bg-bg-hover hover:border-border-hover'
-            } disabled:opacity-50 disabled:cursor-not-allowed`}
+            } disabled:opacity-50`}
+            style={{ cursor: disabled ? 'not-allowed' : !voice.isAvailable ? 'help' : undefined }}
           >
             {voice.state === 'processing' ? (
               <LoadingSpinner />
@@ -259,7 +260,8 @@ export function PanelInput({ onSendMessage, onCancel, onInputChange, isProcessin
             type="button"
             onClick={handleSubmit}
             disabled={!message.trim() || disabled}
-            className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-lg bg-accent text-bg transition-colors hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ cursor: !message.trim() || disabled ? 'not-allowed' : undefined }}
+            className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-lg bg-accent text-bg transition-colors hover:bg-accent/90 disabled:opacity-50"
           >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
               <path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.926A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.086l-1.414 4.926a.75.75 0 0 0 .826.95 28.897 28.897 0 0 0 15.293-7.155.75.75 0 0 0 0-1.114A28.897 28.897 0 0 0 3.105 2.288Z" />

--- a/src/components/panel/panel-sidebar.tsx
+++ b/src/components/panel/panel-sidebar.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import type { ChatSession, FileEntry } from '@/lib/ipc'
-import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useWorkspaceFiles } from '@/hooks/use-workspace-files'
 import { FilesTree } from './files-tree'
 import { FilePreview } from './file-preview'
@@ -177,7 +176,8 @@ function HistoryContent({
           type="button"
           onClick={onNewChat}
           disabled={isCurrentChatEmpty}
-          className="w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-xs text-text-secondary hover:bg-surface-hover hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+          style={{ cursor: isCurrentChatEmpty ? 'not-allowed' : undefined }}
+          className="w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-xs text-text-secondary hover:bg-surface-hover hover:text-text-primary transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-secondary"
         >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
             <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
@@ -236,13 +236,8 @@ function HistoryContent({
 function FilesContent({ workspaceId }: { workspaceId: string }) {
   const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null)
 
-  // Get the workspace to access repoPath
-  const workspaces = useWorkspaceStore((s) => s.workspaces)
-  const workspace = workspaces.find((w) => w.id === workspaceId)
-  const repoPath = workspace?.repoPath ?? null
-
   // Fetch files for the workspace
-  const { groupedFiles, loading } = useWorkspaceFiles(repoPath)
+  const { groupedFiles, loading } = useWorkspaceFiles(workspaceId)
 
   const handleSelectFile = useCallback((file: FileEntry) => {
     setSelectedFile(file)
@@ -256,7 +251,7 @@ function FilesContent({ workspaceId }: { workspaceId: string }) {
   if (selectedFile) {
     return (
       <div className="flex-1 overflow-hidden">
-        <FilePreview file={selectedFile} onClose={handleClosePreview} />
+        <FilePreview workspaceId={workspaceId} file={selectedFile} onClose={handleClosePreview} />
       </div>
     )
   }

--- a/src/components/panel/shared/chat-input-types.ts
+++ b/src/components/panel/shared/chat-input-types.ts
@@ -8,6 +8,8 @@ export type { ModelId }
 export type ModelSelection = { model: ModelId; extendedContext: boolean }
 
 export type ChatInputConfig = {
+  defaultModel?: ModelId
+  defaultThinkingLevel?: ThinkingLevel
   showModelSelector?: boolean
   showContextToggle?: boolean
   showThinkingSelector?: boolean

--- a/src/components/panel/shared/use-chat-input-state.ts
+++ b/src/components/panel/shared/use-chat-input-state.ts
@@ -31,21 +31,37 @@ export function useChatInputState({
   const defaultPermissionMode = useSettingsStore((s) => s.global.agent.defaultPermissionMode)
 
   const [message, setMessage] = useState('')
-  const [model, setModel] = useState<ModelId>('sonnet')
+  const [model, setModel] = useState<ModelId>(config.defaultModel ?? 'sonnet')
   const [extendedContext, setExtendedContext] = useState(false)
-  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>('medium')
+  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(config.defaultThinkingLevel ?? 'medium')
   const [permissionMode, setPermissionMode] = useState<PermissionMode>(defaultPermissionMode)
   const [isDragOver, setIsDragOver] = useState(false)
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const appliedDraftInsertionIdRef = useRef<number | null>(null)
+  const appliedDefaultModelRef = useRef<ModelId>(config.defaultModel ?? 'sonnet')
+  const appliedDefaultThinkingRef = useRef<ThinkingLevel>(config.defaultThinkingLevel ?? 'medium')
 
   const { models, getCapabilities } = useModelCapabilities()
   const caps = getCapabilities(model)
   const supportsExtendedContext = caps.supportsExtendedContext
   const maxEffort = caps.maxEffort as ThinkingLevel
   const maxThinkingIdx = THINKING_LEVEL_ORDER.indexOf(maxEffort)
+
+  useEffect(() => {
+    const nextDefault = config.defaultModel
+    if (!nextDefault || nextDefault === appliedDefaultModelRef.current) return
+    setModel((current) => current === appliedDefaultModelRef.current ? nextDefault : current)
+    appliedDefaultModelRef.current = nextDefault
+  }, [config.defaultModel])
+
+  useEffect(() => {
+    const nextDefault = config.defaultThinkingLevel
+    if (!nextDefault || nextDefault === appliedDefaultThinkingRef.current) return
+    setThinkingLevel((current) => current === appliedDefaultThinkingRef.current ? nextDefault : current)
+    appliedDefaultThinkingRef.current = nextDefault
+  }, [config.defaultThinkingLevel])
 
   useEffect(() => {
     const currentIdx = THINKING_LEVEL_ORDER.indexOf(thinkingLevel)

--- a/src/components/panel/terminal-view.test.tsx
+++ b/src/components/panel/terminal-view.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, render, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { TerminalView } from './terminal-view'
 import { resizePty, ensurePtySession } from '@/lib/ipc/terminal'
 import { listen } from '@/lib/ipc'
@@ -147,7 +147,7 @@ describe('TerminalView', () => {
     render(<TerminalView taskId="task-1" workingDir="/tmp/worktree" />)
 
     await waitFor(() => {
-      expect(ensurePtySession).toHaveBeenCalledWith('task-1', '/tmp/worktree', 100, 30)
+      expect(ensurePtySession).toHaveBeenCalledWith('task-1', '/tmp/worktree', 100, 30, true)
     })
     expect(resizePty).toHaveBeenCalledWith('task-1', 100, 30)
     expect(xtermMock.instances[0]?.options).toMatchObject({
@@ -206,5 +206,22 @@ describe('TerminalView', () => {
       output(btoa('second'))
     })
     expect(term.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows an attach-only empty state instead of spawning for missing sessions', async () => {
+    vi.mocked(ensurePtySession).mockResolvedValueOnce({
+      taskId: 'task-1',
+      pid: null,
+      status: 'Missing',
+    })
+
+    render(<TerminalView taskId="task-1" workingDir="/tmp/worktree" allowSpawn={false} />)
+
+    await waitFor(() => {
+      expect(ensurePtySession).toHaveBeenCalledWith('task-1', '/tmp/worktree', 100, 30, false)
+    })
+    expect(await screen.findByText('No live terminal session')).toBeInTheDocument()
+    expect(screen.queryByText('Spawning terminal')).not.toBeInTheDocument()
+    expect(xtermMock.instances[0]?.writes).toEqual([])
   })
 })

--- a/src/components/panel/terminal-view.tsx
+++ b/src/components/panel/terminal-view.tsx
@@ -1,6 +1,6 @@
 /**
  * Terminal View — Embedded xterm.js terminal backed by a lazy PTY session.
- * On mount: ensures a PTY session exists (bare shell in working dir).
+ * On mount: attaches to a PTY session, optionally spawning a bare shell.
  * Listens for pty:{taskId}:output events and renders raw terminal output.
  * Sends user input via write_to_pty, resizes via resize_pty.
  */
@@ -23,14 +23,16 @@ import { useSettingsStore } from '@/stores/settings-store'
 type TerminalViewProps = {
   taskId: string
   workingDir: string
+  allowSpawn?: boolean
 }
 
-export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
+export function TerminalView({ taskId, workingDir, allowSpawn = true }: TerminalViewProps) {
   const terminalHostRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const shouldStickToBottomRef = useRef(true)
   const [hasOutput, setHasOutput] = useState(false)
+  const [missingSession, setMissingSession] = useState(false)
   const terminalSettings = useSettingsStore((s) => s.global.terminal)
   const fontSize = sanitizeNumber(terminalSettings.fontSize, 12, 10, 24)
   const lineHeight = lineHeightRatio(terminalSettings.lineHeight, fontSize)
@@ -42,6 +44,7 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
 
     // Reset empty-state flag when (re)mounting for a new task
     setHasOutput(false)
+    setMissingSession(false)
 
     let disposed = false
 
@@ -99,6 +102,9 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
       if (disposed) return
       try {
         fitAddon.fit()
+        if (term.rows > 0) {
+          term.refresh(0, term.rows - 1)
+        }
         if (term.cols > 0 && term.rows > 0) {
           void resizePty(taskId, term.cols, term.rows)
         }
@@ -109,7 +115,14 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
 
     const scheduleFit = (delay = 0) => {
       const run = () => {
-        requestAnimationFrame(() => {
+        if (disposed) return
+        const requestFrame = Reflect.get(window, 'requestAnimationFrame') as
+          | ((callback: FrameRequestCallback) => number)
+          | undefined
+        const raf = requestFrame ?? ((callback: FrameRequestCallback) => {
+          return window.setTimeout(() => { callback(performance.now()) }, 0)
+        })
+        raf(() => {
           if (!disposed) fitAndResize()
         })
       }
@@ -192,7 +205,8 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
           // Ensure minimum sensible dimensions
           const cols = Math.max(term.cols, 80)
           const rows = Math.max(term.rows, 24)
-          ensurePtySession(taskId, workingDir, cols, rows)
+          void resizePty(taskId, cols, rows)
+          ensurePtySession(taskId, workingDir, cols, rows, allowSpawn)
             .then((info) => {
               // Re-check `disposed` AFTER the await: a fast task-switch can
               // tear down this effect while ensure_pty_session is in flight.
@@ -201,6 +215,9 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
               // by the user as stale content during a brief window before
               // the new task's effect starts.
               if (disposed) { resolve(); return }
+              if (info.status === 'Missing') {
+                setMissingSession(true)
+              }
               // Restore cached scrollback from previous session
               if (info.scrollback) {
                 try {
@@ -219,8 +236,12 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
             })
             .catch((err: unknown) => {
               if (!disposed) {
-                const msg = err instanceof Error ? err.message : String(err)
-                term.write(`\x1b[31mFailed to start terminal: ${msg}\x1b[0m\r\n`)
+                if (allowSpawn) {
+                  const msg = err instanceof Error ? err.message : String(err)
+                  term.write(`\x1b[31mFailed to start terminal: ${msg}\x1b[0m\r\n`)
+                } else {
+                  setMissingSession(true)
+                }
               }
               resolve()
             })
@@ -231,8 +252,29 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
     // Observe container resize
     const resizeObserver = new ResizeObserver(() => {
       scheduleFit()
+      scheduleFit(120)
+      scheduleFit(320)
     })
     resizeObserver.observe(container)
+    let parent: HTMLElement | null = container.parentElement
+    while (parent) {
+      resizeObserver.observe(parent)
+      parent = parent.parentElement
+    }
+
+    const handleWindowResize = () => {
+      scheduleFit()
+      scheduleFit(150)
+    }
+    window.addEventListener('resize', handleWindowResize)
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        scheduleFit()
+        scheduleFit(150)
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 
     // Theme observer — react to data-theme changes on <html>
     const themeObserver = new MutationObserver(() => {
@@ -252,6 +294,8 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
       binaryDisposable.dispose()
       viewport?.removeEventListener('scroll', syncStickToBottom)
       viewport?.removeEventListener('wheel', handleViewportWheel)
+      window.removeEventListener('resize', handleWindowResize)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
       resizeObserver.disconnect()
       themeObserver.disconnect()
       void Promise.all(listenerPromises).then((unlisteners) => {
@@ -261,7 +305,7 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
       if (termRef.current === term) termRef.current = null
       if (fitAddonRef.current === fitAddon) fitAddonRef.current = null
     }
-  }, [fontSize, lineHeight, scrollback, taskId, workingDir])
+  }, [allowSpawn, fontSize, lineHeight, scrollback, taskId, workingDir])
 
   return (
     <div
@@ -278,8 +322,10 @@ export function TerminalView({ taskId, workingDir }: TerminalViewProps) {
           <div className="pointer-events-auto max-w-sm">
             <EmptyState
               size="md"
-              title="Spawning terminal"
-              description="A shell is starting in this task's tmux session. Output will appear here as soon as it's ready."
+              title={missingSession ? 'No live terminal session' : 'Spawning terminal'}
+              description={missingSession
+                ? 'This task does not currently have a running terminal. Start or resume the agent from Activity to create one.'
+                : "A shell is starting in this task's tmux session. Output will appear here as soon as it's ready."}
               icon={
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-full w-full">
                   <path d="M4 6h16M4 6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2M6 11l3 3-3 3M12 17h6" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/components/panel/use-orchestrator-task-refresh.ts
+++ b/src/components/panel/use-orchestrator-task-refresh.ts
@@ -1,7 +1,8 @@
 import { useEffect } from 'react'
-import { listen } from '@tauri-apps/api/event'
+import { listen } from '@/lib/ipc'
 
 type TaskEventPayload = {
+  workspace_id?: string
   workspaceId?: string
 }
 
@@ -14,23 +15,24 @@ export function useOrchestratorTaskRefresh(
 
     const setupListeners = async () => {
       const refreshIfMatches = (payload: TaskEventPayload) => {
-        if (payload.workspaceId === workspaceId) {
+        const eventWorkspaceId = payload.workspaceId ?? payload.workspace_id
+        if (eventWorkspaceId === workspaceId) {
           void refreshTasks(workspaceId)
         }
       }
 
-      const unsubTaskCreated = await listen('task:created', (event) => {
-        refreshIfMatches(event.payload as TaskEventPayload)
+      const unsubTaskCreated = await listen<TaskEventPayload>('task:created', (payload) => {
+        refreshIfMatches(payload)
       })
       unsubscribes.push(unsubTaskCreated)
 
-      const unsubTaskUpdated = await listen('task:updated', (event) => {
-        refreshIfMatches(event.payload as TaskEventPayload)
+      const unsubTaskUpdated = await listen<TaskEventPayload>('task:updated', (payload) => {
+        refreshIfMatches(payload)
       })
       unsubscribes.push(unsubTaskUpdated)
 
-      const unsubTaskDeleted = await listen('task:deleted', (event) => {
-        refreshIfMatches(event.payload as TaskEventPayload)
+      const unsubTaskDeleted = await listen<TaskEventPayload>('task:deleted', (payload) => {
+        refreshIfMatches(payload)
       })
       unsubscribes.push(unsubTaskDeleted)
     }

--- a/src/components/settings/tabs/agent-tab.tsx
+++ b/src/components/settings/tabs/agent-tab.tsx
@@ -7,16 +7,18 @@ import { SettingSection, SettingRow, SettingInput, SettingSlider } from '@/compo
 import { Dropdown } from '@/components/shared/dropdown'
 import { getModelBudgetKey } from '@/lib/usage-budget'
 
-const PROVIDER_INFO: Record<string, { name: string; description: string; cliId: string }> = {
+const PROVIDER_INFO: Record<string, { name: string; description: string; cliId: string; supportsApi: boolean }> = {
   anthropic: {
     name: 'Anthropic',
-    description: 'Claude models via CLI or API',
+    description: 'Claude models via CLI or ANTHROPIC_API_KEY',
     cliId: 'claude',
+    supportsApi: true,
   },
   openai: {
     name: 'OpenAI',
-    description: 'Codex models via CLI or API',
+    description: 'Codex models via CLI',
     cliId: 'codex',
+    supportsApi: false,
   },
 }
 
@@ -136,9 +138,10 @@ export function AgentTab() {
     // Set mode first
     updateProvider(providerId, { connectionMode: 'cli' })
 
-    // Check if we already have a path set
+    // Keep manually-entered absolute/custom paths, but verify default binary
+    // names such as "claude" or "codex" instead of treating them as detected.
     const provider = model.providers.find((p) => p.id === providerId)
-    if (provider?.cliPath) return
+    if (provider?.cliPath && provider.cliPath !== cliId) return
 
     // Check if already detected
     if (detectedClis[cliId]?.isAvailable) {
@@ -153,6 +156,8 @@ export function AgentTab() {
       setDetectedClis((prev) => ({ ...prev, [cliId]: detected }))
       if (detected.isAvailable) {
         updateProvider(providerId, { cliPath: detected.path })
+      } else {
+        updateProvider(providerId, { cliPath: undefined })
       }
     } catch (err) {
       console.error('Failed to detect CLI:', err)
@@ -185,7 +190,7 @@ export function AgentTab() {
       {/* ── 1. PROVIDERS ─────────────────────────────────────── */}
       <SettingSection
         title="Providers"
-        description="Connect AI providers via their CLI (recommended for auth) or direct API key."
+        description="Connect AI providers via their CLI. Direct API mode is available for Anthropic when ANTHROPIC_API_KEY is set in the app environment."
       >
         <div className="mb-3 flex items-center justify-between gap-3">
           <span className="text-xs text-text-secondary">
@@ -250,6 +255,15 @@ export function AgentTab() {
             const isExpanded = expanded[provider.id] && provider.enabled
             const providerModels = allModels.filter((m) => m.provider === provider.id)
             const providerModelCount = providerModels.length
+            const cliId = info.cliId
+            const supportsApi = info.supportsApi
+            const connectionMode = supportsApi ? provider.connectionMode : 'cli'
+            const detectedCli = detectedClis[cliId]
+            const isDetectedCli = Boolean(
+              provider.cliPath &&
+              detectedCli?.isAvailable &&
+              detectedCli.path === provider.cliPath,
+            )
 
             return (
               <div
@@ -327,7 +341,7 @@ export function AgentTab() {
                           onClick={() => { void handleCliModeSelect(provider.id) }}
                           disabled={detecting[provider.id]}
                           className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
-                            provider.connectionMode === 'cli'
+                            connectionMode === 'cli'
                               ? 'border-accent bg-accent/10 text-text-primary'
                               : 'border-border-default text-text-secondary hover:border-accent/50'
                           } disabled:opacity-50`}
@@ -345,35 +359,43 @@ export function AgentTab() {
                           )}
                         </button>
                         <button
-                          onClick={() => { updateProvider(provider.id, { connectionMode: 'api' }) }}
+                          onClick={() => {
+                            if (supportsApi) updateProvider(provider.id, { connectionMode: 'api' })
+                          }}
+                          disabled={!supportsApi}
                           className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
-                            provider.connectionMode === 'api'
+                            connectionMode === 'api'
                               ? 'border-accent bg-accent/10 text-text-primary'
                               : 'border-border-default text-text-secondary hover:border-accent/50'
-                          }`}
+                          } disabled:opacity-40 disabled:hover:border-border-default`}
                         >
-                          API
+                          {supportsApi ? 'API' : 'API unavailable'}
                         </button>
                       </div>
                       <p className="mt-1.5 text-[11px] text-text-secondary/80">
-                        {provider.connectionMode === 'cli'
+                        {connectionMode === 'cli'
                           ? 'Uses the installed CLI (auth and billing handled by the CLI).'
-                          : 'Direct API key. Requests bill to your provider account.'}
+                          : supportsApi
+                            ? `Uses ${provider.apiKeyEnvVar} from the app environment. Requests bill to your provider account.`
+                            : 'Direct API streaming is not wired for this provider yet; use the CLI connection.'}
                       </p>
                     </div>
 
                     {/* CLI Path */}
-                    {provider.connectionMode === 'cli' && (
+                    {connectionMode === 'cli' && (
                       <div>
                         <label className="mb-1.5 flex items-center gap-2 text-xs font-medium text-text-secondary">
                           CLI Path
-                          {provider.cliPath && (
+                          {isDetectedCli && (
                             <span className="flex items-center gap-1 text-green-500">
                               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3">
                                 <path fillRule="evenodd" d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z" clipRule="evenodd" />
                               </svg>
                               Auto-detected
                             </span>
+                          )}
+                          {provider.cliPath && !isDetectedCli && (
+                            <span className="text-text-secondary/80">Configured manually</span>
                           )}
                         </label>
                         <SettingInput
@@ -436,21 +458,14 @@ export function AgentTab() {
                     )}
 
                     {/* API Key */}
-                    {provider.connectionMode === 'api' && (
+                    {connectionMode === 'api' && supportsApi && (
                       <div>
                         <label className="mb-1.5 block text-xs font-medium text-text-secondary">
-                          API Key <span className="text-text-secondary/60">(env var: {provider.apiKeyEnvVar})</span>
+                          API Key Source
                         </label>
-                        <SettingInput
-                          value={agent.envVars[provider.apiKeyEnvVar] ?? ''}
-                          onChange={(value) => {
-                            updateAgent({
-                              envVars: { ...agent.envVars, [provider.apiKeyEnvVar]: value },
-                            })
-                          }}
-                          placeholder="sk-..."
-                          type="password"
-                        />
+                        <div className="rounded border border-border bg-bg-tertiary px-3 py-2 font-mono text-xs text-text-secondary">
+                          Environment variable required: {provider.apiKeyEnvVar}
+                        </div>
                       </div>
                     )}
 

--- a/src/components/settings/tabs/script-editor.tsx
+++ b/src/components/settings/tabs/script-editor.tsx
@@ -391,7 +391,10 @@ function StepEditor({
             />
           )}
           {step.type === 'bash' && (
-            <label className="flex cursor-pointer items-center gap-1.5 text-[11px] text-text-secondary">
+            <label
+              className="flex items-center gap-1.5 text-[11px] text-text-secondary"
+              style={{ cursor: 'pointer' }}
+            >
               <input
                 type="checkbox"
                 checked={step.continueOnError ?? false}

--- a/src/components/settings/tabs/templates-tab.tsx
+++ b/src/components/settings/tabs/templates-tab.tsx
@@ -97,7 +97,8 @@ export function TemplatesTab() {
           >
             <div className="flex items-start justify-between">
               <div
-                className="flex-1 cursor-pointer"
+                className="flex-1"
+                style={{ cursor: 'pointer' }}
                 onClick={() => { setSelectedTemplate(selectedTemplate?.id === template.id ? null : template); }}
               >
                 <div className="flex items-center gap-2">

--- a/src/components/settings/tabs/updates-tab.test.tsx
+++ b/src/components/settings/tabs/updates-tab.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UpdatesTab } from './updates-tab'
+import { checkForUpdate, getUpdateStatus } from '@/lib/ipc/updater'
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn(() => Promise.resolve('0.1.0')),
+}))
+
+vi.mock('@/lib/ipc/updater', () => ({
+  getUpdateStatus: vi.fn(),
+  checkForUpdate: vi.fn(),
+  installUpdate: vi.fn(),
+}))
+
+const mockGetUpdateStatus = vi.mocked(getUpdateStatus)
+const mockCheckForUpdate = vi.mocked(checkForUpdate)
+
+describe('UpdatesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows an explicit disabled state when updater artifacts are not configured', async () => {
+    mockGetUpdateStatus.mockResolvedValue({
+      configured: false,
+      reason: 'Application updates are disabled for this build because updater artifacts were not generated.',
+      endpointCount: 1,
+      artifactsEnabled: false,
+    })
+
+    render(<UpdatesTab />)
+
+    expect(await screen.findByText(/updater artifacts were not generated/i)).toBeInTheDocument()
+    const checkButton = screen.getByRole('button', { name: 'Check for Updates' })
+    expect(checkButton).toBeDisabled()
+
+    fireEvent.click(checkButton)
+    expect(mockCheckForUpdate).not.toHaveBeenCalled()
+  })
+
+  it('checks for updates when the build is configured', async () => {
+    mockGetUpdateStatus.mockResolvedValue({
+      configured: true,
+      reason: null,
+      endpointCount: 1,
+      artifactsEnabled: true,
+    })
+    mockCheckForUpdate.mockResolvedValue(null)
+
+    render(<UpdatesTab />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Check for Updates' })).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for Updates' }))
+
+    expect(mockCheckForUpdate).toHaveBeenCalledTimes(1)
+    expect(await screen.findByText(/latest version/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/settings/tabs/updates-tab.tsx
+++ b/src/components/settings/tabs/updates-tab.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { getVersion } from '@tauri-apps/api/app'
-import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
+import { checkForUpdate, getUpdateStatus, installUpdate, type UpdateInfo, type UpdateStatus } from '@/lib/ipc/updater'
 
 type CheckState = 'idle' | 'checking' | 'up-to-date' | 'available' | 'installing' | 'error'
 
@@ -27,12 +27,24 @@ export function UpdatesTab() {
   const [update, setUpdate] = useState<UpdateInfo | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [currentVersion, setCurrentVersion] = useState<string | null>(null)
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null)
 
   useEffect(() => {
     getVersion().then(setCurrentVersion).catch(() => { /* non-critical */ })
+    getUpdateStatus()
+      .then(setUpdateStatus)
+      .catch(() => {
+        setUpdateStatus({
+          configured: false,
+          reason: 'Application update status could not be read for this build.',
+          endpointCount: 0,
+          artifactsEnabled: false,
+        })
+      })
   }, [])
 
   const handleCheck = useCallback(() => {
+    if (updateStatus && !updateStatus.configured) return
     setState('checking')
     setError(null)
     setUpdate(null)
@@ -49,7 +61,7 @@ export function UpdatesTab() {
         setError(formatErr(err))
         setState('error')
       })
-  }, [])
+  }, [updateStatus])
 
   const handleInstall = useCallback(() => {
     setState('installing')
@@ -61,6 +73,8 @@ export function UpdatesTab() {
   }, [])
 
   const installing = state === 'installing'
+  const updatesConfigured = updateStatus?.configured ?? false
+  const checkingDisabled = state === 'checking' || state === 'installing' || !updatesConfigured
 
   return (
     <div className="space-y-6">
@@ -74,12 +88,22 @@ export function UpdatesTab() {
             </div>
             <button
               onClick={handleCheck}
-              disabled={state === 'checking' || state === 'installing'}
-              className="rounded px-3 py-1.5 text-sm font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              disabled={checkingDisabled}
+              style={{ cursor: checkingDisabled ? 'not-allowed' : undefined }}
+              className="rounded px-3 py-1.5 text-sm font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
             >
               {state === 'checking' ? 'Checking…' : 'Check for Updates'}
             </button>
           </div>
+
+          {updateStatus && !updateStatus.configured && (
+            <div className="rounded-md border border-border-default bg-surface px-3 py-2 text-sm text-text-secondary">
+              <p>{updateStatus.reason ?? 'Application updates are not configured for this build.'}</p>
+              <p className="mt-1 text-xs">
+                Release builds need updater artifacts and a signing public key before in-app updates can be checked.
+              </p>
+            </div>
+          )}
 
           {state === 'up-to-date' && (
             <div className="rounded-md border border-border-default bg-surface px-3 py-2 text-sm text-text-secondary">
@@ -101,6 +125,7 @@ export function UpdatesTab() {
                 <button
                   onClick={handleInstall}
                   disabled={installing}
+                  style={{ cursor: installing ? 'not-allowed' : undefined }}
                   className="rounded px-3 py-1.5 text-sm font-medium bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
                 >
                   {installing ? 'Installing…' : 'Install & Restart'}

--- a/src/components/settings/tabs/voice-tab.tsx
+++ b/src/components/settings/tabs/voice-tab.tsx
@@ -8,6 +8,7 @@ import {
   listWhisperModels,
   downloadWhisperModel,
   deleteWhisperModel,
+  isVoiceAvailable,
   onWhisperDownloadProgress,
   onWhisperDownloadComplete,
   type WhisperModelInfo,
@@ -134,6 +135,7 @@ export function VoiceTab() {
   const [downloadingModel, setDownloadingModel] = useState<string | null>(null)
   const [downloadProgress, setDownloadProgress] = useState<Record<string, number>>({})
   const [error, setError] = useState<string | null>(null)
+  const [voiceAvailable, setVoiceAvailable] = useState<boolean | null>(null)
 
   const updateVoice = (updates: Partial<VoiceConfig>) => {
     updateGlobal('voice', { ...voice, ...updates })
@@ -152,6 +154,9 @@ export function VoiceTab() {
   }, [])
 
   useEffect(() => {
+    isVoiceAvailable()
+      .then(setVoiceAvailable)
+      .catch(() => { setVoiceAvailable(false) })
     void loadModels()
   }, [loadModels])
 
@@ -205,17 +210,24 @@ export function VoiceTab() {
   }
 
   const hasDownloadedModel = models.some((m) => m.status === 'downloaded')
+  const voiceUnavailable = voiceAvailable === false
 
   return (
     <div className="space-y-6">
       <SettingSection title="Voice Input">
+        {voiceUnavailable && (
+          <p className="mb-3 rounded bg-yellow-500/10 px-3 py-2 text-xs text-yellow-300">
+            Voice input is not included in this build.
+          </p>
+        )}
         <SettingRow
           label="Enable voice input"
           description="Use local Whisper for speech-to-text (no API key needed)"
         >
           <Toggle
             checked={voice.enabled}
-            onChange={(checked) => { updateVoice({ enabled: checked }) }}
+            onChange={(checked) => { updateVoice({ enabled: voiceUnavailable ? false : checked }) }}
+            disabled={voiceUnavailable}
             aria-label="Enable voice input"
           />
         </SettingRow>
@@ -243,7 +255,7 @@ export function VoiceTab() {
                 model={model}
                 isSelected={voice.model === model.model}
                 onSelect={() => { updateVoice({ model: model.model as WhisperModelId }) }}
-                disabled={!voice.enabled || downloadingModel !== null}
+                disabled={voiceUnavailable || !voice.enabled || downloadingModel !== null}
                 onDownload={() => void handleDownload(model.model)}
                 onDelete={() => void handleDelete(model.model)}
                 downloadProgress={downloadProgress[model.model] ?? null}
@@ -259,7 +271,7 @@ export function VoiceTab() {
           options={LANGUAGES}
           value={voice.language}
           onChange={(value) => { updateVoice({ language: value }); }}
-          disabled={!voice.enabled}
+          disabled={voiceUnavailable || !voice.enabled}
         />
       </SettingSection>
 
@@ -268,7 +280,7 @@ export function VoiceTab() {
           value={voice.hotkey}
           onChange={(value) => { updateVoice({ hotkey: value }) }}
           placeholder="Click to record shortcut"
-          disabled={!voice.enabled}
+          disabled={voiceUnavailable || !voice.enabled}
         />
       </SettingSection>
 
@@ -280,7 +292,7 @@ export function VoiceTab() {
           <Toggle
             checked={voice.pushToTalk}
             onChange={(checked) => { updateVoice({ pushToTalk: checked }); }}
-            disabled={!voice.enabled}
+            disabled={voiceUnavailable || !voice.enabled}
             aria-label="Push-to-talk"
           />
         </SettingRow>
@@ -296,7 +308,7 @@ export function VoiceTab() {
           min={0}
           max={1}
           step={0.1}
-          disabled={!voice.enabled}
+          disabled={voiceUnavailable || !voice.enabled}
           formatValue={(v) => `${String(Math.round(v * 100))}%`}
         />
       </SettingSection>

--- a/src/components/settings/tabs/workspace-tab.tsx
+++ b/src/components/settings/tabs/workspace-tab.tsx
@@ -160,6 +160,7 @@ export function WorkspaceTab() {
                 <PathPicker
                   value={workspace.repoPath}
                   onChange={(path) => { void handleRepoPathChange(path) }}
+                  onError={(text) => { setMessage({ type: 'error', text }) }}
                   readOnly
                 />
               </div>
@@ -413,7 +414,8 @@ export function WorkspaceTab() {
                 <button
                   onClick={() => { void handleDeleteWorkspace() }}
                   disabled={isDeleting || confirmName !== workspace.name}
-                  className="rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-40"
+                  style={{ cursor: isDeleting || confirmName !== workspace.name ? 'not-allowed' : undefined }}
+                  className="rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600 disabled:opacity-40"
                 >
                   {isDeleting ? 'Deleting...' : 'Delete permanently'}
                 </button>

--- a/src/components/shared/accent-color-picker.tsx
+++ b/src/components/shared/accent-color-picker.tsx
@@ -69,7 +69,8 @@ export function AccentColorPicker({ value, onChange }: AccentColorPickerProps) {
           type="color"
           value={value}
           onChange={(e) => { onChange(e.target.value); }}
-          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+          className="absolute inset-0 h-full w-full opacity-0"
+          style={{ cursor: 'pointer' }}
         />
       </button>
     </div>

--- a/src/components/shared/dropdown.tsx
+++ b/src/components/shared/dropdown.tsx
@@ -124,7 +124,8 @@ export function Dropdown({
           isOpen
             ? 'border-accent ring-2 ring-accent/20'
             : 'border-border-default hover:border-accent/50'
-        } ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+        } ${disabled ? 'opacity-50' : ''}`}
+        style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
       >
         <span className={selected ? 'text-text-primary' : 'text-text-secondary/50'}>
           {selected?.label ?? placeholder}

--- a/src/components/shared/icon-button.tsx
+++ b/src/components/shared/icon-button.tsx
@@ -42,7 +42,8 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         onClick={onClick}
         disabled={disabled}
         aria-label={tooltip}
-        className={`flex items-center justify-center rounded transition-colors ${sizeClasses[size]} ${variantClasses[variant]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+        style={{ cursor: disabled ? 'not-allowed' : undefined }}
+        className={`flex items-center justify-center rounded transition-colors ${sizeClasses[size]} ${variantClasses[variant]} ${disabled ? 'opacity-50' : ''} ${className}`}
       >
         {icon}
       </button>

--- a/src/components/shared/labeled-slider.tsx
+++ b/src/components/shared/labeled-slider.tsx
@@ -59,7 +59,8 @@ export function LabeledSlider<T extends string>({
       <div
         ref={trackRef}
         onMouseDown={handleMouseDown}
-        className="relative h-2 cursor-pointer rounded-full bg-surface"
+        className="relative h-2 rounded-full bg-surface"
+        style={{ cursor: 'pointer' }}
       >
         {/* Fill */}
         <div

--- a/src/components/shared/model-selector.tsx
+++ b/src/components/shared/model-selector.tsx
@@ -7,7 +7,7 @@ import { useState, useCallback } from 'react'
 import { SelectorDropdown, SelectorOption, SelectorButton } from './selector-dropdown'
 import { useModelCapabilities, type ModelCapability } from '@/hooks/use-model-capabilities'
 
-export type ModelId = 'opus' | 'sonnet' | 'haiku'
+export type ModelId = string
 
 interface ModelSelectorProps {
   value: ModelId
@@ -25,7 +25,9 @@ export function ModelSelector({
   const models = modelsProp ?? dynamicModels
   const [open, setOpen] = useState(false)
 
-  const currentModel = models.find((m) => m.id === value) ?? models[1]
+  const currentModel = models.find((m) =>
+    m.id === value || m.fullId === value || m.aliases?.includes(value)
+  ) ?? models[1]
 
   const handleSelect = useCallback((modelId: ModelId) => {
     onChange(modelId)
@@ -47,7 +49,7 @@ export function ModelSelector({
           <SelectorOption
             key={model.id}
             selected={model.id === value}
-            onClick={() => { handleSelect(model.id as ModelId) }}
+            onClick={() => { handleSelect(model.id) }}
             label={model.name}
             description={model.description}
           />

--- a/src/components/shared/path-picker.tsx
+++ b/src/components/shared/path-picker.tsx
@@ -1,15 +1,17 @@
 import { useCallback } from 'react'
 import { open } from '@tauri-apps/plugin-dialog'
 import { useNativeInput } from '@/hooks/use-native-input'
+import { getErrorMessage } from '@/lib/errors'
 
 type PathPickerProps = {
   value: string
   onChange: (path: string) => void
+  onError?: (message: string) => void
   readOnly?: boolean
   placeholder?: string
 }
 
-export function PathPicker({ value, onChange, readOnly, placeholder = '/path/to/repo' }: PathPickerProps) {
+export function PathPicker({ value, onChange, onError, readOnly, placeholder = '/path/to/repo' }: PathPickerProps) {
   const { ref, handleChange } = useNativeInput(onChange)
 
   const handleBrowse = useCallback(async () => {
@@ -18,10 +20,10 @@ export function PathPicker({ value, onChange, readOnly, placeholder = '/path/to/
       if (selected) {
         onChange(selected)
       }
-    } catch {
-      // User cancelled or dialog error — ignore
+    } catch (err) {
+      onError?.(`Could not open folder picker: ${getErrorMessage(err)}`)
     }
-  }, [onChange])
+  }, [onChange, onError])
 
   return (
     <div className="flex gap-2">
@@ -38,6 +40,7 @@ export function PathPicker({ value, onChange, readOnly, placeholder = '/path/to/
       <button
         type="button"
         onClick={() => { void handleBrowse() }}
+        style={{ cursor: 'pointer' }}
         className="shrink-0 rounded-lg border border-border-default bg-bg px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-surface-hover"
       >
         Browse

--- a/src/components/shared/select.tsx
+++ b/src/components/shared/select.tsx
@@ -18,7 +18,8 @@ export function Select({ options, value, onChange, disabled, className = '', ...
         value={value}
         onChange={(e) => { onChange(e.target.value); }}
         disabled={disabled}
-        className={`w-full appearance-none rounded-lg border border-border-default bg-surface px-3 py-2 pr-10 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+        style={{ cursor: disabled ? 'not-allowed' : undefined }}
+        className={`w-full appearance-none rounded-lg border border-border-default bg-surface px-3 py-2 pr-10 text-sm text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:opacity-50 ${className}`}
         {...props}
       >
         {options.map((option) => (

--- a/src/components/shared/setting-components.tsx
+++ b/src/components/shared/setting-components.tsx
@@ -82,7 +82,8 @@ export function SettingCard({ children, active = false, onClick, className = '' 
         active
           ? 'border-accent bg-accent/5'
           : 'border-border-default hover:border-accent/50'
-      } ${onClick ? 'cursor-pointer' : ''} ${className}`}
+      } ${className}`}
+      style={onClick ? { cursor: 'pointer' } : undefined}
     >
       {children}
     </Component>
@@ -115,7 +116,8 @@ export function SettingInput({
       onChange={(e) => { onChange(e.target.value); }}
       placeholder={placeholder}
       disabled={disabled}
-      className={`w-full rounded-lg border border-border-default bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-50 ${
+      style={{ cursor: disabled ? 'not-allowed' : undefined }}
+      className={`w-full rounded-lg border border-border-default bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:opacity-50 ${
         mono ? 'font-mono' : ''
       }`}
     />
@@ -146,7 +148,8 @@ export function SettingTextarea({
       placeholder={placeholder}
       disabled={disabled}
       rows={rows}
-      className="w-full resize-none rounded-lg border border-border-default bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-secondary/50 transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-50"
+      style={{ cursor: disabled ? 'not-allowed' : undefined }}
+      className="w-full resize-none rounded-lg border border-border-default bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-secondary/50 transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:opacity-50"
     />
   )
 }
@@ -298,7 +301,8 @@ export function ShortcutRecorder({
           setPressedKeys([])
         }}
         disabled={disabled}
-        className={`flex-1 rounded-lg border px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-50 ${
+        style={{ cursor: disabled ? 'not-allowed' : undefined }}
+        className={`flex-1 rounded-lg border px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:opacity-50 ${
           isRecording
             ? 'border-accent bg-accent/10 text-accent'
             : value

--- a/src/components/shared/thinking-selector.tsx
+++ b/src/components/shared/thinking-selector.tsx
@@ -55,9 +55,10 @@ export function ThinkingSelector({ value, maxLevel, onChange }: ThinkingSelector
               type="button"
               onClick={() => { if (!disabled) handleSelect(level.id) }}
               disabled={disabled}
+              style={{ cursor: disabled ? 'not-allowed' : undefined }}
               className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
                 disabled
-                  ? 'text-text-muted/30 cursor-not-allowed'
+                  ? 'text-text-muted/30'
                   : level.id === value
                     ? 'text-accent hover:bg-surface-hover'
                     : 'text-text-secondary hover:bg-surface-hover'

--- a/src/components/shared/toggle.tsx
+++ b/src/components/shared/toggle.tsx
@@ -25,13 +25,14 @@ export function Toggle({ checked, onChange, disabled = false, size = 'sm', 'aria
       aria-labelledby={ariaLabelledby}
       disabled={disabled}
       onClick={() => { onChange(!checked); }}
-      className={`relative inline-flex shrink-0 cursor-pointer items-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:cursor-not-allowed disabled:opacity-50 ${s.track} ${
+      className={`relative inline-flex shrink-0 items-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:opacity-50 ${s.track} ${
         disabled
           ? 'border-border-default/60 bg-surface-hover/40'
           : checked
             ? 'border-accent bg-accent'
             : 'border-border-default/80 bg-surface-hover/60'
       }`}
+      style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
     >
       <motion.span
         layout

--- a/src/components/task-detail/diff-section.tsx
+++ b/src/components/task-detail/diff-section.tsx
@@ -4,6 +4,7 @@ import { DiffViewer } from '@/components/review/diff-viewer'
 
 type DiffSectionProps = {
   branch: string | null
+  referenceKind?: 'branch' | 'commit' | 'none'
   changes: ChangeSummary | null
   loading: boolean
   diffLoading: boolean
@@ -20,6 +21,7 @@ const FILE_LIST_LIMIT = 6
 
 export function DiffSection({
   branch,
+  referenceKind = branch ? 'branch' : 'none',
   changes,
   loading,
   diffLoading,
@@ -34,19 +36,27 @@ export function DiffSection({
   const [showAll, setShowAll] = useState(false)
   const [filesExpanded, setFilesExpanded] = useState(false)
 
-  // Reset selection when branch changes
+  const hasReference = referenceKind !== 'none' && Boolean(branch)
+  const referenceLabel = referenceKind === 'commit'
+    ? `commit ${branch ?? ''}`
+    : branch
+
+  // Reset selection when the comparison reference changes.
   useEffect(() => {
     setSelectedFile(null)
     setShowAll(false)
     setFilesExpanded(false)
   }, [branch])
 
-  if (!branch) {
+  if (!hasReference) {
     return (
       <div className="rounded-md border border-border-default bg-surface px-3 py-3" data-testid="changes-empty-no-branch">
-        <span className="text-xs text-text-secondary">
-          No branch on this task — create one to see diffs.
-        </span>
+        <div className="space-y-1">
+          <div className="text-xs font-medium text-text-primary">No task change reference</div>
+          <p className="text-xs leading-relaxed text-text-secondary">
+            This task has no recorded branch or committed hash in its transcript yet. Agent runs should create a task branch/worktree, or the Changes tab needs a commit hash to diff.
+          </p>
+        </div>
       </div>
     )
   }
@@ -100,12 +110,17 @@ export function DiffSection({
     <div className="rounded-md border border-border-default bg-surface" data-testid="changes-panel">
       {/* Summary header */}
       <div className={`flex items-center justify-between gap-2 border-b border-border-default ${compact ? 'px-2 py-1.5' : 'px-3 py-2'}`}>
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           <span className="text-xs font-medium text-text-primary">
             {changes.totalFiles} file{changes.totalFiles !== 1 ? 's' : ''}
           </span>
           <span className="text-xs text-success">+{changes.totalAdditions}</span>
           <span className="text-xs text-error">-{changes.totalDeletions}</span>
+          {referenceLabel && (
+            <span className="min-w-0 truncate rounded border border-border-default/70 px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
+              {referenceLabel}
+            </span>
+          )}
         </div>
         <button
           type="button"

--- a/src/components/task-detail/notification-section.tsx
+++ b/src/components/task-detail/notification-section.tsx
@@ -198,7 +198,8 @@ export function NotificationSection({
             type="button"
             onClick={() => void handleMarkNotified()}
             disabled={isLoading || stakeholderList.length === 0}
-            className="w-full rounded bg-surface-hover py-1.5 text-xs font-medium text-text-primary hover:bg-border-default disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ cursor: isLoading || stakeholderList.length === 0 ? 'not-allowed' : undefined }}
+            className="w-full rounded bg-surface-hover py-1.5 text-xs font-medium text-text-primary hover:bg-border-default disabled:opacity-50"
           >
             {stakeholderList.length === 0
               ? 'Add stakeholders to notify'

--- a/src/components/task-detail/task-checklist.tsx
+++ b/src/components/task-detail/task-checklist.tsx
@@ -211,7 +211,8 @@ export function TaskChecklist({ task, onUpdate, repoPath }: TaskChecklistProps) 
             ) : (
               <span
                 onClick={() => { handleStartEdit(item) }}
-                className={`flex-1 text-xs leading-relaxed cursor-text ${
+                style={{ cursor: 'text' }}
+                className={`flex-1 text-xs leading-relaxed ${
                   item.checked ? 'text-text-secondary line-through' : 'text-text-primary'
                 }`}
               >

--- a/src/hooks/chat-session/use-chat-session.ts
+++ b/src/hooks/chat-session/use-chat-session.ts
@@ -6,7 +6,6 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import * as ipc from '@/lib/ipc'
 import type {
   StreamChunkEvent,
@@ -17,6 +16,7 @@ import type {
   AgentThinkingEvent,
   AgentToolCallEvent,
   AgentCompleteEvent,
+  UnlistenFn,
 } from '@/lib/ipc'
 import type {
   ToolCall,
@@ -204,34 +204,34 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
           return payload.sessionId === sessionId
         }
 
-        const unlistenProcessing = await listen<OrchestratorEvent>('orchestrator:processing', (event) => {
-          if (!isCurrentOrchestratorSession(event.payload)) return
+        const unlistenProcessing = await ipc.listen<OrchestratorEvent>('orchestrator:processing', (payload) => {
+          if (!isCurrentOrchestratorSession(payload)) return
           setStreaming((prev) => ({ ...prev, isStreaming: true, startTime: Date.now() }))
           setError(null)
         })
         listeners.push(unlistenProcessing)
 
-        const unlistenStream = await listen<StreamChunkEvent>('orchestrator:stream', (event) => {
-          if (!isCurrentOrchestratorSession(event.payload)) return
-          if (event.payload.finishReason) return
-          if (event.payload.delta) {
-            setStreaming((prev) => ({ ...prev, content: prev.content + event.payload.delta }))
+        const unlistenStream = await ipc.listen<StreamChunkEvent>('orchestrator:stream', (payload) => {
+          if (!isCurrentOrchestratorSession(payload)) return
+          if (payload.finishReason) return
+          if (payload.delta) {
+            setStreaming((prev) => ({ ...prev, content: prev.content + payload.delta }))
           }
         })
         listeners.push(unlistenStream)
 
-        const unlistenThinking = await listen<ThinkingEvent>('orchestrator:thinking', (event) => {
-          if (!isCurrentOrchestratorSession(event.payload)) return
-          if (event.payload.isComplete) return
-          if (event.payload.content) {
-            setStreaming((prev) => ({ ...prev, thinkingContent: prev.thinkingContent + event.payload.content }))
+        const unlistenThinking = await ipc.listen<ThinkingEvent>('orchestrator:thinking', (payload) => {
+          if (!isCurrentOrchestratorSession(payload)) return
+          if (payload.isComplete) return
+          if (payload.content) {
+            setStreaming((prev) => ({ ...prev, thinkingContent: prev.thinkingContent + payload.content }))
           }
         })
         listeners.push(unlistenThinking)
 
-        const unlistenToolCall = await listen<ToolCallEvent>('orchestrator:tool_call', (event) => {
-          if (!isCurrentOrchestratorSession(event.payload)) return
-          const { toolId, toolName, status, input } = event.payload
+        const unlistenToolCall = await ipc.listen<ToolCallEvent>('orchestrator:tool_call', (payload) => {
+          if (!isCurrentOrchestratorSession(payload)) return
+          const { toolId, toolName, status, input } = payload
           const nextStatus = toStreamingToolCallStatus(status)
           setStreaming((prev) => {
             const existing = prev.toolCalls.find((t) => t.id === toolId)
@@ -244,16 +244,16 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         })
         listeners.push(unlistenToolCall)
 
-        const unlistenToolResult = await listen<{ workspaceId: string; sessionId: string; isError: boolean }>('orchestrator:tool_result', (event) => {
-          if (!isCurrentOrchestratorSession(event.payload)) return
-          if (!event.payload.isError) {
+        const unlistenToolResult = await ipc.listen<{ workspaceId: string; sessionId: string; isError: boolean }>('orchestrator:tool_result', (payload) => {
+          if (!isCurrentOrchestratorSession(payload)) return
+          if (!payload.isError) {
             onToolResultRef.current?.()
           }
         })
         listeners.push(unlistenToolResult)
 
-        const unlistenComplete = await listen<OrchestratorEvent>('orchestrator:complete', (event) => {
-          if (!isCurrentOrchestratorSession(event.payload)) return
+        const unlistenComplete = await ipc.listen<OrchestratorEvent>('orchestrator:complete', (payload) => {
+          if (!isCurrentOrchestratorSession(payload)) return
           isProcessingRef.current = false
           setStreaming(INITIAL_STREAMING_STATE)
           void loadMessagesRef.current().then(() => {
@@ -262,11 +262,11 @@ export function useChatSession(config: ChatSessionConfig): ChatSessionState & Ch
         })
         listeners.push(unlistenComplete)
 
-        const unlistenError = await listen<OrchestratorEvent>('orchestrator:error', (event) => {
-          if (!isCurrentOrchestratorSession(event.payload)) return
+        const unlistenError = await ipc.listen<OrchestratorEvent>('orchestrator:error', (payload) => {
+          if (!isCurrentOrchestratorSession(payload)) return
           isProcessingRef.current = false
           setStreaming(INITIAL_STREAMING_STATE)
-          setError(event.payload.message ?? 'An error occurred')
+          setError(payload.message ?? 'An error occurred')
         })
         listeners.push(unlistenError)
       }

--- a/src/hooks/use-attachments.ts
+++ b/src/hooks/use-attachments.ts
@@ -4,15 +4,13 @@
  */
 
 import { useState, useCallback } from 'react'
-import { open } from '@tauri-apps/plugin-dialog'
-import { readFile } from '@tauri-apps/plugin-fs'
+import { pickAttachmentFiles, type AttachmentFile } from '@/lib/ipc'
 import type { Attachment, AttachmentError } from '@/types'
 import {
   getAttachmentType,
   isFileSupported,
   getMaxSize,
   MAX_ATTACHMENTS,
-  SUPPORTED_EXTENSIONS,
 } from '@/types'
 
 type UseAttachmentsOptions = {
@@ -146,10 +144,10 @@ export function useAttachments(options: UseAttachmentsOptions = {}): UseAttachme
   const [isLoading, setIsLoading] = useState(false)
 
   /**
-   * Validate and process a file from Tauri (path-based)
+   * Validate and process a file selected by the backend native picker.
    */
-  const processFileFromPath = useCallback(async (path: string): Promise<Attachment | null> => {
-    const name = path.split('/').pop() || path
+  const processSelectedFile = useCallback(async (file: AttachmentFile): Promise<Attachment | null> => {
+    const { path, name } = file
     const extension = getExtension(name)
     const mimeType = inferMimeType(extension)
 
@@ -164,8 +162,7 @@ export function useAttachments(options: UseAttachmentsOptions = {}): UseAttachme
     }
 
     try {
-      // Read file data
-      const data = await readFile(path)
+      const data = file.bytes
       const size = data.length
 
       // Determine type
@@ -300,25 +297,16 @@ export function useAttachments(options: UseAttachmentsOptions = {}): UseAttachme
     try {
       setIsLoading(true)
 
-      const selected = await open({
-        multiple: true,
-        filters: [
-          {
-            name: 'Supported Files',
-            extensions: SUPPORTED_EXTENSIONS.map(e => e.slice(1)), // Remove leading dot
-          },
-        ],
-      })
+      const selected = await pickAttachmentFiles()
 
-      if (!selected) return
+      if (selected.length === 0) return
 
-      const paths = Array.isArray(selected) ? selected : [selected]
       const remaining = maxAttachments - attachments.length
-      const toProcess = paths.slice(0, remaining)
+      const toProcess = selected.slice(0, remaining)
 
       const newAttachments: Attachment[] = []
-      for (const path of toProcess) {
-        const attachment = await processFileFromPath(path)
+      for (const file of toProcess) {
+        const attachment = await processSelectedFile(file)
         if (attachment) {
           newAttachments.push(attachment)
         }
@@ -330,7 +318,7 @@ export function useAttachments(options: UseAttachmentsOptions = {}): UseAttachme
     } finally {
       setIsLoading(false)
     }
-  }, [attachments.length, maxAttachments, onError, processFileFromPath])
+  }, [attachments.length, maxAttachments, onError, processSelectedFile])
 
   /**
    * Handle paste event (images only)

--- a/src/hooks/use-chat-session.test.ts
+++ b/src/hooks/use-chat-session.test.ts
@@ -18,18 +18,13 @@ vi.mock('@/lib/ipc', () => ({
   cancelOrchestratorChat: vi.fn(),
   getChatHistory: vi.fn(),
   clearChatHistory: vi.fn(),
-}))
-
-// Mock Tauri event listen (for orchestrator mode)
-vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
 }))
 
 import * as ipc from '@/lib/ipc'
-import { listen } from '@tauri-apps/api/event'
 
 const mockIpc = vi.mocked(ipc)
-const mockListen = vi.mocked(listen)
+const mockListen = vi.mocked(ipc.listen)
 
 // Store event handlers for simulating events
 const eventHandlers: Map<string, ((event: unknown) => void)[]> = new Map()
@@ -37,7 +32,7 @@ const eventHandlers: Map<string, ((event: unknown) => void)[]> = new Map()
 function emitEvent(eventName: string, payload: unknown) {
   const handlers = eventHandlers.get(eventName) ?? []
   for (const handler of handlers) {
-    handler({ payload })
+    handler(payload)
   }
 }
 
@@ -58,7 +53,7 @@ describe('useChatSession', () => {
 
     // Capture event listeners for orchestrator mode
     mockListen.mockImplementation((eventName, handler) => {
-      const name = String(eventName)
+      const name = eventName
       const h = handler as (event: unknown) => void
       const handlers = eventHandlers.get(name) || []
       handlers.push(h)

--- a/src/hooks/use-cli-path.ts
+++ b/src/hooks/use-cli-path.ts
@@ -6,7 +6,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useSettingsStore } from '@/stores/settings-store'
-import { detectSingleCli } from '@/lib/ipc'
+import { detectSingleCli, verifyCliPath } from '@/lib/ipc'
 
 type CliPathResult = {
   cliPath: string
@@ -49,6 +49,7 @@ export function useCliPath(providerId: string = 'anthropic'): CliPathResult {
     setResolvedPath(configuredPath)
     setDetectionError(null)
     setIsDetecting(needsDetection)
+    hasDetected.current = false
   }, [configuredPath, needsDetection])
 
   useEffect(() => {
@@ -57,8 +58,37 @@ export function useCliPath(providerId: string = 'anthropic'): CliPathResult {
   }, [providerId])
 
   useEffect(() => {
-    // Only auto-detect if path is just a binary name (no slashes)
     if (configuredPath.includes('/')) {
+      if (hasDetected.current) return
+      hasDetected.current = true
+      let cancelled = false
+
+      const verifyPath = async () => {
+        try {
+          const detected = await verifyCliPath(configuredPath)
+          if (cancelled) return
+          if (!detected.isAvailable) {
+            setDetectionError(`Configured ${cliId} CLI path is not valid. Check Settings > Agents & Models.`)
+          }
+        } catch {
+          if (!cancelled) {
+            setDetectionError(`Failed to verify configured ${cliId} CLI path`)
+          }
+        } finally {
+          if (!cancelled) {
+            setIsDetecting(false)
+          }
+        }
+      }
+
+      void verifyPath()
+
+      return () => {
+        cancelled = true
+      }
+    }
+
+    if (configuredPath.trim() === '') {
       return
     }
 

--- a/src/hooks/use-git.ts
+++ b/src/hooks/use-git.ts
@@ -27,7 +27,7 @@ export type CommitInfo = {
 
 const ALL_FILES = '__all__'
 
-export function useGit(repoPath: string | null) {
+export function useGit(repoPath: string | null, baseBranch?: string) {
   const [changes, setChanges] = useState<ChangeSummary | null>(null)
   const [commits, setCommits] = useState<CommitInfo[]>([])
   const [loading, setLoading] = useState(false)
@@ -44,6 +44,7 @@ export function useGit(repoPath: string | null) {
         const result = await invoke<ChangeSummary>('get_changes', {
           repoPath,
           branch,
+          baseBranch,
         })
         setChanges(result)
       } catch {
@@ -52,7 +53,7 @@ export function useGit(repoPath: string | null) {
         setLoading(false)
       }
     },
-    [repoPath],
+    [baseBranch, repoPath],
   )
 
   const fetchCommits = useCallback(
@@ -62,19 +63,20 @@ export function useGit(repoPath: string | null) {
         const result = await invoke<CommitInfo[]>('get_commits', {
           repoPath,
           branch,
+          baseBranch,
         })
         setCommits(result)
       } catch {
         setCommits([])
       }
     },
-    [repoPath],
+    [baseBranch, repoPath],
   )
 
   const fetchDiff = useCallback(
     async (branch: string, filePath: string | null) => {
       if (!repoPath) return ''
-      const cacheKey = `${repoPath}::${branch}`
+      const cacheKey = `${repoPath}::${baseBranch ?? ''}::${branch}`
       if (diffCacheKeyRef.current !== cacheKey) {
         diffCacheKeyRef.current = cacheKey
         setDiffByFile({})
@@ -86,6 +88,65 @@ export function useGit(repoPath: string | null) {
         const result = await invoke<string>('get_diff', {
           repoPath,
           branch,
+          baseBranch,
+          filePath: filePath ?? undefined,
+        })
+        setDiffByFile((prev) => ({ ...prev, [key]: result }))
+        return result
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        setDiffError(message)
+        return ''
+      } finally {
+        setDiffLoading(false)
+      }
+    },
+    [baseBranch, repoPath],
+  )
+
+  const fetchAll = useCallback(
+    async (branch: string) => {
+      await Promise.all([fetchChanges(branch), fetchCommits(branch)])
+    },
+    [fetchChanges, fetchCommits],
+  )
+
+  const fetchCommitAll = useCallback(
+    async (commitHash: string) => {
+      if (!repoPath) return
+      try {
+        setLoading(true)
+        const [changeResult, commitResult] = await Promise.all([
+          invoke<ChangeSummary>('get_commit_changes', { repoPath, commitHash }),
+          invoke<CommitInfo>('get_commit_info', { repoPath, commitHash }),
+        ])
+        setChanges(changeResult)
+        setCommits([commitResult])
+      } catch {
+        setChanges(null)
+        setCommits([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [repoPath],
+  )
+
+  const fetchCommitDiff = useCallback(
+    async (commitHash: string, filePath: string | null) => {
+      if (!repoPath) return ''
+      const cacheKey = `${repoPath}::commit::${commitHash}`
+      if (diffCacheKeyRef.current !== cacheKey) {
+        diffCacheKeyRef.current = cacheKey
+        setDiffByFile({})
+      }
+      const key = filePath ?? ALL_FILES
+      try {
+        setDiffLoading(true)
+        setDiffError(null)
+        const result = await invoke<string>('get_commit_diff', {
+          repoPath,
+          commitHash,
           filePath: filePath ?? undefined,
         })
         setDiffByFile((prev) => ({ ...prev, [key]: result }))
@@ -101,13 +162,6 @@ export function useGit(repoPath: string | null) {
     [repoPath],
   )
 
-  const fetchAll = useCallback(
-    async (branch: string) => {
-      await Promise.all([fetchChanges(branch), fetchCommits(branch)])
-    },
-    [fetchChanges, fetchCommits],
-  )
-
   return {
     changes,
     commits,
@@ -119,5 +173,7 @@ export function useGit(repoPath: string | null) {
     fetchCommits,
     fetchDiff,
     fetchAll,
+    fetchCommitAll,
+    fetchCommitDiff,
   }
 }

--- a/src/hooks/use-model-capabilities.ts
+++ b/src/hooks/use-model-capabilities.ts
@@ -7,11 +7,13 @@
 import { useCallback, useMemo } from 'react'
 import { useModels, type ModelEntry } from './use-models'
 
-export type ModelId = 'opus' | 'sonnet' | 'haiku'
+export type ModelId = string
 
 /** Legacy capability shape used by model-selector and chat-input */
 export type ModelCapability = {
   id: string
+  fullId?: string
+  aliases?: string[]
   name: string
   description: string
   supportsExtendedContext: boolean
@@ -41,6 +43,8 @@ function toCapability(entry: ModelEntry): ModelCapability {
 
   return {
     id: entry.alias ?? entry.id,
+    fullId: entry.id,
+    aliases: entry.alias ? [entry.alias] : [],
     name: entry.displayName,
     description,
     supportsExtendedContext: entry.supportsExtendedContext,
@@ -52,6 +56,8 @@ function toCapability(entry: ModelEntry): ModelCapability {
 
 const FALLBACK: ModelCapability = {
   id: 'sonnet',
+  fullId: 'claude-sonnet-4-6-20260217',
+  aliases: ['sonnet'],
   name: 'Sonnet',
   description: 'Fast & capable',
   supportsExtendedContext: false,
@@ -70,7 +76,7 @@ export function useModelCapabilities(
 
   const getCapabilities = useCallback(
     (modelId: string): ModelCapability =>
-      models.find((m) => m.id === modelId) ?? FALLBACK,
+      models.find((m) => m.id === modelId || m.fullId === modelId || m.aliases?.includes(modelId)) ?? FALLBACK,
     [models],
   )
 

--- a/src/hooks/use-settings-sync.ts
+++ b/src/hooks/use-settings-sync.ts
@@ -21,22 +21,31 @@ export function useSettingsSync() {
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastSavedRef = useRef<string | null>(null)
+  const loadedWorkspaceRef = useRef<string | null>(null)
 
   // Load workspace settings from backend when workspace changes
   useEffect(() => {
     if (!activeWorkspaceId) return
+    loadedWorkspaceRef.current = null
+    lastSavedRef.current = null
 
     const loadSettings = async () => {
       try {
         const workspace = await getWorkspace(activeWorkspaceId)
+        const config = workspace.config || '{}'
+        lastSavedRef.current = config
         if (workspace.config && workspace.config !== '{}') {
           const parsed = JSON.parse(workspace.config) as WorkspaceSettings
           // Only update if we have actual settings
           if (Object.keys(parsed).length > 0) {
             loadWorkspaceSettings(activeWorkspaceId, parsed)
-            lastSavedRef.current = workspace.config
+          } else if (Object.keys(useSettingsStore.getState().workspaceOverrides[activeWorkspaceId] ?? {}).length > 0) {
+            loadWorkspaceSettings(activeWorkspaceId, {})
           }
+        } else if (Object.keys(useSettingsStore.getState().workspaceOverrides[activeWorkspaceId] ?? {}).length > 0) {
+          loadWorkspaceSettings(activeWorkspaceId, {})
         }
+        loadedWorkspaceRef.current = activeWorkspaceId
       } catch (error) {
         console.error('[settings-sync] Failed to load workspace settings:', error)
       }
@@ -50,7 +59,7 @@ export function useSettingsSync() {
     // Filter to only workspace-specific settings
     const workspaceSpecificSettings: WorkspaceSettings = {}
 
-    if (settings.agent) workspaceSpecificSettings.agent = settings.agent
+    if (settings.agent) workspaceSpecificSettings.agent = { ...settings.agent, envVars: {} }
     if (settings.git) workspaceSpecificSettings.git = settings.git
     if (settings.voice) workspaceSpecificSettings.voice = settings.voice
     if (settings.model) workspaceSpecificSettings.model = settings.model
@@ -74,6 +83,7 @@ export function useSettingsSync() {
   // Watch for changes and save with debounce
   useEffect(() => {
     if (!activeWorkspaceId) return
+    if (loadedWorkspaceRef.current !== activeWorkspaceId) return
 
     const currentOverrides = workspaceOverrides[activeWorkspaceId]
     if (!currentOverrides) return

--- a/src/hooks/use-task-detail.ts
+++ b/src/hooks/use-task-detail.ts
@@ -2,16 +2,24 @@
 
 import { useCallback, useEffect } from 'react'
 import type { Task } from '@/types'
+import { parseWorkspaceConfig } from '@/types'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useGit } from '@/hooks/use-git'
 
-export function useTaskDetail(task: Task) {
+type UseTaskDetailOptions = {
+  fallbackCommitHash?: string | null
+}
+
+export type ChangeReferenceKind = 'branch' | 'commit' | 'none'
+
+export function useTaskDetail(task: Task, options: UseTaskDetailOptions = {}) {
   const workspaces = useWorkspaceStore((s) => s.workspaces)
   const updateTask = useTaskStore((s) => s.updateTask)
 
   const workspace = workspaces.find((w) => w.id === task.workspaceId)
-  const repoPath = workspace?.repoPath ?? null
+  const repoPath = task.worktreePath ?? workspace?.repoPath ?? null
+  const baseBranch = workspace ? parseWorkspaceConfig(workspace.config).defaultBaseBranch : undefined
 
   const {
     changes,
@@ -22,24 +30,39 @@ export function useTaskDetail(task: Task) {
     diffError,
     fetchAll,
     fetchDiff,
-  } = useGit(repoPath)
+    fetchCommitAll,
+    fetchCommitDiff,
+  } = useGit(repoPath, baseBranch)
+
+  const fallbackCommitHash = task.branch ? null : options.fallbackCommitHash
+  const changeReference = task.branch ?? fallbackCommitHash ?? null
+  const changeReferenceKind: ChangeReferenceKind = task.branch ? 'branch' : fallbackCommitHash ? 'commit' : 'none'
 
   useEffect(() => {
     if (task.branch) {
       void fetchAll(task.branch)
+    } else if (fallbackCommitHash) {
+      void fetchCommitAll(fallbackCommitHash)
     }
-  }, [task.branch, fetchAll])
+  }, [fallbackCommitHash, fetchAll, fetchCommitAll, task.agentStatus, task.branch, task.updatedAt])
 
   const loadDiff = useCallback(
     async (filePath: string | null) => {
-      if (!task.branch) return ''
-      return fetchDiff(task.branch, filePath)
+      if (task.branch) {
+        return fetchDiff(task.branch, filePath)
+      }
+      if (fallbackCommitHash) {
+        return fetchCommitDiff(fallbackCommitHash, filePath)
+      }
+      return ''
     },
-    [task.branch, fetchDiff],
+    [fallbackCommitHash, fetchCommitDiff, fetchDiff, task.branch],
   )
 
   return {
     repoPath,
+    changeReference,
+    changeReferenceKind,
     updateTask,
     changes,
     commits,

--- a/src/hooks/use-updater.ts
+++ b/src/hooks/use-updater.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { checkForUpdate, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
+import { checkForUpdate, getUpdateStatus, installUpdate, type UpdateInfo } from '@/lib/ipc/updater'
 
 export type UseUpdaterResult = {
   pendingUpdate: UpdateInfo | null
@@ -17,7 +17,11 @@ export function useUpdater(): UseUpdaterResult {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    checkForUpdate()
+    getUpdateStatus()
+      .then((status) => {
+        if (!status.configured) return null
+        return checkForUpdate()
+      })
       .then((info) => { if (info) setPendingUpdate(info) })
       .catch(() => { /* ignore update check failures silently */ })
   }, [])

--- a/src/hooks/use-workspace-files.ts
+++ b/src/hooks/use-workspace-files.ts
@@ -11,7 +11,7 @@ export type GroupedFiles = {
   notes: FileEntry[]
 }
 
-export function useWorkspaceFiles(repoPath: string | null) {
+export function useWorkspaceFiles(workspaceId: string | null) {
   const [files, setFiles] = useState<FileEntry[]>([])
   const [groupedFiles, setGroupedFiles] = useState<GroupedFiles>({
     context: [],
@@ -22,7 +22,7 @@ export function useWorkspaceFiles(repoPath: string | null) {
   const [error, setError] = useState<string | null>(null)
 
   const fetchFiles = useCallback(async () => {
-    if (!repoPath) {
+    if (!workspaceId) {
       setFiles([])
       setGroupedFiles({ context: [], tickets: [], notes: [] })
       return
@@ -31,7 +31,7 @@ export function useWorkspaceFiles(repoPath: string | null) {
     try {
       setLoading(true)
       setError(null)
-      const result = await scanWorkspaceFiles(repoPath)
+      const result = await scanWorkspaceFiles(workspaceId)
       setFiles(result)
 
       // Group files by category
@@ -54,7 +54,7 @@ export function useWorkspaceFiles(repoPath: string | null) {
     } finally {
       setLoading(false)
     }
-  }, [repoPath])
+  }, [workspaceId])
 
   // Auto-fetch on mount and when repoPath changes
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,8 @@
 
 /* Default values (dark theme fallback) - MUST come before theme selectors */
 :root {
+  color-scheme: dark;
+
   --bg: #0D0D0D;
   --surface: #1A1A1A;
   --surface-hover: #242424;
@@ -49,6 +51,9 @@
   --error: #F87171;
   --running: #60A5FA;
   --attention: #F59E0B;
+  --scrollbar-track: #141414;
+  --scrollbar-thumb: #3A3A3A;
+  --scrollbar-thumb-hover: #4A4A4A;
 
   /* Appearance defaults */
   --base-font-size: 14px;
@@ -58,6 +63,8 @@
 }
 
 [data-theme='dark'] {
+  color-scheme: dark;
+
   --bg: #0D0D0D;
   --surface: #1A1A1A;
   --surface-hover: #242424;
@@ -70,9 +77,14 @@
   --error: #F87171;
   --running: #60A5FA;
   --attention: #F59E0B;
+  --scrollbar-track: #141414;
+  --scrollbar-thumb: #3A3A3A;
+  --scrollbar-thumb-hover: #4A4A4A;
 }
 
 [data-theme='light'] {
+  color-scheme: light;
+
   --bg: #FAFAF9;
   --surface: #FFFFFF;
   --surface-hover: #F5F5F4;
@@ -85,6 +97,9 @@
   --error: #DC2626;
   --running: #2563EB;
   --attention: #D97706;
+  --scrollbar-track: #F1F0EF;
+  --scrollbar-thumb: #C9C5C0;
+  --scrollbar-thumb-hover: #AFA9A2;
 }
 
 /* Attention pulse animation */
@@ -155,6 +170,55 @@ body,
   font-family: var(--font-sans);
   font-size: var(--base-font-size);
   line-height: 1.5;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  color-scheme: inherit;
+}
+
+select,
+option,
+optgroup {
+  background-color: var(--surface);
+  color: var(--text-primary);
+}
+
+* {
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  scrollbar-width: thin;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+  min-height: 32px;
+  border: 2px solid var(--scrollbar-track);
+  border-radius: 999px;
+  background: var(--scrollbar-thumb);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+}
+
+::-webkit-scrollbar-corner {
+  background: var(--scrollbar-track);
 }
 
 /* Card styles using appearance variables */

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -5,8 +5,9 @@
 
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- Mock data uses ?? for defensive safety with unknown runtime args */
 
-import type { Workspace, Column, Task, Label, AgentMode, AgentStatus, PipelineState } from '@/types'
+import type { Workspace, Column, Task, Label, AgentMode, AgentStatus, PipelineState, Script } from '@/types'
 import type { AgentTranscriptEvent, AgentTranscriptEventType } from '@/types/events'
+import type { ModelsCache } from '@/lib/ipc/models'
 import { DEFAULT_TRIGGERS } from '@/types/column'
 
 // Check if we're running in Tauri or in a test environment
@@ -207,6 +208,101 @@ const sampleDiffByPath: Record<string, string> = {
 const sampleCombinedDiff = Object.values(sampleDiffByPath).join('\n')
 
 let mockLabels: Label[] = []
+let mockScripts: Script[] = [
+  {
+    id: 'code-check',
+    name: 'Code Check',
+    description: 'Run type-check and linter',
+    steps: '[{"type":"bash","name":"Type check","command":"npm run type-check"},{"type":"bash","name":"Lint","command":"npm run lint"}]',
+    isBuiltIn: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 'run-tests',
+    name: 'Run Tests',
+    description: 'Run the test suite',
+    steps: '[{"type":"bash","name":"Run tests","command":"npm test"}]',
+    isBuiltIn: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 'ai-code-review',
+    name: 'AI Code Review',
+    description: 'Agent reviews the diff and suggests improvements',
+    steps: '[{"type":"agent","name":"Review code","prompt":"Review the changes on this branch. Check for bugs, security issues, and code quality.","model":"sonnet"}]',
+    isBuiltIn: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+]
+const mockModelsCache: ModelsCache = {
+  lastFetched: '',
+  source: 'built-in',
+  models: [
+    {
+      id: 'claude-opus-4-6-20260217',
+      displayName: 'Claude Opus 4.6',
+      provider: 'anthropic',
+      alias: 'opus',
+      tier: 'flagship',
+      contextWindow: 200000,
+      supportsExtendedContext: true,
+      maxOutputTokens: 32000,
+      inputCostPerM: 15,
+      outputCostPerM: 75,
+      capabilities: ['text', 'tools'],
+      isNew: false,
+      createdAt: null,
+    },
+    {
+      id: 'claude-sonnet-4-6-20260217',
+      displayName: 'Claude Sonnet 4.6',
+      provider: 'anthropic',
+      alias: 'sonnet',
+      tier: 'standard',
+      contextWindow: 200000,
+      supportsExtendedContext: true,
+      maxOutputTokens: 64000,
+      inputCostPerM: 3,
+      outputCostPerM: 15,
+      capabilities: ['text', 'tools'],
+      isNew: false,
+      createdAt: null,
+    },
+    {
+      id: 'claude-haiku-4-5-20251001',
+      displayName: 'Claude Haiku 4.5',
+      provider: 'anthropic',
+      alias: 'haiku',
+      tier: 'fast',
+      contextWindow: 200000,
+      supportsExtendedContext: false,
+      maxOutputTokens: 8192,
+      inputCostPerM: 1,
+      outputCostPerM: 5,
+      capabilities: ['text', 'tools'],
+      isNew: false,
+      createdAt: null,
+    },
+    {
+      id: 'codex-5.3',
+      displayName: 'Codex 5.3',
+      provider: 'openai',
+      alias: null,
+      tier: 'flagship',
+      contextWindow: 400000,
+      supportsExtendedContext: true,
+      maxOutputTokens: 128000,
+      inputCostPerM: null,
+      outputCostPerM: null,
+      capabilities: ['text', 'code', 'tools'],
+      isNew: false,
+      createdAt: null,
+    },
+  ],
+}
 let mockTranscriptEvents: AgentTranscriptEvent[] = sampleTranscriptEvents('task-1')
 const mockEventListeners = new Map<string, Set<(payload: unknown) => void>>()
 
@@ -325,7 +421,9 @@ const mockCommands: Record<string, CommandHandler> = {
       tabOrder: mockWorkspaces.length,
       isActive: false,
       activeTaskCount: 0,
-      config: '{}',
+      config: args?.defaultAgentCli
+        ? JSON.stringify({ defaultAgentCli: args.defaultAgentCli })
+        : '{}',
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }
@@ -358,6 +456,18 @@ const mockCommands: Record<string, CommandHandler> = {
       if (ws) ws.tabOrder = idx
     })
   },
+  scan_workspace_files: () => [],
+  read_file_content: () => '# Mock file\n\nBrowser mock mode does not read local files.',
+  create_note_file: (args) => {
+    const name = typeof args?.filename === 'string' ? args.filename : 'note.md'
+    return {
+      path: `/tmp/demo-repo/${name}`,
+      name,
+      category: 'notes',
+      modifiedAt: Date.now(),
+    }
+  },
+  pick_attachment_files: () => [],
 
   // Column commands
   list_columns: (args) => mockColumns.filter((c) => c.workspaceId === args?.workspaceId),
@@ -579,6 +689,34 @@ const mockCommands: Record<string, CommandHandler> = {
   // Settings
   get_settings: () => ({ theme: 'dark', defaultTemplate: 'standard' }),
   update_settings: () => undefined,
+  get_available_models: (args) => {
+    const provider = typeof args?.provider === 'string' ? args.provider : null
+    return {
+      ...mockModelsCache,
+      models: provider
+        ? mockModelsCache.models.filter((model) => model.provider === provider)
+        : mockModelsCache.models,
+    }
+  },
+  refresh_models: () => {
+    const refreshed = {
+      ...mockModelsCache,
+      lastFetched: new Date().toISOString(),
+      source: 'built-in',
+    } satisfies ModelsCache
+    emitMockEvent('models:updated', refreshed)
+    return refreshed
+  },
+  get_update_status: () => ({
+    configured: false,
+    reason: 'Application updates are not configured in browser mock mode.',
+    endpointCount: 0,
+    artifactsEnabled: false,
+  }),
+  check_for_update: () => null,
+  install_update: () => {
+    throw new Error('Application updates are not available in browser mock mode.')
+  },
 
   // PR creation (stub)
   create_pr: (args) => {
@@ -826,6 +964,9 @@ const mockCommands: Record<string, CommandHandler> = {
     recordCount: 0,
   }),
   get_workspace_model_usage_between: () => [],
+  get_workspace_daily_costs: () => [],
+  get_workspace_column_costs: () => [],
+  get_workspace_task_costs: () => [],
   get_task_usage_summary: () => ({
     totalInputTokens: 0,
     totalOutputTokens: 0,
@@ -833,6 +974,43 @@ const mockCommands: Record<string, CommandHandler> = {
     recordCount: 0,
   }),
   clear_workspace_usage: () => undefined,
+
+  // Script commands
+  list_scripts: () => [...mockScripts].sort((a, b) => Number(b.isBuiltIn) - Number(a.isBuiltIn) || a.name.localeCompare(b.name)),
+  get_script: (args) => {
+    const script = mockScripts.find((s) => s.id === args?.id)
+    if (!script) throw new Error('Script not found')
+    return script
+  },
+  create_script: (args) => {
+    const now = new Date().toISOString()
+    const script: Script = {
+      id: generateId('script'),
+      name: (args?.name as string) || 'New Script',
+      description: (args?.description as string) || '',
+      steps: (args?.steps as string) || '[]',
+      isBuiltIn: false,
+      createdAt: now,
+      updatedAt: now,
+    }
+    mockScripts.push(script)
+    return script
+  },
+  update_script: (args) => {
+    const script = mockScripts.find((s) => s.id === args?.id)
+    if (!script) throw new Error('Script not found')
+    if (script.isBuiltIn) throw new Error('Cannot modify built-in scripts')
+    script.name = (args?.name as string) ?? script.name
+    script.description = (args?.description as string) ?? script.description
+    script.steps = (args?.steps as string) ?? script.steps
+    script.updatedAt = new Date().toISOString()
+    return script
+  },
+  delete_script: (args) => {
+    const script = mockScripts.find((s) => s.id === args?.id)
+    if (script?.isBuiltIn) throw new Error('Cannot delete built-in scripts')
+    mockScripts = mockScripts.filter((s) => s.id !== args?.id)
+  },
 
   // Session history (stubs)
   create_snapshot: () => ({
@@ -968,6 +1146,32 @@ const mockCommands: Record<string, CommandHandler> = {
     version: null,
     isAvailable: false,
   }),
+  check_runtime_prerequisites: () => [
+    {
+      id: 'git',
+      name: 'Git',
+      required: true,
+      available: true,
+      version: 'git version mock',
+      installHint: 'Install Git from https://git-scm.com/downloads or your OS package manager.',
+    },
+    {
+      id: 'tmux',
+      name: 'tmux',
+      required: true,
+      available: true,
+      version: 'tmux mock',
+      installHint: 'Install tmux with Homebrew on macOS or your Linux package manager.',
+    },
+    {
+      id: 'gh',
+      name: 'GitHub CLI',
+      required: false,
+      available: false,
+      version: null,
+      installHint: 'Install GitHub CLI from https://cli.github.com/ for PR automation.',
+    },
+  ],
   get_cli_capabilities: () => ({
     cliId: 'claude',
     cliVersion: 'mock',

--- a/src/lib/ipc/files.ts
+++ b/src/lib/ipc/files.ts
@@ -9,18 +9,36 @@ export type FileEntry = {
   modifiedAt: number
 }
 
-export async function scanWorkspaceFiles(repoPath: string): Promise<FileEntry[]> {
-  return invoke<FileEntry[]>('scan_workspace_files', { repoPath })
+export type AttachmentFile = {
+  path: string
+  name: string
+  bytes: Uint8Array
 }
 
-export async function readFileContent(filePath: string): Promise<string> {
-  return invoke<string>('read_file_content', { filePath })
+type RawAttachmentFile = Omit<AttachmentFile, 'bytes'> & {
+  bytes: number[]
+}
+
+export async function scanWorkspaceFiles(workspaceId: string): Promise<FileEntry[]> {
+  return invoke<FileEntry[]>('scan_workspace_files', { workspaceId })
+}
+
+export async function readFileContent(workspaceId: string, filePath: string): Promise<string> {
+  return invoke<string>('read_file_content', { workspaceId, filePath })
 }
 
 export async function createNoteFile(
-  repoPath: string,
+  workspaceId: string,
   filename: string,
   content: string,
 ): Promise<FileEntry> {
-  return invoke<FileEntry>('create_note_file', { repoPath, filename, content })
+  return invoke<FileEntry>('create_note_file', { workspaceId, filename, content })
+}
+
+export async function pickAttachmentFiles(): Promise<AttachmentFile[]> {
+  const files = await invoke<RawAttachmentFile[]>('pick_attachment_files')
+  return files.map(file => ({
+    ...file,
+    bytes: new Uint8Array(file.bytes),
+  }))
 }

--- a/src/lib/ipc/git.ts
+++ b/src/lib/ipc/git.ts
@@ -46,16 +46,29 @@ export type ChangeSummary = {
   totalFiles: number
 }
 
-export async function getChanges(repoPath: string, branch: string): Promise<ChangeSummary> {
-  return invoke<ChangeSummary>('get_changes', { repoPath, branch })
+export async function getChanges(repoPath: string, branch: string, baseBranch?: string): Promise<ChangeSummary> {
+  return invoke<ChangeSummary>('get_changes', { repoPath, branch, baseBranch })
 }
 
 export async function getDiff(
   repoPath: string,
   branch: string,
+  baseBranch?: string,
   filePath?: string,
 ): Promise<string> {
-  return invoke<string>('get_diff', { repoPath, branch, filePath })
+  return invoke<string>('get_diff', { repoPath, branch, baseBranch, filePath })
+}
+
+export async function getCommitChanges(repoPath: string, commitHash: string): Promise<ChangeSummary> {
+  return invoke<ChangeSummary>('get_commit_changes', { repoPath, commitHash })
+}
+
+export async function getCommitDiff(
+  repoPath: string,
+  commitHash: string,
+  filePath?: string,
+): Promise<string> {
+  return invoke<string>('get_commit_diff', { repoPath, commitHash, filePath })
 }
 
 export type CommitInfo = {
@@ -66,8 +79,12 @@ export type CommitInfo = {
   timestamp: number
 }
 
-export async function getCommits(repoPath: string, branch: string): Promise<CommitInfo[]> {
-  return invoke<CommitInfo[]>('get_commits', { repoPath, branch })
+export async function getCommits(repoPath: string, branch: string, baseBranch?: string): Promise<CommitInfo[]> {
+  return invoke<CommitInfo[]>('get_commits', { repoPath, branch, baseBranch })
+}
+
+export async function getCommitInfo(repoPath: string, commitHash: string): Promise<CommitInfo> {
+  return invoke<CommitInfo>('get_commit_info', { repoPath, commitHash })
 }
 
 export type ConflictEntry = {
@@ -80,6 +97,6 @@ export type ConflictMatrix = {
   hasConflicts: boolean
 }
 
-export async function getConflictMatrix(repoPath: string): Promise<ConflictMatrix> {
-  return invoke<ConflictMatrix>('get_conflict_matrix', { repoPath })
+export async function getConflictMatrix(repoPath: string, baseBranch?: string): Promise<ConflictMatrix> {
+  return invoke<ConflictMatrix>('get_conflict_matrix', { repoPath, baseBranch })
 }

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -20,6 +20,7 @@ export * from './terminal'
 export * from './label'
 export * from './models'
 export * from './updater'
+export * from './system'
 
 // Re-export listen and types that consumers use directly
 export { listen, type UnlistenFn, type EventCallback } from './invoke'

--- a/src/lib/ipc/system.ts
+++ b/src/lib/ipc/system.ts
@@ -1,0 +1,14 @@
+import { invoke } from './invoke'
+
+export type RuntimePrerequisite = {
+  id: string
+  name: string
+  required: boolean
+  available: boolean
+  version: string | null
+  installHint: string
+}
+
+export async function checkRuntimePrerequisites(): Promise<RuntimePrerequisite[]> {
+  return invoke<RuntimePrerequisite[]>('check_runtime_prerequisites')
+}

--- a/src/lib/ipc/terminal.ts
+++ b/src/lib/ipc/terminal.ts
@@ -27,8 +27,9 @@ export async function ensurePtySession(
   workingDir: string,
   cols: number,
   rows: number,
+  allowSpawn = true,
 ): Promise<{ taskId: string; pid: number | null; status: string; scrollback?: string }> {
-  return invoke('ensure_pty_session', { taskId, workingDir, cols, rows })
+  return invoke('ensure_pty_session', { taskId, workingDir, cols, rows, allowSpawn })
 }
 
 export type TransportType = 'pipe' | 'pty'

--- a/src/lib/ipc/updater.ts
+++ b/src/lib/ipc/updater.ts
@@ -6,6 +6,17 @@ export type UpdateInfo = {
   date: string | null
 }
 
+export type UpdateStatus = {
+  configured: boolean
+  reason: string | null
+  endpointCount: number
+  artifactsEnabled: boolean
+}
+
+export async function getUpdateStatus(): Promise<UpdateStatus> {
+  return invoke<UpdateStatus>('get_update_status')
+}
+
 export async function checkForUpdate(): Promise<UpdateInfo | null> {
   return invoke<UpdateInfo | null>('check_for_update')
 }

--- a/src/lib/ipc/workspace.ts
+++ b/src/lib/ipc/workspace.ts
@@ -5,8 +5,22 @@ import type { Workspace } from '@/types'
 
 export const getWorkspaces = () => invoke<Workspace[]>('list_workspaces')
 
-export async function createWorkspace(name: string, repoPath: string): Promise<Workspace> {
-  return invoke<Workspace>('create_workspace', { name, repoPath })
+export type CreateWorkspaceOptions = {
+  templateId?: string
+  defaultAgentCli?: string
+}
+
+export async function createWorkspace(
+  name: string,
+  repoPath: string,
+  options: CreateWorkspaceOptions = {},
+): Promise<Workspace> {
+  return invoke<Workspace>('create_workspace', {
+    name,
+    repoPath,
+    ...(options.templateId ? { templateId: options.templateId } : {}),
+    ...(options.defaultAgentCli ? { defaultAgentCli: options.defaultAgentCli } : {}),
+  })
 }
 
 export async function getWorkspace(id: string): Promise<Workspace> {

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -54,21 +54,45 @@ type PersistedSettingsState = {
   workspaceOverrides?: SettingsState['workspaceOverrides']
 }
 
+function stripSecretEnvVars<T extends { agent?: Partial<Settings['agent']> }>(settings: T): T {
+  if (!settings.agent) return settings
+  return {
+    ...settings,
+    agent: {
+      ...settings.agent,
+      envVars: {},
+    },
+  }
+}
+
+function sanitizeWorkspaceOverrides(
+  overrides: SettingsState['workspaceOverrides'] | undefined,
+): SettingsState['workspaceOverrides'] {
+  if (!overrides) return {}
+  return Object.fromEntries(
+    Object.entries(overrides).map(([workspaceId, settings]) => [
+      workspaceId,
+      stripSecretEnvVars(settings),
+    ]),
+  )
+}
+
 function mergeSettings(settings: PersistedSettings | undefined): Settings {
+  const sanitized = stripSecretEnvVars(settings ?? {})
   return {
     ...DEFAULT_SETTINGS,
-    ...settings,
-    agent: { ...DEFAULT_SETTINGS.agent, ...settings?.agent },
-    model: { ...DEFAULT_SETTINGS.model, ...settings?.model },
-    voice: { ...DEFAULT_SETTINGS.voice, ...settings?.voice },
-    git: { ...DEFAULT_SETTINGS.git, ...settings?.git },
-    appearance: { ...DEFAULT_SETTINGS.appearance, ...settings?.appearance },
-    cards: { ...DEFAULT_SETTINGS.cards, ...settings?.cards },
-    terminal: { ...DEFAULT_SETTINGS.terminal, ...settings?.terminal },
-    panel: { ...DEFAULT_SETTINGS.panel, ...settings?.panel },
-    gestures: { ...DEFAULT_SETTINGS.gestures, ...settings?.gestures },
-    advanced: { ...DEFAULT_SETTINGS.advanced, ...settings?.advanced },
-    workspaceDefaults: { ...DEFAULT_SETTINGS.workspaceDefaults, ...settings?.workspaceDefaults },
+    ...sanitized,
+    agent: { ...DEFAULT_SETTINGS.agent, ...sanitized.agent },
+    model: { ...DEFAULT_SETTINGS.model, ...sanitized.model },
+    voice: { ...DEFAULT_SETTINGS.voice, ...sanitized.voice },
+    git: { ...DEFAULT_SETTINGS.git, ...sanitized.git },
+    appearance: { ...DEFAULT_SETTINGS.appearance, ...sanitized.appearance },
+    cards: { ...DEFAULT_SETTINGS.cards, ...sanitized.cards },
+    terminal: { ...DEFAULT_SETTINGS.terminal, ...sanitized.terminal },
+    panel: { ...DEFAULT_SETTINGS.panel, ...sanitized.panel },
+    gestures: { ...DEFAULT_SETTINGS.gestures, ...sanitized.gestures },
+    advanced: { ...DEFAULT_SETTINGS.advanced, ...sanitized.advanced },
+    workspaceDefaults: { ...DEFAULT_SETTINGS.workspaceDefaults, ...sanitized.workspaceDefaults },
   }
 }
 
@@ -152,8 +176,8 @@ export const useSettingsStore = create<SettingsState>()(
       {
         name: 'bento-settings',
         partialize: (state) => ({
-          global: state.global,
-          workspaceOverrides: state.workspaceOverrides,
+          global: stripSecretEnvVars(state.global),
+          workspaceOverrides: sanitizeWorkspaceOverrides(state.workspaceOverrides),
         }),
         merge: (persistedState, currentState) => {
           const persisted = persistedState as PersistedSettingsState | undefined
@@ -161,7 +185,7 @@ export const useSettingsStore = create<SettingsState>()(
             ...currentState,
             ...persisted,
             global: mergeSettings(persisted?.global),
-            workspaceOverrides: persisted?.workspaceOverrides ?? currentState.workspaceOverrides,
+            workspaceOverrides: sanitizeWorkspaceOverrides(persisted?.workspaceOverrides ?? currentState.workspaceOverrides),
           }
         },
       },

--- a/src/stores/workspace-store.test.ts
+++ b/src/stores/workspace-store.test.ts
@@ -52,21 +52,38 @@ describe('workspace-store', () => {
     it('should create workspace and add to store', async () => {
       vi.mocked(invoke).mockResolvedValueOnce(mockWorkspace)
 
-      await useWorkspaceStore.getState().add('New Workspace', '/new/path')
+      const created = await useWorkspaceStore.getState().add('New Workspace', '/new/path')
 
       expect(invoke).toHaveBeenCalledWith('create_workspace', {
         name: 'New Workspace',
         repoPath: '/new/path',
       })
+      expect(created).toEqual(mockWorkspace)
       expect(useWorkspaceStore.getState().workspaces).toContainEqual(mockWorkspace)
     })
 
-    it('should not auto-activate new workspace (use setActive manually)', async () => {
+    it('should pass workspace setup options to creation', async () => {
+      vi.mocked(invoke).mockResolvedValueOnce(mockWorkspace)
+
+      await useWorkspaceStore.getState().add('New Workspace', '/new/path', {
+        templateId: 'quick-fix',
+        defaultAgentCli: 'codex',
+      })
+
+      expect(invoke).toHaveBeenCalledWith('create_workspace', {
+        name: 'New Workspace',
+        repoPath: '/new/path',
+        templateId: 'quick-fix',
+        defaultAgentCli: 'codex',
+      })
+    })
+
+    it('should not auto-activate new workspace in the store itself', async () => {
       vi.mocked(invoke).mockResolvedValueOnce(mockWorkspace)
 
       await useWorkspaceStore.getState().add('New Workspace', '/new/path')
 
-      // add() doesn't set active - caller must use setActive() explicitly
+      // Callers decide whether to switch immediately after creation.
       expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
     })
   })

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import type { Workspace } from '@/types'
 import * as ipc from '@/lib/ipc'
+import type { CreateWorkspaceOptions } from '@/lib/ipc/workspace'
 
 type WorkspaceState = {
   workspaces: Workspace[]
@@ -11,7 +12,7 @@ type WorkspaceState = {
   load: () => Promise<void>
   refreshWorkspace: (id: string) => Promise<void>
   setActive: (id: string) => void
-  add: (name: string, repoPath: string) => Promise<void>
+  add: (name: string, repoPath: string, options?: CreateWorkspaceOptions) => Promise<Workspace>
   clone: (sourceId: string, newName: string) => Promise<void>
   remove: (id: string) => Promise<void>
   update: (id: string, updates: Partial<Workspace>) => Promise<void>
@@ -42,9 +43,10 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         set({ activeWorkspaceId: id })
       },
 
-      add: async (name, repoPath) => {
-        const workspace = await ipc.createWorkspace(name, repoPath)
+      add: async (name, repoPath, options) => {
+        const workspace = await ipc.createWorkspace(name, repoPath, options)
         set((s) => ({ workspaces: [...s.workspaces, workspace] }))
+        return workspace
       },
 
       clone: async (sourceId, newName) => {

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -46,6 +46,8 @@ describe('my-store', () => {
 
 Frontend tests using Playwright. Tests run against the Vite dev server with mocked Tauri APIs.
 
+This is browser coverage, not native app coverage. It is good for UI rendering, interaction, responsive layout, and deterministic mocked-data flows. It does not prove that real agents, tmux sessions, shell commands, filesystem access, updater behavior, SQLite migrations, or native WebView styling work.
+
 ```bash
 # Run E2E tests
 npm run test:e2e
@@ -81,6 +83,11 @@ npx playwright show-report
 | Keyboard shortcuts | Yes | Cmd+, etc. |
 | File system ops | Mocked | Not real filesystem |
 | Shell commands | Mocked | Not real shell |
+| Agent execution | Mocked | Use Tauri dev or WebDriverIO for real runs |
+| Terminal/tmux/PTY | No | Requires native Tauri runtime |
+| Native scrollbars/forms | Partial | Browser engine differs from app WebView |
+
+For the complete runtime matrix, see `docs/testing-and-runtime-modes.md`.
 
 ## Native E2E Tests (WebDriverIO + Tauri)
 

--- a/src/types/checklist.ts
+++ b/src/types/checklist.ts
@@ -7,6 +7,7 @@ export type DetectConfig = {
   pattern?: string      // File glob pattern or regex
   content?: string      // Content to search for (file-contains)
   command?: string      // Command to run (command-succeeds)
+  allowUnsafeCommand?: boolean // Required for command-succeeds auto-detection
 }
 
 export type ChecklistItem = {
@@ -100,7 +101,7 @@ export const BUILT_IN_CHECKLIST_TEMPLATES: ChecklistTemplate[] = [
           {
             text: 'Unit tests pass',
             detectType: 'command-succeeds',
-            detectConfig: { command: 'npm test' },
+            detectConfig: { command: 'npm test', allowUnsafeCommand: true },
           },
           { text: 'Integration tests pass' },
           { text: 'E2E tests pass' },
@@ -116,12 +117,12 @@ export const BUILT_IN_CHECKLIST_TEMPLATES: ChecklistTemplate[] = [
           {
             text: 'No lint errors or warnings',
             detectType: 'command-succeeds',
-            detectConfig: { command: 'npm run lint' },
+            detectConfig: { command: 'npm run lint', allowUnsafeCommand: true },
           },
           {
             text: 'Type checking passes',
             detectType: 'command-succeeds',
-            detectConfig: { command: 'npm run type-check' },
+            detectConfig: { command: 'npm run type-check', allowUnsafeCommand: true },
           },
           { text: 'Code reviewed and approved' },
           { text: 'No TODO/FIXME comments in production code' },

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -184,7 +184,6 @@ export const DEFAULT_SETTINGS: Settings = {
         apiKeyEnvVar: 'ANTHROPIC_API_KEY',
         enabled: true,
         connectionMode: 'cli',
-        cliPath: 'claude',
         defaultModel: 'claude-sonnet-4-6-20260217',
       },
       {
@@ -193,7 +192,6 @@ export const DEFAULT_SETTINGS: Settings = {
         apiKeyEnvVar: 'OPENAI_API_KEY',
         enabled: false,
         connectionMode: 'cli',
-        cliPath: 'codex',
         defaultModel: 'codex-5.3',
       },
     ],


### PR DESCRIPTION
## Summary

Launch-readiness audit pass picking up from Codex session
`019e44df-459a-75b1-a21d-5b4901684c67`. Five parallel audits (security,
UI/UX, release workflow, IPC, settings) drove ~6k lines of fixes across
121 files, split into 11 logical commits on this branch.

**Key fixes**

- Updater is no longer silently misconfigured: `get_update_status` reports
  pubkey/endpoint/artifact state, frontend hides the Check button on
  unsigned builds, and the release workflow refuses to build without
  `TAURI_UPDATER_PUBKEY` (`REQUIRE_TAURI_UPDATER_PUBKEY=1`).
- IPC trust boundaries tightened: `verify_cli_path` checks binary name +
  exec bit before invoking, `files.rs` enforces canonical-workspace
  containment on every path, `validate_agent_cli_path` allowlist on
  `pipeline/triggers.rs` closes the stored-trigger shell-injection path.
- Secrets no longer persisted: Zustand `partialize` strips
  `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` out of `localStorage`.
- CSP tightened (drop `unsafe-eval`, restrict `default-src`), dropped
  unused `tauri-plugin-shell` and `tauri-plugin-fs`.
- Move-to context-menu submenu now has a real `onClick` + keyboard
  support (was hover-only — broken for keyboard / touch).
- Release workflow gains version + signing-secret preflight and
  Apple notarization key materialization.

**Other notable work**

- Template-driven workspace setup with base-branch auto-detect.
- Per-commit changes/diff/info IPC for the agent-panel Changes view.
- Runtime prerequisite probe + attachments dialog (replacing the
  removed `tauri-plugin-fs` flow).
- WKWebView-safe cursor styles across shared/kanban/settings components.
- pnpm-only CI, IPC registration check (`pnpm test:ipc`), `pnpm audit`,
  transitive dep pinning for advisories.

**Commit map**

1. `chore(ci):` pnpm migration + IPC registration check + dep pinning
2. `chore(release):` version + signing-secret preflight + notarization
3. `chore(tauri):` drop shell/fs plugins, tighten CSP, bundle metadata
4. `fix(updater):` pubkey gating + hide UI on unsigned builds
5. `fix(security):` IPC path / CLI allowlist / secret scrubbing
6. `feat(workspace):` template columns + repo validation + base branch
7. `feat(git):` per-commit changes/diff/info IPC + panel Changes view
8. `feat(agent):` runtime telemetry + auto-commit hash + panel polish
9. `feat(prereqs):` system check + attachments + browser mocks + misc
10. `style:` WKWebView cursor + Move-to keyboard + honest agent-tab
11. `docs:` README/CLAUDE/PRODUCT + testing-and-runtime-modes

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run test:ipc`
- [x] `pnpm run test:run` (45 files / 394 tests)
- [x] `cargo fmt --check`
- [x] `cargo check --workspace`
- [x] `pnpm build`
- [x] `pnpm tauri build --bundles deb,appimage` (artifacts in `target/release/bundle/`)
- [ ] macOS signed/notarized `.app`/`.dmg` — needs release workflow on tag
- [ ] Walk through Settings → Updates on an unsigned build, confirm the
      "not configured" panel renders and Check button is disabled
- [ ] Open task context-menu via keyboard, confirm Move-to opens with
      ArrowRight and closes with Escape