### PR TITLE
Launch-readiness follow-ups: change-tracker totals, CSP, .p8 write, commit-hash inference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,8 +181,11 @@ jobs:
             echo "APPLE_API_KEY_PATH=$APPLE_API_KEY_PATH_SECRET" >> "$GITHUB_ENV"
           elif [[ -n "$APPLE_API_KEY_P8" ]]; then
             KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
-            printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
-            chmod 600 "$KEY_PATH"
+            # umask 077 so the file is born 0600 — closes the race window
+            # between write and chmod. printf '%s\n' restores the trailing
+            # newline GitHub Actions secrets strip; strict PEM parsers and
+            # some notarytool versions reject a key without it.
+            ( umask 077 && printf '%s\n' "$APPLE_API_KEY_P8" > "$KEY_PATH" )
             echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
           fi
 

--- a/index.html
+++ b/index.html
@@ -4,19 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KaitenCode</title>
-    <script>
-      // Apply theme immediately to prevent flash
-      (function() {
-        const stored = localStorage.getItem('bento-theme-preference');
-        let theme = 'dark';
-        if (stored === 'light') {
-          theme = 'light';
-        } else if (stored === 'system' || !stored) {
-          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
-        document.documentElement.dataset.theme = theme;
-      })();
-    </script>
+    <!-- Theme preload lives in /public so the bundled-app CSP
+         (script-src 'self') can serve it without an unsafe-inline relax. -->
+    <script src="/theme-preload.js"></script>
     <style>
       /* Minimal reset - only what's needed before React loads */
       html, body, #root { margin: 0; padding: 0; height: 100%; }

--- a/public/theme-preload.js
+++ b/public/theme-preload.js
@@ -1,0 +1,23 @@
+// Applies the persisted theme before React mounts to avoid a light/dark
+// flash on cold start. Lives in /public so Vite serves it at /theme-preload.js
+// from the same origin as the document, which satisfies the bundled-app CSP
+// (script-src 'self'). Keep this file dependency-free; it runs as a classic
+// script before any module code.
+(function () {
+  var stored = null;
+  try {
+    stored = localStorage.getItem('bento-theme-preference');
+  } catch (_) {
+    // localStorage may be unavailable (private mode, SSR, etc.); fall through.
+  }
+  var theme = 'dark';
+  if (stored === 'light') {
+    theme = 'light';
+  } else if (stored === 'system' || !stored) {
+    theme =
+      window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+  }
+  document.documentElement.dataset.theme = theme;
+})();

--- a/src-tauri/src/git/change_tracker.rs
+++ b/src-tauri/src/git/change_tracker.rs
@@ -229,20 +229,21 @@ pub fn get_changes(
     let branch_diff = get_branch_diff(&repo, branch, base_branch, None)?;
     let workdir_diff = get_workdir_diff(&repo, branch, None)?;
 
-    let branch_stats = branch_diff.stats().map_err(|e| e.to_string())?;
-    let mut total_additions = branch_stats.insertions();
-    let mut total_deletions = branch_stats.deletions();
-
     let mut files = Vec::new();
     let mut seen_paths = HashSet::new();
     collect_file_changes(&branch_diff, &mut files, &mut seen_paths);
 
     if let Some(workdir_diff) = workdir_diff {
-        let workdir_stats = workdir_diff.stats().map_err(|e| e.to_string())?;
-        total_additions += workdir_stats.insertions();
-        total_deletions += workdir_stats.deletions();
         collect_file_changes(&workdir_diff, &mut files, &mut seen_paths);
     }
+
+    // Derive totals from the per-file list rather than summing branch+workdir
+    // diff stats independently: when a file is touched in BOTH the branch
+    // diff and the dirty worktree, the file entry is deduped via seen_paths,
+    // so summing both stats would double-count it and produce a header that
+    // disagreed with the listed file rows.
+    let total_additions: usize = files.iter().map(|f| f.additions).sum();
+    let total_deletions: usize = files.iter().map(|f| f.deletions).sum();
 
     Ok(ChangeSummary {
         total_additions,

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -341,13 +341,21 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
 }
 
 function inferLatestCommitHash(events: AgentTranscriptEvent[]): string | null {
+  // Pull the hash from event metadata that the auto-commit safety net emits
+  // (see bridge.rs / commands/agent.rs auto_commit_completed_worktree:
+  // `{ "source": "auto_commit", "commit": "<sha>" }`). Reading from metadata
+  // is robust; the previous regex over event.content grabbed any 7+ char
+  // hex run — including UUID fragments, content-hash digests, and tokens —
+  // and fed those to get_commit_changes as a synthetic ref.
   for (let i = events.length - 1; i >= 0; i--) {
-    const content = events[i]?.content
-    if (!content) continue
-    const matches = Array.from(content.matchAll(/\b[0-9a-f]{7,40}\b/gi))
-      .map((match) => match[0])
-      .filter((hash) => !/^[0-9]+$/.test(hash))
-    if (matches.length > 0) return matches[matches.length - 1] ?? null
+    const event = events[i]
+    if (!event) continue
+    const metadata = parseEventMetadata(event.metadataJson)
+    if (metadata.source !== 'auto_commit') continue
+    const commit = metadata.commit
+    if (typeof commit === 'string' && /^[0-9a-f]{7,40}$/i.test(commit)) {
+      return commit
+    }
   }
   return null
 }


### PR DESCRIPTION
## Summary

Four follow-up fixes surfaced by the code review on #208. Each
addresses a medium-severity finding that didn't block merge but is
worth landing before the next release.

- `fix(git):` `get_changes` derived totals from the deduped per-file
  list instead of summing branch + workdir stats independently.
  Header and row sums now agree when a file is touched in both.
- `fix(agent-panel):` auto-commit hash read from event metadata
  (`{ "source": "auto_commit", "commit": ... }`) instead of grepping
  arbitrary transcript content with `/\b[0-9a-f]{7,40}\b/gi`. No more
  false-positive Changes views on UUID fragments or token prefixes.
- `chore(release):` `.p8` written with `umask 077` (no 0644 window)
  and trailing newline restored — strict PEM parsers reject a key
  without one.
- `fix(csp):` inline `<script>` theme preload extracted to
  `public/theme-preload.js`, so the bundled-app CSP
  (`script-src 'self'`) no longer blocks it.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (465 + 17 tests pass)
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run test:ipc`
- [ ] Cold-launch the production build, confirm theme preload still
      runs (no light/dark flash on saved 'light' preference)
- [ ] Trigger an auto-commit (worktree dirty after agent exit 0),
      confirm the Changes panel renders the hash from metadata and
      that the totals match the per-file sum