### PR TITLE
Front 3 — unify the agent-spawn path

### DIFF
--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -258,7 +258,11 @@ fn get_tools() -> Vec<Value> {
                     "title": { "type": "string" },
                     "description": { "type": "string" },
                     "column": { "type": "string", "description": "Column name (default: first column)" },
-                    "model": { "type": "string", "description": "AI model (opus, sonnet, haiku)" }
+                    "model": { "type": "string", "description": "AI model (opus, sonnet, haiku)" },
+                    "trigger_prompt": { "type": "string", "description": "Override prompt sent to the agent when the task's column trigger fires" },
+                    "dependencies": { "type": "string", "description": "JSON array of task IDs this task depends on; non-empty marks the task blocked until they complete" },
+                    "priority": { "type": "string", "description": "Task priority (low, medium, high). Default: medium" },
+                    "runtime_mode": { "type": "string", "description": "Agent runtime mode override (terminal, managed, interactive)" }
                 },
                 "required": ["title"]
             }),
@@ -277,13 +281,15 @@ fn get_tools() -> Vec<Value> {
         ),
         tool(
             "update_task",
-            "Update task title or description",
+            "Update a task's title, description, priority, or model",
             json!({
                 "type": "object",
                 "properties": {
                     "task": { "type": "string", "description": "Task title or ID" },
                     "title": { "type": "string" },
-                    "description": { "type": "string" }
+                    "description": { "type": "string" },
+                    "priority": { "type": "string", "description": "Task priority (low, medium, high)" },
+                    "model": { "type": "string", "description": "AI model (opus, sonnet, haiku)" }
                 },
                 "required": ["task"]
             }),
@@ -898,6 +904,9 @@ fn handle_create_task(conn: &Connection, args: &Value) -> Value {
 
     let model = args.get("model").and_then(|v| v.as_str());
     let trigger_prompt = args.get("trigger_prompt").and_then(|v| v.as_str());
+    let dependencies = args.get("dependencies").and_then(|v| v.as_str());
+    let priority = args.get("priority").and_then(|v| v.as_str());
+    let runtime_mode = args.get("runtime_mode").and_then(|v| v.as_str());
 
     // Route through app API (triggers pipeline + updates UI)
     if let Some(resp) = api_call(
@@ -909,6 +918,9 @@ fn handle_create_task(conn: &Connection, args: &Value) -> Value {
             "description": description,
             "model": model,
             "trigger_prompt": trigger_prompt,
+            "dependencies": dependencies,
+            "priority": priority,
+            "runtime_mode": runtime_mode,
         }),
     ) {
         if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
@@ -1023,11 +1035,51 @@ fn handle_update_task(conn: &Connection, args: &Value) -> Value {
 
     let new_title = args.get("title").and_then(|v| v.as_str());
     let new_desc = args.get("description").and_then(|v| v.as_str());
+    let new_priority = args.get("priority").and_then(|v| v.as_str());
+    let new_model = args.get("model").and_then(|v| v.as_str());
 
-    if new_title.is_none() && new_desc.is_none() {
-        return json!({ "error": "Nothing to update — provide title or description" });
+    if new_title.is_none()
+        && new_desc.is_none()
+        && new_priority.is_none()
+        && new_model.is_none()
+    {
+        return json!({ "error": "Nothing to update — provide title, description, priority, or model" });
     }
 
+    // Route through app API so tasks:changed fires and the UI refreshes.
+    let mut body = serde_json::Map::new();
+    body.insert("task_id".into(), json!(task_id));
+    if let Some(t) = new_title {
+        body.insert("title".into(), json!(t));
+    }
+    if let Some(d) = new_desc {
+        body.insert("description".into(), json!(d));
+    }
+    if let Some(p) = new_priority {
+        body.insert("priority".into(), json!(p));
+    }
+    if let Some(m) = new_model {
+        body.insert("model".into(), json!(m));
+    }
+
+    if let Some(resp) = api_call("/api/update_task", &Value::Object(body)) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "task_id": task_id,
+                "title": new_title.unwrap_or(task["title"].as_str().unwrap_or("")),
+                "message": "Task updated"
+            });
+        }
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
     let ts = now();
     let mut updates = Vec::new();
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
@@ -1039,6 +1091,14 @@ fn handle_update_task(conn: &Connection, args: &Value) -> Value {
     if let Some(d) = new_desc {
         updates.push(format!("description = ?{}", param_values.len() + 1));
         param_values.push(Box::new(d.to_string()));
+    }
+    if let Some(p) = new_priority {
+        updates.push(format!("priority = ?{}", param_values.len() + 1));
+        param_values.push(Box::new(p.to_string()));
+    }
+    if let Some(m) = new_model {
+        updates.push(format!("model = ?{}", param_values.len() + 1));
+        param_values.push(Box::new(m.to_string()));
     }
     updates.push(format!("updated_at = ?{}", param_values.len() + 1));
     param_values.push(Box::new(ts));
@@ -1152,8 +1212,9 @@ fn handle_reject_task(conn: &Connection, args: &Value) -> Value {
     let task_id = task["id"].as_str().unwrap();
     let reason = args.get("reason").and_then(|v| v.as_str()).unwrap_or("");
 
-    // Route through app API (updates UI)
-    if let Some(resp) = api_call("/api/reject_task", &json!({"id": task_id})) {
+    // Route through app API (updates UI). Pass the reason so it's persisted as
+    // pipeline_error consistently whether the app is up or we fall back to DB.
+    if let Some(resp) = api_call("/api/reject_task", &json!({"id": task_id, "reason": reason})) {
         if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
             return json!({
                 "task_id": task_id, "title": task["title"], "review_status": "rejected",
@@ -1216,9 +1277,40 @@ fn handle_add_dependency(conn: &Connection, args: &Value) -> Value {
     }));
 
     let deps_json = serde_json::to_string(&deps).unwrap();
-    let ts = now();
-    let blocked = 1; // Has dependencies, so blocked
 
+    // Route through app API: runs cycle validation + emits tasks:changed.
+    if let Some(resp) = api_call(
+        "/api/set_dependencies",
+        &json!({"task_id": task_id, "dependencies": deps_json}),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "task_id": task_id,
+                "title": task["title"],
+                "depends_on": dep_task["title"],
+                "condition": condition,
+                "blocked": true,
+                "message": format!(
+                    "'{}' now depends on '{}' ({})",
+                    task["title"].as_str().unwrap_or("?"),
+                    dep_task["title"].as_str().unwrap_or("?"),
+                    condition
+                )
+            });
+        }
+        // API reachable but rejected (e.g. would create a cycle): surface it.
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
+    let ts = now();
+    let blocked = 1;
     match conn.execute(
         "UPDATE tasks SET dependencies = ?1, blocked = ?2, updated_at = ?3 WHERE id = ?4",
         params![deps_json, blocked, ts, task_id],
@@ -1274,8 +1366,36 @@ fn handle_remove_dependency(conn: &Connection, args: &Value) -> Value {
 
     let deps_json = serde_json::to_string(&deps).unwrap();
     let blocked = if deps.is_empty() { 0 } else { 1 };
-    let ts = now();
 
+    // Route through app API: emits tasks:changed (and re-validates).
+    if let Some(resp) = api_call(
+        "/api/set_dependencies",
+        &json!({"task_id": task_id, "dependencies": deps_json}),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "task_id": task_id,
+                "title": task["title"],
+                "removed": dep_task["title"],
+                "blocked": blocked != 0,
+                "message": format!(
+                    "Removed dependency '{}' from '{}'",
+                    dep_task["title"].as_str().unwrap_or("?"),
+                    task["title"].as_str().unwrap_or("?")
+                )
+            });
+        }
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
+    let ts = now();
     match conn.execute(
         "UPDATE tasks SET dependencies = ?1, blocked = ?2, updated_at = ?3 WHERE id = ?4",
         params![deps_json, blocked, ts, task_id],
@@ -1313,10 +1433,33 @@ fn handle_mark_complete(conn: &Connection, args: &Value) -> Value {
         Err(e) => return json!({ "error": e }),
     };
     let task_id = task["id"].as_str().unwrap();
+
+    // Route through app API: runs the real completion engine (timing, dependents,
+    // auto-advance, telemetry) and emits tasks:changed so the UI refreshes.
+    if let Some(resp) = api_call(
+        "/api/mark_complete",
+        &json!({"task_id": task_id, "success": success}),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "task_id": task_id,
+                "title": task["title"],
+                "message": format!(
+                    "Marked '{}' as {}",
+                    task["title"].as_str().unwrap_or("?"),
+                    if success { "complete" } else { "failed" }
+                )
+            });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
     let ts = now();
-
     let new_state = if success { "completed" } else { "failed" };
-
     match conn.execute(
         "UPDATE tasks SET pipeline_state = ?1, updated_at = ?2 WHERE id = ?3",
         params![new_state, ts, task_id],
@@ -1440,16 +1583,44 @@ fn handle_create_workspace(conn: &Connection, args: &Value) -> Value {
         None => return json!({ "error": "repo_path is required" }),
     };
 
+    let template_id = args.get("template_id").and_then(|v| v.as_str());
+    let default_agent_cli = args.get("default_agent_cli").and_then(|v| v.as_str());
+
+    // Route through app API so the workspace is created with the same config +
+    // template columns as the UI, and an entities:changed event refreshes it.
+    if let Some(resp) = api_call(
+        "/api/create_workspace",
+        &json!({
+            "name": name,
+            "repo_path": repo_path,
+            "template_id": template_id,
+            "default_agent_cli": default_agent_cli,
+        }),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "message": format!("Created workspace '{}'", name),
+                "workspace": resp.get("data"),
+            });
+        }
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write with hardcoded default columns.
     let id = Uuid::new_v4().to_string();
     let ts = now();
-
     match conn.execute(
         "INSERT INTO workspaces (id, name, repo_path, tab_order, is_active, config, created_at, updated_at) \
          VALUES (?1, ?2, ?3, 0, 1, '{}', ?4, ?5)",
         params![id, name, repo_path, ts, ts],
     ) {
         Ok(_) => {
-            // Create default columns
             let columns = ["Backlog", "Working", "Review", "Done"];
             for (i, col_name) in columns.iter().enumerate() {
                 let col_id = Uuid::new_v4().to_string();
@@ -1462,12 +1633,7 @@ fn handle_create_workspace(conn: &Connection, args: &Value) -> Value {
             checkpoint_wal(conn);
             json!({
                 "message": format!("Created workspace '{}' with 4 columns", name),
-                "workspace": {
-                    "id": id,
-                    "name": name,
-                    "repo_path": repo_path,
-                    "columns": columns
-                }
+                "workspace": { "id": id, "name": name, "repo_path": repo_path, "columns": columns }
             })
         }
         Err(e) => json!({ "error": e.to_string() }),
@@ -1510,9 +1676,29 @@ fn handle_create_column(conn: &Connection, args: &Value) -> Value {
             .unwrap_or(0)
         });
 
+    // Route through app API (same db CRUD + entities:changed event).
+    if let Some(resp) = api_call(
+        "/api/create_column",
+        &json!({ "workspace_id": workspace_id, "name": name, "position": position }),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "message": format!("Created column '{}' at position {}", name, position),
+                "column": resp.get("data"),
+            });
+        }
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
     let id = Uuid::new_v4().to_string();
     let ts = now();
-
     match conn.execute(
         "INSERT INTO columns (id, workspace_id, name, icon, position, visible, created_at, updated_at) \
          VALUES (?1, ?2, ?3, 'list', ?4, 1, ?5, ?6)",
@@ -1592,6 +1778,28 @@ fn handle_configure_triggers(conn: &Connection, args: &Value) -> Value {
         Err(e) => return json!({ "error": e }),
     };
 
+    // Route through app API: canonical ColumnTriggersV2 validation + entities:changed.
+    if let Some(resp) = api_call(
+        "/api/configure_triggers",
+        &json!({ "column_id": col_id, "triggers": triggers }),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "message": format!("Configured triggers for column '{}'", col_name),
+                "column": col_name,
+                "triggers": serde_json::from_str::<Value>(triggers).unwrap_or(Value::Null)
+            });
+        }
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
     let ts = now();
     match conn.execute(
         "UPDATE columns SET triggers = ?1, updated_at = ?2 WHERE id = ?3",
@@ -1677,6 +1885,33 @@ fn handle_create_script(conn: &Connection, args: &Value) -> Value {
         Err(e) => return json!({ "error": format!("Invalid steps JSON: {}", e) }),
     };
 
+    // Route through app API (same db CRUD + entities:changed event).
+    if let Some(resp) = api_call(
+        "/api/create_script",
+        &json!({ "name": name, "description": description, "steps": steps }),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            let created_id = resp
+                .get("data")
+                .and_then(|d| d.get("id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            return json!({
+                "message": format!("Created script '{}'", name),
+                "id": created_id,
+                "name": name,
+            });
+        }
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
     let id = new_id();
     let ts = now();
     match conn.execute(
@@ -1784,11 +2019,34 @@ fn handle_run_script(conn: &Connection, args: &Value) -> Value {
             json!({ "type": "run_script", "script_id": script_id }),
         );
     }
+    let triggers_str = triggers.to_string();
 
+    // Route through app API: validates the merged triggers + entities:changed.
+    if let Some(resp) = api_call(
+        "/api/configure_triggers",
+        &json!({ "column_id": col_id, "triggers": triggers_str }),
+    ) {
+        if resp.get("success").and_then(|v| v.as_bool()) == Some(true) {
+            return json!({
+                "message": format!("Column '{}' will now run script '{}' on entry", col_name, script_name),
+                "column": col_name,
+                "script": script_name,
+            });
+        }
+        if let Some(err) = resp.get("error") {
+            return json!({ "error": err.clone() });
+        }
+    }
+
+    if !allow_db_fallback() {
+        return json!({ "error": "Failed to reach app API — is the app running?" });
+    }
+
+    // Test-only fallback: direct DB write.
     let ts = now();
     match conn.execute(
         "UPDATE columns SET triggers = ?1, updated_at = ?2 WHERE id = ?3",
-        params![triggers.to_string(), ts, col_id],
+        params![triggers_str, ts, col_id],
     ) {
         Ok(_) => json!({
             "message": format!("Column '{}' will now run script '{}' on entry", col_name, script_name),

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -106,91 +106,11 @@ async fn move_task(
     AxumState(api): AxumState<Arc<ApiState>>,
     Json(req): Json<MoveTaskReq>,
 ) -> impl IntoResponse {
-    // Phase 1: DB updates (hold lock briefly)
-    let (task, task_before, old_column_id, column_changed) = {
-        let conn = get_db!(api);
-
-        let task_before = match db::get_task(&conn, &req.id) {
-            Ok(t) => t,
-            Err(e) => return err_response(StatusCode::NOT_FOUND, e.to_string()).into_response(),
-        };
-
-        let old_column_id = task_before.column_id.clone();
-        let column_changed = old_column_id != req.target_column_id;
-
-        let ts = db::now();
-        if column_changed {
-            let _ = conn.execute(
-                "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
-                rusqlite::params![req.target_column_id, req.position, ts, req.id],
-            );
-        } else {
-            let _ = conn.execute(
-                "UPDATE tasks SET column_id = ?1, position = ?2, updated_at = ?3 WHERE id = ?4",
-                rusqlite::params![req.target_column_id, req.position, ts, req.id],
-            );
-        }
-
-        let task = match db::get_task(&conn, &req.id) {
-            Ok(t) => t,
-            Err(e) => {
-                return err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-                    .into_response()
-            }
-        };
-
-        (task, task_before, old_column_id, column_changed)
-    }; // DB lock released
-
-    // Phase 2: Pipeline triggers (may spawn async tasks)
-    if column_changed {
-        let conn = get_db!(api);
-        let old_column = db::get_column(&conn, &old_column_id).ok();
-        let target_column = db::get_column(&conn, &req.target_column_id).ok();
-
-        // Cancel running agent if task is leaving its column AND target has no spawn_cli trigger.
-        // If target also has a trigger, the new trigger replaces the old agent — no need to cancel.
-        if task_before.agent_status.as_deref() == Some("running") {
-            let target_has_trigger = target_column
-                .as_ref()
-                .and_then(|c| c.triggers.as_deref())
-                .map(|t| t.contains("spawn_cli"))
-                .unwrap_or(false);
-
-            if !target_has_trigger {
-                eprintln!(
-                    "[api] Task {} leaving to non-trigger column — cancelling agent",
-                    req.id
-                );
-                crate::chat::tmux_transport::cancel_task_agent(
-                    &conn,
-                    &req.id,
-                    task_before.agent_session_id.as_deref(),
-                );
-            }
-        }
-
-        if let (Some(ref old_col), Some(ref tgt_col)) = (&old_column, &target_column) {
-            let _ = pipeline::triggers::fire_on_exit(
-                &conn,
-                &api.app,
-                &task_before,
-                old_col,
-                Some(tgt_col),
-            );
-        }
-
-        pipeline::emit_tasks_changed(&api.app, &task.workspace_id, "api_task_moved");
-
-        if let Some(ref tgt_col) = target_column {
-            let _ = pipeline::fire_trigger(&conn, &api.app, &task, tgt_col);
-        }
-
-        let task = db::get_task(&conn, &req.id).unwrap_or(task);
-        return ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response();
+    let conn = get_db!(api);
+    match pipeline::move_task_service(&conn, &api.app, &req.id, &req.target_column_id, req.position) {
+        Ok(task) => ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response(),
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
-
-    ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response()
 }
 
 #[derive(Deserialize)]
@@ -201,6 +121,9 @@ struct CreateTaskReq {
     description: Option<String>,
     trigger_prompt: Option<String>,
     model: Option<String>,
+    dependencies: Option<String>,
+    priority: Option<String>,
+    runtime_mode: Option<String>,
 }
 
 async fn create_task(
@@ -209,45 +132,25 @@ async fn create_task(
 ) -> impl IntoResponse {
     let conn = get_db!(api);
 
-    let task = match db::insert_task(
+    match pipeline::create_task_service(
         &conn,
-        &req.workspace_id,
-        &req.column_id,
-        req.title.trim(),
-        req.description.as_deref(),
+        &api.app,
+        &db::NewTask {
+            workspace_id: &req.workspace_id,
+            column_id: &req.column_id,
+            title: req.title.trim(),
+            description: req.description.as_deref(),
+            model: req.model.as_deref(),
+            trigger_prompt: req.trigger_prompt.as_deref(),
+            dependencies: req.dependencies.as_deref(),
+            priority: req.priority.as_deref(),
+            runtime_mode_override: req.runtime_mode.as_deref(),
+        },
+        true,
     ) {
-        Ok(t) => t,
-        Err(e) => {
-            return err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-        }
-    };
-
-    if let Some(ref prompt) = req.trigger_prompt {
-        let ts = db::now();
-        let _ = conn.execute(
-            "UPDATE tasks SET trigger_prompt = ?1, updated_at = ?2 WHERE id = ?3",
-            rusqlite::params![prompt, ts, task.id],
-        );
+        Ok(task) => ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response(),
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
-    if let Some(ref model) = req.model {
-        let ts = db::now();
-        let _ = conn.execute(
-            "UPDATE tasks SET model = ?1, updated_at = ?2 WHERE id = ?3",
-            rusqlite::params![model, ts, task.id],
-        );
-    }
-
-    let task = db::get_task(&conn, &task.id).unwrap_or(task);
-
-    // Fire column trigger
-    if let Ok(column) = db::get_column(&conn, &req.column_id) {
-        let _ = pipeline::fire_trigger(&conn, &api.app, &task, &column);
-    }
-
-    pipeline::emit_tasks_changed(&api.app, &req.workspace_id, "api_task_created");
-
-    let task = db::get_task(&conn, &task.id).unwrap_or(task);
-    ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response()
 }
 
 #[derive(Deserialize)]
@@ -314,28 +217,292 @@ async fn approve_task(
         return ok_response(serde_json::to_value(&advanced).unwrap_or_default()).into_response();
     }
 
+    pipeline::emit_tasks_changed(&api.app, &task.workspace_id, "api_task_approved");
     ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response()
+}
+
+#[derive(Deserialize)]
+struct RejectReq {
+    id: String,
+    #[serde(default)]
+    reason: Option<String>,
 }
 
 async fn reject_task(
     AxumState(api): AxumState<Arc<ApiState>>,
-    Json(req): Json<TaskIdReq>,
+    Json(req): Json<RejectReq>,
 ) -> impl IntoResponse {
     let conn = get_db!(api);
 
-    let task = match db::update_task_review_status(&conn, &req.id, Some("rejected")) {
+    let mut task = match db::update_task_review_status(&conn, &req.id, Some("rejected")) {
         Ok(t) => t,
         Err(e) => {
             return err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     };
 
+    // Persist the rejection reason as pipeline_error, matching the Tauri command.
+    if let Some(ref reason_text) = req.reason {
+        if let Ok(updated) = db::update_task_pipeline_state(
+            &conn,
+            &req.id,
+            &task.pipeline_state,
+            task.pipeline_triggered_at.as_deref(),
+            Some(reason_text),
+        ) {
+            task = updated;
+        }
+    }
+
+    pipeline::emit_tasks_changed(&api.app, &task.workspace_id, "api_task_rejected");
     ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response()
 }
 
 #[derive(Deserialize)]
 struct RetryReq {
     task_id: String,
+}
+
+#[derive(Deserialize)]
+struct MarkCompleteReq {
+    task_id: String,
+    #[serde(default = "default_true")]
+    success: bool,
+    #[serde(default)]
+    error_detail: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Deserialize)]
+struct UpdateTaskReq {
+    task_id: String,
+    title: Option<String>,
+    description: Option<String>,
+    column_id: Option<String>,
+    position: Option<i64>,
+    agent_mode: Option<String>,
+    priority: Option<String>,
+    model: Option<String>,
+    estimated_hours: Option<f64>,
+}
+
+/// Single field-update entry point for out-of-process callers (MCP).
+/// Routes through `pipeline::update_task_service` so the `tasks:changed` event
+/// fires and the field set matches the Tauri command.
+async fn update_task(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<UpdateTaskReq>,
+) -> impl IntoResponse {
+    let conn = get_db!(api);
+    match pipeline::update_task_service(
+        &conn,
+        &api.app,
+        &req.task_id,
+        &pipeline::UpdateTaskFields {
+            title: req.title.as_deref(),
+            description: req.description.as_deref().map(Some),
+            column_id: req.column_id.as_deref(),
+            position: req.position,
+            agent_mode: req.agent_mode.as_deref().map(Some),
+            priority: req.priority.as_deref(),
+            model: req.model.as_deref().map(Some),
+            estimated_hours: req.estimated_hours.map(Some),
+        },
+    ) {
+        Ok(task) => ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response(),
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct SetDependenciesReq {
+    task_id: String,
+    /// JSON array of `{ task_id, condition, ... }` dependency objects.
+    dependencies: String,
+}
+
+/// Single validated entry point for replacing a task's dependency list.
+/// Routes through `pipeline::dependencies::set_task_dependencies` so MCP gets
+/// the same cycle validation + `tasks:changed` event the UI path has.
+async fn set_dependencies(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<SetDependenciesReq>,
+) -> impl IntoResponse {
+    let deps: Vec<pipeline::dependencies::TaskDependency> =
+        match serde_json::from_str(&req.dependencies) {
+            Ok(d) => d,
+            Err(e) => {
+                return err_response(
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid dependencies JSON: {}", e),
+                )
+                .into_response()
+            }
+        };
+    let conn = get_db!(api);
+    match pipeline::dependencies::set_task_dependencies(&conn, &api.app, &req.task_id, &deps) {
+        Ok(task) => ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response(),
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// The single completion entry point for out-of-process callers (MCP).
+/// Routes through `pipeline::mark_complete_with_error`, the same engine the
+/// Tauri command uses — so timing, dependents, auto-advance, telemetry, and
+/// `tasks:changed`/`pipeline:complete` events all fire identically.
+async fn mark_complete(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<MarkCompleteReq>,
+) -> impl IntoResponse {
+    let conn = get_db!(api);
+    match pipeline::mark_complete_with_error(
+        &conn,
+        &api.app,
+        &req.task_id,
+        req.success,
+        req.error_detail.as_deref(),
+    ) {
+        Ok(task) => ok_response(serde_json::to_value(&task).unwrap_or_default()).into_response(),
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// ─── Entity creation (workspace / column / triggers / script) ───────────────
+// These let MCP route through the app instead of writing the DB directly, so
+// writes go through the same validation + emit an `entities:changed` event the
+// frontend's entity-sync hook listens to.
+
+#[derive(Deserialize)]
+struct CreateWorkspaceReq {
+    name: String,
+    repo_path: String,
+    #[serde(default)]
+    template_id: Option<String>,
+    #[serde(default)]
+    default_agent_cli: Option<String>,
+}
+
+async fn create_workspace(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<CreateWorkspaceReq>,
+) -> impl IntoResponse {
+    let conn = get_db!(api);
+    match crate::commands::workspace::create_workspace_core(
+        &conn,
+        &req.name,
+        &req.repo_path,
+        req.template_id.as_deref(),
+        req.default_agent_cli.as_deref(),
+    ) {
+        Ok(ws) => {
+            pipeline::emit_entities_changed(&api.app, &ws.id, "workspace");
+            ok_response(serde_json::to_value(&ws).unwrap_or_default()).into_response()
+        }
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct CreateColumnReq {
+    workspace_id: String,
+    name: String,
+    position: Option<i64>,
+}
+
+async fn create_column(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<CreateColumnReq>,
+) -> impl IntoResponse {
+    if req.name.trim().is_empty() {
+        return err_response(StatusCode::BAD_REQUEST, "Column name cannot be empty".into())
+            .into_response();
+    }
+    let conn = get_db!(api);
+    // Default to appending after the last column when no position is given.
+    let position = req.position.unwrap_or_else(|| {
+        conn.query_row(
+            "SELECT COALESCE(MAX(position), -1) + 1 FROM columns WHERE workspace_id = ?1",
+            rusqlite::params![req.workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(0)
+    });
+    match db::insert_column(&conn, &req.workspace_id, req.name.trim(), position) {
+        Ok(col) => {
+            pipeline::emit_entities_changed(&api.app, &req.workspace_id, "column");
+            ok_response(serde_json::to_value(&col).unwrap_or_default()).into_response()
+        }
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct ConfigureTriggersReq {
+    column_id: String,
+    triggers: String,
+}
+
+async fn configure_triggers(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<ConfigureTriggersReq>,
+) -> impl IntoResponse {
+    if let Err(e) = pipeline::triggers::validate_triggers_json(&req.triggers) {
+        return err_response(StatusCode::BAD_REQUEST, e.to_string()).into_response();
+    }
+    let conn = get_db!(api);
+    match db::update_column(
+        &conn,
+        &req.column_id,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(&req.triggers),
+    ) {
+        Ok(col) => {
+            pipeline::emit_entities_changed(&api.app, &col.workspace_id, "column");
+            ok_response(serde_json::to_value(&col).unwrap_or_default()).into_response()
+        }
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct CreateScriptReq {
+    name: String,
+    #[serde(default)]
+    description: String,
+    steps: String,
+}
+
+async fn create_script(
+    AxumState(api): AxumState<Arc<ApiState>>,
+    Json(req): Json<CreateScriptReq>,
+) -> impl IntoResponse {
+    if req.name.trim().is_empty() {
+        return err_response(StatusCode::BAD_REQUEST, "Script name cannot be empty".into())
+            .into_response();
+    }
+    if let Err(e) = serde_json::from_str::<Vec<serde_json::Value>>(&req.steps) {
+        return err_response(
+            StatusCode::BAD_REQUEST,
+            format!("Steps must be a JSON array: {}", e),
+        )
+        .into_response();
+    }
+    let conn = get_db!(api);
+    let id = db::new_id();
+    match db::insert_script(&conn, &id, req.name.trim(), &req.description, &req.steps, false) {
+        Ok(script) => {
+            pipeline::emit_entities_changed(&api.app, "", "script");
+            ok_response(serde_json::to_value(&script).unwrap_or_default()).into_response()
+        }
+        Err(e) => err_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
 }
 
 async fn retry_task(
@@ -687,11 +854,18 @@ pub fn start(app: AppHandle) {
         let protected = Router::new()
             .route("/api/move_task", post(move_task))
             .route("/api/create_task", post(create_task))
+            .route("/api/update_task", post(update_task))
             .route("/api/delete_task", post(delete_task))
             .route("/api/approve_task", post(approve_task))
             .route("/api/reject_task", post(reject_task))
             .route("/api/retry_task", post(retry_task))
             .route("/api/retry_from_start", post(retry_from_start))
+            .route("/api/mark_complete", post(mark_complete))
+            .route("/api/set_dependencies", post(set_dependencies))
+            .route("/api/create_workspace", post(create_workspace))
+            .route("/api/create_column", post(create_column))
+            .route("/api/configure_triggers", post(configure_triggers))
+            .route("/api/create_script", post(create_script))
             .route("/api/settings", get(get_settings))
             .route("/api/settings", post(update_settings))
             .route(

--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -540,10 +540,16 @@ fn build_claude_streaming_command(
     // Build the streaming and fallback command lines. Note: these go inside a
     // `bash -c '...'` so we already have one level of single-quote nesting —
     // the helper `bash_double_quote_for_outer_squote` escapes single quotes
-    // for that outer layer.
+    // for that outer layer. The streaming-output flags are shared with the
+    // managed adapter via `runtime::CLAUDE_STREAM_OUTPUT_FLAGS` so the two
+    // spawn families can't drift on them; the terminal-only flags
+    // (`--dangerously-skip-permissions`, `--include-partial-messages`, `-p`,
+    // and the jq pipe) stay here.
+    let stream_flags = super::runtime::CLAUDE_STREAM_OUTPUT_FLAGS.join(" ");
     let stream_cmd = format!(
-        "{cli} --dangerously-skip-permissions --output-format stream-json --verbose --include-partial-messages{resume}{args}{prompt} | tee -a \"${{KAITENCODE_CLAUDE_JSON_LOG:-${{BENTOYA_CLAUDE_JSON_LOG:-/dev/null}}}}\" | jq -rj --unbuffered \"$KAITENCODE_CLAUDE_FILTER\"",
+        "{cli} --dangerously-skip-permissions {stream_flags} --include-partial-messages{resume}{args}{prompt} | tee -a \"${{KAITENCODE_CLAUDE_JSON_LOG:-${{BENTOYA_CLAUDE_JSON_LOG:-/dev/null}}}}\" | jq -rj --unbuffered \"$KAITENCODE_CLAUDE_FILTER\"",
         cli = cli_quoted,
+        stream_flags = stream_flags,
         resume = resume_segment,
         args = user_args_segment,
         prompt = prompt_quoted,
@@ -578,6 +584,14 @@ fn build_claude_streaming_command(
     )
 }
 
+/// Terminal/headless codex invocation. Unlike Claude there is no shared flag
+/// constant with the managed adapter (`CodexCliAdapter::managed_turn_args`):
+/// the two paths sandbox differently *by design* — this terminal path pins
+/// `-c sandbox_mode="danger-full-access" -c approval_policy="never"` (stable
+/// `-c` overrides that survive inside worktrees) whereas the managed adapter
+/// uses `--dangerously-bypass-approvals-and-sandbox`. Only `exec`, `--json`,
+/// and `--skip-git-repo-check` overlap, and those are inert if codex renames
+/// them, so they're left inline rather than centralized.
 fn build_codex_streaming_command(
     cli_command: &str,
     args: &[String],
@@ -1236,6 +1250,57 @@ fn ensure_trigger_session(
 /// The frontend's `TerminalView` can attach (or be attached) at any time
 /// during the trigger via `ensure_pty_session`, which finds the existing
 /// tmux session and starts streaming live to xterm.js.
+/// Shared "mark this agent session started" write sequence used by the
+/// tmux-backed trigger spawn paths (headless terminal + interactive). Sets the
+/// session's runtime mode + tmux name, flips it to `running` (clearing any
+/// stale exit code left by a reused/completed session — bug-fix #5), optionally
+/// records the model, points the task at the session, and emits a
+/// `tasks:changed` carrying the real `workspace_id` so the live card refreshes.
+/// Callers keep their own resume-id and transcript-event handling.
+#[allow(clippy::too_many_arguments)]
+fn persist_agent_session_started(
+    conn: &Connection,
+    app: &AppHandle,
+    task_id: &str,
+    workspace_id: &str,
+    session_id: &str,
+    adapter_kind: &str,
+    runtime_mode: &str,
+    tmux_name: &str,
+    model: Option<&str>,
+) {
+    let _ = db::update_agent_session_runtime(
+        conn,
+        session_id,
+        Some(adapter_kind),
+        Some(runtime_mode),
+        None,
+        Some(Some(tmux_name)),
+    );
+    let _ = db::update_agent_session(
+        conn,
+        session_id,
+        None,
+        Some("running"),
+        Some(None),
+        None,
+        None,
+        None,
+    );
+    // Skip the model write when unset so paths that never track a model
+    // (interactive) don't perform a redundant no-op update.
+    if model.is_some() {
+        let _ = db::update_agent_session_model(conn, session_id, model, None);
+    }
+    let _ = db::update_task_agent_status(conn, task_id, Some("running"), None);
+    let ts = db::now();
+    let _ = conn.execute(
+        "UPDATE tasks SET agent_session_id = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![session_id, ts, task_id],
+    );
+    pipeline::emit_tasks_changed(app, workspace_id, "agent_session_created");
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_cli_trigger_task(
     app: AppHandle,
@@ -1273,49 +1338,27 @@ pub fn spawn_cli_trigger_task(
             match session_result {
                 Ok(session) => {
                     let tmux_name = tmux_session_name(&task_id);
-                    // Bug-fix #5: when reusing a persistent session that was
-                    // previously `completed`, clear stale exit_code so the
-                    // (running, exit_code=0) ghost state can't survive a
-                    // mid-run process death. Otherwise pipeline freezes.
-                    let _ = db::update_agent_session(
+                    // Reused persistent sessions may carry a `managed` mode and
+                    // a stale exit code; the helper flips to running + clears it.
+                    let runtime_mode = task_snapshot
+                        .as_ref()
+                        .and_then(|task| task.agent_mode.as_deref())
+                        .filter(|mode| *mode == "managed")
+                        .unwrap_or("terminal");
+                    persist_agent_session_started(
                         &conn,
-                        &session.id,
-                        None,
-                        Some("running"),
-                        Some(None),
-                        None,
-                        None,
-                        None,
-                    );
-                    let _ = db::update_agent_session_runtime(
-                        &conn,
-                        &session.id,
-                        Some(db::adapter_kind_for_agent_type(&cli_command)),
-                        Some(
-                            task_snapshot
-                                .as_ref()
-                                .and_then(|task| task.agent_mode.as_deref())
-                                .filter(|mode| *mode == "managed")
-                                .unwrap_or("terminal"),
-                        ),
-                        None,
-                        Some(Some(&tmux_name)),
-                    );
-                    let _ = db::update_agent_session_model(
-                        &conn,
-                        &session.id,
+                        &app,
+                        &task_id,
                         task_snapshot
                             .as_ref()
-                            .and_then(|task| task.model.as_deref()),
-                        None,
+                            .map(|t| t.workspace_id.as_str())
+                            .unwrap_or(""),
+                        &session.id,
+                        db::adapter_kind_for_agent_type(&cli_command),
+                        runtime_mode,
+                        &tmux_name,
+                        task_snapshot.as_ref().and_then(|task| task.model.as_deref()),
                     );
-                    let _ = db::update_task_agent_status(&conn, &task_id, Some("running"), None);
-                    let ts = db::now();
-                    let _ = conn.execute(
-                        "UPDATE tasks SET agent_session_id = ?1, updated_at = ?2 WHERE id = ?3",
-                        rusqlite::params![session.id, ts, task_id],
-                    );
-                    pipeline::emit_tasks_changed(&app, "", "agent_session_created");
                     let adapter = db::adapter_kind_for_agent_type(&cli_command);
                     let candidate_resume_id = if persistent_lifecycle {
                         db::resolve_cli_session_id(&session, adapter)
@@ -2701,31 +2744,20 @@ pub fn spawn_interactive_trigger_task(
             match session_record {
                 Ok(session) => {
                     let tmux_name = tmux_session_name(&task_id);
-                    let _ = db::update_agent_session_runtime(
+                    persist_agent_session_started(
                         &conn,
+                        &app,
+                        &task_id,
+                        task_snapshot
+                            .as_ref()
+                            .map(|t| t.workspace_id.as_str())
+                            .unwrap_or(""),
                         &session.id,
-                        Some(db::adapter_kind_for_agent_type(&cli_command)),
-                        Some("interactive"),
-                        None,
-                        Some(Some(&tmux_name)),
-                    );
-                    let _ = db::update_agent_session(
-                        &conn,
-                        &session.id,
-                        None,
-                        Some("running"),
-                        Some(None),
-                        None,
-                        None,
+                        db::adapter_kind_for_agent_type(&cli_command),
+                        "interactive",
+                        &tmux_name,
                         None,
                     );
-                    let _ = db::update_task_agent_status(&conn, &task_id, Some("running"), None);
-                    let ts = db::now();
-                    let _ = conn.execute(
-                        "UPDATE tasks SET agent_session_id = ?1, updated_at = ?2 WHERE id = ?3",
-                        rusqlite::params![session.id, ts, task_id],
-                    );
-                    pipeline::emit_tasks_changed(&app, "", "agent_session_created");
                     let metadata = serde_json::json!({
                         "cli": cli_command,
                         "workdir": working_dir,

--- a/src-tauri/src/chat/runtime.rs
+++ b/src-tauri/src/chat/runtime.rs
@@ -166,6 +166,22 @@ pub struct ManagedCliTurnInvocation {
     pub delivery: AgentInputDelivery,
 }
 
+/// The `claude` streaming-output flags that BOTH spawn families must keep in
+/// lock-step: the managed argv path ([`ClaudeCliAdapter::managed_turn_args`])
+/// and the terminal/headless shell-string path
+/// (`chat::bridge::build_claude_streaming_command`). If Claude ever renames
+/// `stream-json` or the verbose toggle, this is the single place to change it.
+///
+/// Everything *else* about the two invocations legitimately differs and is
+/// intentionally kept local to each builder — the terminal path adds
+/// `--dangerously-skip-permissions` / `--include-partial-messages`, passes the
+/// prompt via `-p`, and pipes through `jq`; the managed path uses `--print`,
+/// `--system-prompt`, and a positional message. Those are different render
+/// targets (raw tmux pane vs. semantic event stream), not drift, so only the
+/// genuinely-shared output flags are centralized here.
+pub(crate) const CLAUDE_STREAM_OUTPUT_FLAGS: &[&str] =
+    &["--output-format", "stream-json", "--verbose"];
+
 #[derive(Debug, Clone)]
 pub struct ClaudeCliAdapter {
     pub cli_path: String,
@@ -221,16 +237,14 @@ impl ClaudeCliAdapter {
         resume_id: Option<&str>,
         message: &str,
     ) -> Vec<String> {
-        let mut args = vec![
-            "--print".to_string(),
-            "--output-format".to_string(),
-            "stream-json".to_string(),
-            "--verbose".to_string(),
+        let mut args = vec!["--print".to_string()];
+        args.extend(CLAUDE_STREAM_OUTPUT_FLAGS.iter().map(|s| s.to_string()));
+        args.extend([
             "--model".to_string(),
             model.to_string(),
             "--system-prompt".to_string(),
             system_prompt.to_string(),
-        ];
+        ]);
 
         if let Some(effort) = effort_level {
             args.push("--effort".to_string());
@@ -1542,6 +1556,20 @@ fn metadata_json(value: Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn claude_managed_args_embed_shared_stream_flags_in_order() {
+        // Lock-step guard: the managed argv must contain the shared
+        // streaming-output flags (the same constant the terminal/headless
+        // shell builder splices in), in order, right after `--print`.
+        let args = ClaudeCliAdapter::managed_turn_args("sonnet", "sys", None, None, "hi");
+        assert_eq!(args[0], "--print");
+        assert_eq!(&args[1..1 + CLAUDE_STREAM_OUTPUT_FLAGS.len()], CLAUDE_STREAM_OUTPUT_FLAGS);
+        // Sanity: the rest of the managed shape is unchanged.
+        assert!(args.windows(2).any(|w| w[0] == "--model" && w[1] == "sonnet"));
+        assert!(args.windows(2).any(|w| w[0] == "--system-prompt" && w[1] == "sys"));
+        assert_eq!(args.last().map(String::as_str), Some("hi"));
+    }
 
     fn task_with_session(conn: &Connection) -> (String, String) {
         let workspace = db::insert_workspace(conn, "WS", "/tmp").unwrap();

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1081,11 +1081,7 @@ fn build_task_input_line(
         });
     }
 
-    let mut args = Vec::new();
-    if !model.trim().is_empty() {
-        args.push("--model".to_string());
-        args.push(model.to_string());
-    }
+    let args = crate::pipeline::spawn::model_to_args(Some(model));
 
     let adapter_kind = agent_adapter_kind_from_db(agent_type_from_cli_path(cli_path));
     let mut command = crate::chat::bridge::build_trigger_command(cli_path, &args, text, resume_id);

--- a/src-tauri/src/commands/agent_interactive.rs
+++ b/src-tauri/src/commands/agent_interactive.rs
@@ -21,8 +21,9 @@ use crate::chat::{bridge, tmux_transport};
 use crate::config;
 use crate::db::{self, AppState};
 use crate::error::AppError;
+use crate::pipeline::spawn;
 use crate::pipeline::triggers::{
-    parse_column_triggers, resolve_runtime_mode_for_task, ResolvedRuntimeMode,
+    parse_column_triggers, resolve_runtime_mode_for_task, resolve_working_dir, ResolvedRuntimeMode,
 };
 
 fn session_name(task_id: &str) -> String {
@@ -181,24 +182,18 @@ pub async fn agent_restart(
             .map(|s| s.agent_type)
             .unwrap_or_else(|| "claude".to_string());
 
-        let working_dir = task
-            .worktree_path
-            .clone()
-            .filter(|p| !p.is_empty() && std::path::Path::new(p).exists())
-            .unwrap_or_else(|| workspace.repo_path.clone());
+        // Reuse the shared spawn helpers so restart stays in lock-step with
+        // the original trigger spawn (working-dir, model→args, and the
+        // `.task.md` prompt default all live in pipeline::spawn / triggers).
+        let working_dir = resolve_working_dir(&task, &workspace.repo_path);
 
-        let model = task.model.clone();
-        let mut args: Vec<String> = Vec::new();
-        if let Some(m) = model.filter(|m| !m.trim().is_empty()) {
-            args.push("--model".to_string());
-            args.push(m);
-        }
+        let args = spawn::model_to_args(task.model.as_deref());
 
         let initial_prompt = task
             .trigger_prompt
             .clone()
             .filter(|p| !p.is_empty())
-            .unwrap_or_else(|| format!("{}\n\nSee .task.md for full spec.", task.title));
+            .unwrap_or_else(|| spawn::task_md_default_prompt(&task));
 
         (cli, working_dir, args, initial_prompt, include_sentinel)
     };

--- a/src-tauri/src/commands/column.rs
+++ b/src-tauri/src/commands/column.rs
@@ -1,6 +1,5 @@
 use crate::db::{self, AppState, Column};
 use crate::error::AppError;
-use crate::pipeline::triggers::ColumnTriggersV2;
 use tauri::State;
 
 #[tauri::command]
@@ -69,19 +68,9 @@ pub fn update_column(
         }
     }
 
-    // Validate trigger JSON if provided
+    // Validate trigger JSON if provided (shared validator — single source of truth)
     if let Some(ref t) = triggers {
-        if !t.is_empty() && t != "{}" {
-            match serde_json::from_str::<ColumnTriggersV2>(t) {
-                Ok(_) => {} // Valid
-                Err(e) => {
-                    return Err(AppError::InvalidInput(format!(
-                        "Invalid trigger configuration: {}. Check that trigger types match: auto_setup, spawn_cli, move_column, trigger_task, run_script (requires script_id), create_pr, auto_merge, none.",
-                        e
-                    )));
-                }
-            }
-        }
+        crate::pipeline::triggers::validate_triggers_json(t)?;
     }
 
     let conn = state

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -26,58 +26,31 @@ pub async fn create_task(
     description: Option<String>,
     trigger_prompt: Option<String>,
     dependencies: Option<String>,
+    model: Option<String>,
+    priority: Option<String>,
+    runtime_mode_override: Option<String>,
 ) -> Result<Task, AppError> {
-    if title.trim().is_empty() {
-        return Err(AppError::InvalidInput(
-            "Task title cannot be empty".to_string(),
-        ));
-    }
-
     let conn = state
         .db
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let task = db::insert_task(
+
+    pipeline::create_task_service(
         &conn,
-        &workspace_id,
-        &column_id,
-        title.trim(),
-        description.as_deref(),
-    )?;
-
-    // Set trigger prompt and dependencies if provided
-    let ts = db::now();
-    if trigger_prompt.is_some() || dependencies.is_some() {
-        let has_deps = dependencies
-            .as_ref()
-            .map(|d| d != "[]" && !d.is_empty())
-            .unwrap_or(false);
-        conn.execute(
-            "UPDATE tasks SET trigger_prompt = COALESCE(?1, trigger_prompt), dependencies = COALESCE(?2, dependencies), blocked = ?3, updated_at = ?4 WHERE id = ?5",
-            rusqlite::params![
-                trigger_prompt,
-                dependencies,
-                has_deps as i64,
-                ts,
-                task.id,
-            ],
-        ).map_err(AppError::from)?;
-    }
-
-    let task = db::get_task(&conn, &task.id)?;
-
-    // Fire column trigger for the initial column (unless blocked)
-    let column = db::get_column(&conn, &column_id)?;
-    let task = if !task.blocked {
-        pipeline::fire_trigger(&conn, &app, &task, &column)?
-    } else {
-        task
-    };
-
-    // Notify frontend to refresh task store
-    pipeline::emit_tasks_changed(&app, &workspace_id, "task_created");
-
-    Ok(task)
+        &app,
+        &db::NewTask {
+            workspace_id: &workspace_id,
+            column_id: &column_id,
+            title: title.trim(),
+            description: description.as_deref(),
+            model: model.as_deref(),
+            trigger_prompt: trigger_prompt.as_deref(),
+            dependencies: dependencies.as_deref(),
+            priority: priority.as_deref(),
+            runtime_mode_override: runtime_mode_override.as_deref(),
+        },
+        true,
+    )
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -296,7 +269,7 @@ pub async fn create_task_from_template(
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub fn update_task(
-    _app: AppHandle,
+    app: AppHandle,
     state: State<AppState>,
     id: String,
     title: Option<String>,
@@ -335,40 +308,27 @@ pub fn update_task(
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
-    let desc_ref = description.as_ref().map(|d| d.as_deref());
-    let mode_ref = agent_mode.as_ref().map(|m| m.as_deref());
-    let mut task = db::update_task(
+    pipeline::update_task_service(
         &conn,
+        &app,
         &id,
-        title.as_deref(),
-        desc_ref,
-        column_id.as_deref(),
-        position,
-        mode_ref,
-        priority.as_deref(),
-    )?;
-
-    // Update model if provided
-    if let Some(ref m) = model {
-        let ts = db::now();
-        conn.execute(
-            "UPDATE tasks SET model = ?1, updated_at = ?2 WHERE id = ?3",
-            rusqlite::params![m.as_deref(), ts, id],
-        )
-        .map_err(AppError::from)?;
-        task = db::get_task(&conn, &id)?;
-    }
-
-    if let Some(hours) = estimated_hours {
-        task = db::update_task_time_tracking(&conn, &id, hours)?;
-    }
-
-    Ok(task)
+        &pipeline::UpdateTaskFields {
+            title: title.as_deref(),
+            description: description.as_ref().map(|d| d.as_deref()),
+            column_id: column_id.as_deref(),
+            position,
+            agent_mode: agent_mode.as_ref().map(|m| m.as_deref()),
+            priority: priority.as_deref(),
+            model: model.as_ref().map(|m| m.as_deref()),
+            estimated_hours,
+        },
+    )
 }
 
 /// Update task trigger settings (overrides, prompt, dependencies)
 #[tauri::command(rename_all = "camelCase")]
 pub fn update_task_triggers(
+    app: AppHandle,
     state: State<AppState>,
     id: String,
     trigger_overrides: Option<String>,
@@ -381,18 +341,10 @@ pub fn update_task_triggers(
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
-    // Validate dependencies won't create a cycle before saving
-    if let Some(ref deps_json) = dependencies {
-        if !deps_json.is_empty() && deps_json != "[]" {
-            let deps: Vec<pipeline::dependencies::TaskDependency> = serde_json::from_str(deps_json)
-                .map_err(|e| AppError::InvalidInput(format!("Invalid dependencies JSON: {}", e)))?;
-            pipeline::dependencies::validate_dependencies(&conn, &id, &deps)?;
-        }
-    }
-
     let ts = db::now();
 
-    // Build dynamic UPDATE query
+    // Build dynamic UPDATE for trigger fields. Dependencies are handled
+    // separately through the shared validated service below.
     let mut updates = Vec::new();
     let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
 
@@ -404,30 +356,40 @@ pub fn update_task_triggers(
         updates.push("trigger_prompt = ?");
         params_vec.push(Box::new(prompt.clone()));
     }
-    if let Some(ref deps) = dependencies {
-        updates.push("dependencies = ?");
-        params_vec.push(Box::new(deps.clone()));
-    }
-    if let Some(b) = blocked {
-        updates.push("blocked = ?");
-        params_vec.push(Box::new(b as i64));
-    }
-
-    if updates.is_empty() {
-        return Ok(db::get_task(&conn, &id)?);
+    // Only honor an explicit blocked override when dependencies aren't being set
+    // (when deps are provided, the service derives blocked from them).
+    if dependencies.is_none() {
+        if let Some(b) = blocked {
+            updates.push("blocked = ?");
+            params_vec.push(Box::new(b as i64));
+        }
     }
 
-    updates.push("updated_at = ?");
-    params_vec.push(Box::new(ts));
+    if !updates.is_empty() {
+        updates.push("updated_at = ?");
+        params_vec.push(Box::new(ts));
 
-    let set_clause = updates.join(", ");
-    let sql = format!("UPDATE tasks SET {} WHERE id = ?", set_clause);
-    params_vec.push(Box::new(id.clone()));
+        let set_clause = updates.join(", ");
+        let sql = format!("UPDATE tasks SET {} WHERE id = ?", set_clause);
+        params_vec.push(Box::new(id.clone()));
 
-    let params_refs: Vec<&dyn rusqlite::types::ToSql> =
-        params_vec.iter().map(|p| p.as_ref()).collect();
-    conn.execute(&sql, params_refs.as_slice())
-        .map_err(AppError::from)?;
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        conn.execute(&sql, params_refs.as_slice())
+            .map_err(AppError::from)?;
+    }
+
+    // Route dependency changes through the single validated service (cycle
+    // validation + derived blocked + tasks:changed event).
+    if let Some(ref deps_json) = dependencies {
+        let deps: Vec<pipeline::dependencies::TaskDependency> = if deps_json.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(deps_json)
+                .map_err(|e| AppError::InvalidInput(format!("Invalid dependencies JSON: {}", e)))?
+        };
+        return pipeline::dependencies::set_task_dependencies(&conn, &app, &id, &deps);
+    }
 
     Ok(db::get_task(&conn, &id)?)
 }
@@ -440,100 +402,12 @@ pub async fn move_task(
     target_column_id: String,
     position: i64,
 ) -> Result<Task, AppError> {
-    if position < 0 {
-        return Err(AppError::InvalidInput(
-            "Position must be non-negative".to_string(),
-        ));
-    }
-
     let conn = state
         .db
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
-    // Get the task's current column to check if it changed
-    let task_before = db::get_task(&conn, &id)?;
-    let old_column_id = task_before.column_id.clone();
-    let column_changed = old_column_id != target_column_id;
-
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-
-    // Update column and position atomically
-    // Also reset pipeline state when moving to a new column
-    let ts = db::now();
-    if column_changed {
-        conn.execute(
-            "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
-            rusqlite::params![target_column_id, position, ts, id],
-        )
-        .map_err(AppError::from)?;
-    } else {
-        conn.execute(
-            "UPDATE tasks SET column_id = ?1, position = ?2, updated_at = ?3 WHERE id = ?4",
-            rusqlite::params![target_column_id, position, ts, id],
-        )
-        .map_err(AppError::from)?;
-    }
-
-    tx.commit()
-        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-
-    let task = db::get_task(&conn, &id)?;
-
-    // Fire column trigger if task moved to a new column
-    if column_changed {
-        // Fire on_exit trigger on the old column (V2 triggers)
-        let old_column = db::get_column(&conn, &old_column_id)?;
-        let target_column = db::get_column(&conn, &target_column_id)?;
-
-        // Cancel running agent if target column has no spawn_cli trigger.
-        // If target also has a trigger, it replaces the old agent — no cancel needed.
-        if task_before.agent_status.as_deref() == Some("running") {
-            let target_has_trigger = target_column
-                .triggers
-                .as_deref()
-                .map(|t| t.contains("spawn_cli"))
-                .unwrap_or(false);
-
-            if !target_has_trigger {
-                crate::chat::tmux_transport::cancel_task_agent(
-                    &conn,
-                    &id,
-                    task_before.agent_session_id.as_deref(),
-                );
-            }
-        }
-        let _ = pipeline::triggers::fire_on_exit(
-            &conn,
-            &app,
-            &task_before,
-            &old_column,
-            Some(&target_column),
-        );
-
-        let task = pipeline::cleanup_task_worktree_if_terminal(
-            &conn,
-            &task,
-            &target_column,
-            "manual_move",
-        )?;
-
-        // Notify frontend to refresh task store
-        pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_moved");
-
-        // Re-check dependents with the post-move task state. The pre-move call inside
-        // fire_on_exit only sees the old column, so any dep waiting on this task to
-        // reach a specific column (`completed`, `moved_to_column`, `at_or_past_column`)
-        // needs this second pass.
-        let _ = pipeline::dependencies::check_dependents(&conn, &app, &task);
-
-        let task = pipeline::fire_trigger(&conn, &app, &task, &target_column)?;
-        return Ok(task);
-    }
-
-    Ok(task)
+    pipeline::move_task_service(&conn, &app, &id, &target_column_id, position)
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -864,12 +738,15 @@ pub async fn approve_task(
         return Ok(advanced_task);
     }
 
+    // No auto-advance: still notify the frontend so the review badge refreshes.
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_approved");
     Ok(task)
 }
 
 /// Reject a task - sets review_status to "rejected" and optionally sets pipeline_error
 #[tauri::command]
 pub fn reject_task(
+    app: AppHandle,
     state: State<AppState>,
     id: String,
     reason: Option<String>,
@@ -893,6 +770,7 @@ pub fn reject_task(
         )?;
     }
 
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_rejected");
     Ok(task)
 }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -2,6 +2,7 @@ use crate::config::DEFAULT_BASE_BRANCH;
 use crate::db::{self, AppState, Column, Workspace};
 use crate::error::AppError;
 use git2::{BranchType, Repository};
+use rusqlite::Connection;
 use serde_json::Value;
 use std::path::Path;
 use tauri::State;
@@ -232,6 +233,55 @@ fn columns_for_template(template_id: Option<&str>) -> &'static [DefaultColumn] {
     }
 }
 
+/// Shared workspace-creation core used by both the Tauri command and the HTTP
+/// API. Validates the repo path, writes the workspace + config, and creates the
+/// template's default columns — all in one transaction — so a workspace created
+/// from the UI and from MCP are identical (the MCP path previously hardcoded 4
+/// columns and skipped config + templates).
+pub fn create_workspace_core(
+    conn: &Connection,
+    name: &str,
+    repo_path: &str,
+    template_id: Option<&str>,
+    default_agent_cli: Option<&str>,
+) -> Result<Workspace, AppError> {
+    if name.trim().is_empty() {
+        return Err(AppError::InvalidInput(
+            "Workspace name cannot be empty".to_string(),
+        ));
+    }
+    let repo_path = validate_workspace_repo_path(repo_path)?;
+    let workspace_config = new_workspace_config(&repo_path, default_agent_cli.map(str::trim))?;
+
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    let mut ws = db::insert_workspace(conn, name.trim(), &repo_path)?;
+    if workspace_config != "{}" {
+        ws = db::update_workspace(conn, &ws.id, None, None, None, None, Some(&workspace_config))?;
+    }
+
+    // Auto-create columns from the selected onboarding template.
+    for (i, col) in columns_for_template(template_id).iter().enumerate() {
+        let created =
+            db::insert_column_with_style(conn, &ws.id, col.name, i as i64, col.icon, col.color)?;
+        if !col.trigger_config.is_empty() || !col.exit_config.is_empty() || col.auto_advance {
+            let triggers = serde_json::json!({
+                "triggerConfig": col.trigger_config,
+                "exitConfig": col.exit_config,
+                "autoAdvance": col.auto_advance,
+            })
+            .to_string();
+            db::update_column(conn, &created.id, None, None, None, None, None, Some(&triggers))?;
+        }
+    }
+
+    tx.commit()
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+    Ok(ws)
+}
+
 #[tauri::command]
 pub fn create_workspace(
     state: State<AppState>,
@@ -240,66 +290,17 @@ pub fn create_workspace(
     template_id: Option<String>,
     default_agent_cli: Option<String>,
 ) -> Result<Workspace, AppError> {
-    if name.trim().is_empty() {
-        return Err(AppError::InvalidInput(
-            "Workspace name cannot be empty".to_string(),
-        ));
-    }
-    let repo_path = validate_workspace_repo_path(&repo_path)?;
-    let workspace_config =
-        new_workspace_config(&repo_path, default_agent_cli.as_deref().map(str::trim))?;
-
     let conn = state
         .db
         .lock()
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-
-    let mut ws = db::insert_workspace(&conn, name.trim(), &repo_path)?;
-    if workspace_config != "{}" {
-        ws = db::update_workspace(
-            &conn,
-            &ws.id,
-            None,
-            None,
-            None,
-            None,
-            Some(&workspace_config),
-        )?;
-    }
-
-    // Auto-create columns from the selected onboarding template.
-    for (i, col) in columns_for_template(template_id.as_deref())
-        .iter()
-        .enumerate()
-    {
-        let created =
-            db::insert_column_with_style(&conn, &ws.id, col.name, i as i64, col.icon, col.color)?;
-        if !col.trigger_config.is_empty() || !col.exit_config.is_empty() || col.auto_advance {
-            let triggers = serde_json::json!({
-                "triggerConfig": col.trigger_config,
-                "exitConfig": col.exit_config,
-                "autoAdvance": col.auto_advance,
-            })
-            .to_string();
-            db::update_column(
-                &conn,
-                &created.id,
-                None,
-                None,
-                None,
-                None,
-                None,
-                Some(&triggers),
-            )?;
-        }
-    }
-
-    tx.commit()
-        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-    Ok(ws)
+    create_workspace_core(
+        &conn,
+        &name,
+        &repo_path,
+        template_id.as_deref(),
+        default_agent_cli.as_deref(),
+    )
 }
 
 fn new_workspace_config(

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -606,6 +606,63 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_task_full_sets_all_fields_and_blocked() {
+        let conn = init_test().unwrap();
+        let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();
+        let col = insert_column(&conn, &ws.id, "Backlog", 0).unwrap();
+
+        // Rich create: every caller-supplied field lands in one INSERT.
+        let task = insert_task_full(
+            &conn,
+            &NewTask {
+                workspace_id: &ws.id,
+                column_id: &col.id,
+                title: "Rich task",
+                description: Some("desc"),
+                model: Some("sonnet"),
+                trigger_prompt: Some("do the thing"),
+                dependencies: Some("[\"dep-1\"]"),
+                priority: Some("high"),
+                runtime_mode_override: Some("interactive"),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(task.model.as_deref(), Some("sonnet"));
+        assert_eq!(task.trigger_prompt.as_deref(), Some("do the thing"));
+        assert_eq!(task.dependencies.as_deref(), Some("[\"dep-1\"]"));
+        assert_eq!(task.priority, "high");
+        assert_eq!(task.runtime_mode_override.as_deref(), Some("interactive"));
+        // Non-empty dependencies imply blocked.
+        assert!(task.blocked);
+
+        // Defaults reproduce the legacy insert_task behavior exactly.
+        let bare = insert_task_full(
+            &conn,
+            &NewTask {
+                workspace_id: &ws.id,
+                column_id: &col.id,
+                title: "Bare task",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(bare.priority, "medium");
+        assert!(!bare.blocked);
+        assert_eq!(bare.model, None);
+        assert_eq!(bare.runtime_mode_override, None);
+    }
+
+    #[test]
+    fn test_deps_imply_blocked() {
+        assert!(!deps_imply_blocked(None));
+        assert!(!deps_imply_blocked(Some("")));
+        assert!(!deps_imply_blocked(Some("[]")));
+        assert!(!deps_imply_blocked(Some("  []  ")));
+        assert!(deps_imply_blocked(Some("[\"task-1\"]")));
+    }
+
+    #[test]
     fn test_label_crud_and_task_assignment() {
         let conn = init_test().unwrap();
         let ws = insert_workspace(&conn, "WS", "/tmp").unwrap();

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -102,6 +102,80 @@ fn with_labels_for_tasks(conn: &Connection, tasks: Vec<Task>) -> SqlResult<Vec<T
         .collect())
 }
 
+/// Returns true when a dependencies JSON string represents at least one dependency.
+/// Treats `None`, empty, and the empty-array literal `[]` as "no dependencies".
+pub fn deps_imply_blocked(dependencies: Option<&str>) -> bool {
+    dependencies
+        .map(|d| {
+            let trimmed = d.trim();
+            !trimmed.is_empty() && trimmed != "[]"
+        })
+        .unwrap_or(false)
+}
+
+/// Rich, single-INSERT task creation input. This is the one shape every
+/// task-creation surface (UI, HTTP API, chef/orchestrator, MCP) funnels through
+/// so a task created from any path is byte-for-byte identical in the DB.
+///
+/// Fields default to the same values the legacy `insert_task` hardcoded, so a
+/// bare `NewTask { workspace_id, column_id, title, ..Default::default() }`
+/// reproduces the old behavior exactly.
+#[derive(Debug, Default, Clone)]
+pub struct NewTask<'a> {
+    pub workspace_id: &'a str,
+    pub column_id: &'a str,
+    pub title: &'a str,
+    pub description: Option<&'a str>,
+    pub model: Option<&'a str>,
+    pub trigger_prompt: Option<&'a str>,
+    /// JSON array of task ids. Presence of any entry sets `blocked = true`.
+    pub dependencies: Option<&'a str>,
+    /// Defaults to "medium" when None.
+    pub priority: Option<&'a str>,
+    pub runtime_mode_override: Option<&'a str>,
+}
+
+/// The single rich INSERT. Sets every caller-supplied column atomically in one
+/// statement (no follow-up UPDATEs), derives `blocked` from `dependencies`, and
+/// returns the freshly-loaded `Task`.
+pub fn insert_task_full(conn: &Connection, new: &NewTask) -> SqlResult<Task> {
+    let id = new_id();
+    let ts = now();
+    let blocked = deps_imply_blocked(new.dependencies) as i64;
+    let priority = new.priority.unwrap_or("medium");
+    // Get next position in column
+    let max_pos: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
+            params![new.column_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(-1);
+    conn.execute(
+        "INSERT INTO tasks (id, workspace_id, column_id, title, description, position, priority, files_touched, pipeline_state, trigger_prompt, dependencies, blocked, model, runtime_mode_override, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, '[]', 'idle', ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        params![
+            id,
+            new.workspace_id,
+            new.column_id,
+            new.title,
+            new.description,
+            max_pos + 1,
+            priority,
+            new.trigger_prompt,
+            new.dependencies,
+            blocked,
+            new.model,
+            new.runtime_mode_override,
+            ts,
+            ts
+        ],
+    )?;
+    get_task(conn, &id)
+}
+
+/// Thin wrapper preserving the original 4-field signature. New callers should
+/// prefer [`insert_task_full`] so they can set model/runtime_mode/deps/etc.
 pub fn insert_task(
     conn: &Connection,
     workspace_id: &str,
@@ -109,21 +183,16 @@ pub fn insert_task(
     title: &str,
     description: Option<&str>,
 ) -> SqlResult<Task> {
-    let id = new_id();
-    let ts = now();
-    // Get next position in column
-    let max_pos: i64 = conn
-        .query_row(
-            "SELECT COALESCE(MAX(position), -1) FROM tasks WHERE column_id = ?1",
-            params![column_id],
-            |row| row.get(0),
-        )
-        .unwrap_or(-1);
-    conn.execute(
-        "INSERT INTO tasks (id, workspace_id, column_id, title, description, position, priority, files_touched, pipeline_state, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'medium', '[]', 'idle', ?7, ?8)",
-        params![id, workspace_id, column_id, title, description, max_pos + 1, ts, ts],
-    )?;
-    get_task(conn, &id)
+    insert_task_full(
+        conn,
+        &NewTask {
+            workspace_id,
+            column_id,
+            title,
+            description,
+            ..Default::default()
+        },
+    )
 }
 
 /// Duplicate a task immediately after the source task in the same column.

--- a/src-tauri/src/llm/executor.rs
+++ b/src-tauri/src/llm/executor.rs
@@ -136,37 +136,51 @@ pub fn execute_tools(
                         pipeline::emit_tasks_changed(app, workspace_id, "orchestrator_tool");
                         tasks_updated.push(task);
                     }
-                    ToolOutcome::TaskMoved(task, from_col, to_col) => {
-                        // Fire trigger on the new column (on_entry)
-                        let task = if !task.blocked {
-                            let new_column = columns.iter().find(|c| c.id == task.column_id);
-                            if let Some(col) = new_column {
-                                pipeline::fire_trigger(conn, app, &task, col).unwrap_or(task)
-                            } else {
-                                task
+                    ToolOutcome::TaskMoveRequested {
+                        task_id,
+                        target_column_id,
+                        position,
+                        from_column,
+                        to_column,
+                    } => {
+                        // Route through the unified service so chef moves get
+                        // the same transition as the UI/API: on_exit, agent
+                        // cancellation, terminal worktree cleanup, on_entry, and
+                        // both dependents passes. It also emits `tasks:changed`,
+                        // so we don't re-fire the trigger or re-emit here.
+                        match pipeline::move_task_service(
+                            conn,
+                            app,
+                            &task_id,
+                            &target_column_id,
+                            position,
+                        ) {
+                            Ok(task) => {
+                                results.push(ToolResult {
+                                    tool_use_id: tool_use.id.clone(),
+                                    content: format!(
+                                        "Moved \"{}\" from {} to {}",
+                                        task.title, from_column, to_column
+                                    ),
+                                    is_error: false,
+                                });
+                                let _ = app.emit(
+                                    "task:updated",
+                                    TaskUpdatedPayload {
+                                        workspace_id: workspace_id.to_string(),
+                                        task: task.clone(),
+                                    },
+                                );
+                                tasks_updated.push(task);
                             }
-                        } else {
-                            task
-                        };
-
-                        results.push(ToolResult {
-                            tool_use_id: tool_use.id.clone(),
-                            content: format!(
-                                "Moved \"{}\" from {} to {}",
-                                task.title, from_col, to_col
-                            ),
-                            is_error: false,
-                        });
-                        let _ = app.emit(
-                            "task:updated",
-                            TaskUpdatedPayload {
-                                workspace_id: workspace_id.to_string(),
-                                task: task.clone(),
-                            },
-                        );
-                        // Emit tasks:changed so frontend refreshes
-                        pipeline::emit_tasks_changed(app, workspace_id, "orchestrator_tool");
-                        tasks_updated.push(task);
+                            Err(e) => {
+                                results.push(ToolResult {
+                                    tool_use_id: tool_use.id.clone(),
+                                    content: format!("Error: {}", e),
+                                    is_error: true,
+                                });
+                            }
+                        }
                     }
                     ToolOutcome::TaskDeleted(task_id, title) => {
                         results.push(ToolResult {
@@ -220,6 +234,8 @@ pub fn execute_tools(
                                 column_id: column_id.clone(),
                             },
                         );
+                        // Refresh the board's column store (shared entity-sync channel).
+                        pipeline::emit_entities_changed(app, workspace_id, "column");
                     }
                 }
             }
@@ -294,8 +310,18 @@ fn resolve_last_placeholder(input: &serde_json::Value, last_id: Option<&str>) ->
 enum ToolOutcome {
     TaskCreated(Task),
     TaskUpdated(Task),
-    TaskMoved(Task, String, String),  // task, from_column, to_column
-    TaskDeleted(String, String),      // task_id, title
+    /// A1: chef resolves the move target but does NOT mutate the task — it has
+    /// no `&AppHandle`. The caller loop (which does) routes this through
+    /// `pipeline::move_task_service` for full transition parity (on_exit,
+    /// agent-cancel, worktree cleanup, on_entry, second dependents pass).
+    TaskMoveRequested {
+        task_id: String,
+        target_column_id: String,
+        position: i64,
+        from_column: String,
+        to_column: String,
+    },
+    TaskDeleted(String, String), // task_id, title
     TasksQueued(Vec<String>, String), // task_ids, agent_type
     TriggersConfigured(String, String, String), // column_id, column_name, triggers_json
 }
@@ -322,6 +348,17 @@ fn execute_single_tool(
             }
 
             let description = input.get("description").and_then(|v| v.as_str());
+            let model = input.get("model").and_then(|v| v.as_str());
+            let trigger_prompt = input
+                .get("trigger_prompt")
+                .or_else(|| input.get("triggerPrompt"))
+                .and_then(|v| v.as_str());
+            let dependencies = input.get("dependencies").and_then(|v| v.as_str());
+            let priority = input.get("priority").and_then(|v| v.as_str());
+            let runtime_mode_override = input
+                .get("runtime_mode")
+                .or_else(|| input.get("runtimeMode"))
+                .and_then(|v| v.as_str());
 
             let column_id = if let Some(column_id) = input
                 .get("column_id")
@@ -333,8 +370,21 @@ fn execute_single_tool(
                 find_column_id(columns, input.get("column").and_then(|v| v.as_str()))?
             };
 
-            let task = db::insert_task(conn, workspace_id, &column_id, title, description)
-                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let task = db::insert_task_full(
+                conn,
+                &db::NewTask {
+                    workspace_id,
+                    column_id: &column_id,
+                    title,
+                    description,
+                    model,
+                    trigger_prompt,
+                    dependencies,
+                    priority,
+                    runtime_mode_override,
+                },
+            )
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
             Ok(ToolOutcome::TaskCreated(task))
         }
@@ -361,21 +411,34 @@ fn execute_single_tool(
                 })
                 .transpose()?;
             let description = input.get("description").and_then(|v| v.as_str());
+            let priority = input.get("priority").and_then(|v| v.as_str());
+            let model = input.get("model").and_then(|v| v.as_str());
 
             // Convert description to the expected Option<Option<&str>> format
             let desc_option = description.map(Some);
 
-            let task = db::update_task(
+            let mut task = db::update_task(
                 conn,
                 task_id,
                 title,
                 desc_option,
-                None, // column_id
+                None, // column_id (moves go through move_task)
                 None, // position
                 None, // agent_mode
-                None, // priority
+                priority,
             )
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+            if let Some(m) = model {
+                let ts = db::now();
+                conn.execute(
+                    "UPDATE tasks SET model = ?1, updated_at = ?2 WHERE id = ?3",
+                    rusqlite::params![m, ts, task_id],
+                )
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+                task = db::get_task(conn, task_id)
+                    .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            }
 
             Ok(ToolOutcome::TaskUpdated(task))
         }
@@ -432,15 +495,16 @@ fn execute_single_tool(
                 .unwrap_or(0)
             };
 
-            let task = move_task_to_column(
-                conn,
-                task_id,
-                &current_task.column_id,
-                &target_column_id,
+            // No DB write here — `execute_single_tool` stays `AppHandle`-free
+            // (Wry-vs-Mock test landmine). The caller routes through
+            // `move_task_service`, which owns the column change + reset.
+            Ok(ToolOutcome::TaskMoveRequested {
+                task_id: task_id.to_string(),
+                target_column_id,
                 position,
-            )?;
-
-            Ok(ToolOutcome::TaskMoved(task, from_column, to_column))
+                from_column,
+                to_column,
+            })
         }
 
         "delete_task" => {
@@ -455,6 +519,21 @@ fn execute_single_tool(
             let task =
                 db::get_task(conn, task_id).map_err(|e| AppError::DatabaseError(e.to_string()))?;
             let title = task.title.clone();
+
+            // Clean up the task's worktree + tmux session (matches the Tauri/API
+            // delete paths) so chef-initiated deletes don't orphan resources.
+            if task.worktree_path.is_some() {
+                if let Ok(ws) = db::get_workspace(conn, &task.workspace_id) {
+                    if let Err(e) =
+                        crate::git::branch_manager::remove_task_worktree(&ws.repo_path, task_id)
+                    {
+                        log::warn!("Failed to clean up worktree for deleted task {task_id}: {e}");
+                    }
+                }
+            }
+            if let Err(e) = crate::chat::tmux_transport::kill_session(task_id) {
+                log::warn!("Failed to clean up tmux session for deleted task {task_id}: {e}");
+            }
 
             db::delete_task(conn, task_id).map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
@@ -504,6 +583,10 @@ fn execute_single_tool(
             let triggers_json = serde_json::to_string(&triggers).map_err(|e| {
                 AppError::InvalidInput(format!("Failed to serialize triggers: {}", e))
             })?;
+
+            // Validate against the shared V2 schema (previously this path did no
+            // validation and would accept malformed trigger JSON).
+            crate::pipeline::triggers::validate_triggers_json(&triggers_json)?;
 
             // Save to database
             db::update_column(
@@ -591,30 +674,6 @@ fn resolve_column_id(columns: &[Column], id_or_name: &str) -> Result<String, App
     }
 
     find_column_id(columns, Some(id_or_name))
-}
-
-fn move_task_to_column(
-    conn: &Connection,
-    task_id: &str,
-    old_column_id: &str,
-    target_column_id: &str,
-    position: i64,
-) -> Result<Task, AppError> {
-    let ts = db::now();
-    if old_column_id == target_column_id {
-        conn.execute(
-            "UPDATE tasks SET column_id = ?1, position = ?2, updated_at = ?3 WHERE id = ?4",
-            rusqlite::params![target_column_id, position, ts, task_id],
-        )
-    } else {
-        conn.execute(
-            "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
-            rusqlite::params![target_column_id, position, ts, task_id],
-        )
-    }
-    .map_err(|e| AppError::DatabaseError(e.to_string()))?;
-
-    db::get_task(conn, task_id).map_err(|e| AppError::DatabaseError(e.to_string()))
 }
 
 /// Get column name by ID
@@ -739,7 +798,12 @@ mod tests {
     }
 
     #[test]
-    fn test_move_task_resets_pipeline_state_when_column_changes() {
+    fn test_move_task_resolves_target_without_mutating() {
+        // `execute_single_tool` is `AppHandle`-free, so the move arm now only
+        // *resolves* the target (column id, position, display names) and defers
+        // the actual transition + pipeline-state reset to `move_task_service`
+        // in the caller loop. Assert the resolved request; the DB mutation is
+        // covered by `move_task_service`'s own tests.
         let (conn, workspace_id, columns) = setup_db_with_columns();
         let task = db::insert_task(&conn, &workspace_id, &columns[0].id, "Task", None).unwrap();
         db::update_task_pipeline_state(
@@ -760,13 +824,27 @@ mod tests {
         )
         .unwrap();
 
-        let ToolOutcome::TaskMoved(moved, _, _) = outcome else {
-            panic!("expected task move");
+        let ToolOutcome::TaskMoveRequested {
+            task_id,
+            target_column_id,
+            position,
+            from_column,
+            to_column,
+        } = outcome
+        else {
+            panic!("expected move request");
         };
-        assert_eq!(moved.column_id, columns[1].id);
-        assert_eq!(moved.pipeline_state, "idle");
-        assert!(moved.pipeline_triggered_at.is_none());
-        assert!(moved.pipeline_error.is_none());
+        assert_eq!(task_id, task.id);
+        assert_eq!(target_column_id, columns[1].id);
+        // Target column ("Done") is empty → next free slot is 0.
+        assert_eq!(position, 0);
+        assert_eq!(from_column, "Backlog");
+        assert_eq!(to_column, "Done");
+
+        // The task itself must NOT have moved yet.
+        let unchanged = db::get_task(&conn, &task.id).unwrap();
+        assert_eq!(unchanged.column_id, columns[0].id);
+        assert_eq!(unchanged.pipeline_state, "error");
     }
 
     #[test]

--- a/src-tauri/src/pipeline/dependencies.rs
+++ b/src-tauri/src/pipeline/dependencies.rs
@@ -620,6 +620,34 @@ pub fn validate_dependencies(
     Ok(())
 }
 
+/// The single validated path for replacing a task's full dependency list.
+/// Every surface (Tauri command, HTTP API, MCP add/remove) funnels through here
+/// so cycle/self-loop/existence validation, the derived `blocked` flag, and the
+/// `tasks:changed` event are identical everywhere — closing the MCP gap where
+/// dependencies were written directly with no validation and no UI refresh.
+pub fn set_task_dependencies(
+    conn: &Connection,
+    app: &AppHandle,
+    task_id: &str,
+    deps: &[TaskDependency],
+) -> Result<Task, AppError> {
+    validate_dependencies(conn, task_id, deps)?;
+
+    let deps_json = serde_json::to_string(deps)
+        .map_err(|e| AppError::InvalidInput(format!("Invalid dependencies: {}", e)))?;
+    let blocked = !deps.is_empty();
+    let ts = db::now();
+    conn.execute(
+        "UPDATE tasks SET dependencies = ?1, blocked = ?2, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![deps_json, blocked as i64, ts, task_id],
+    )
+    .map_err(AppError::from)?;
+
+    let task = db::get_task(conn, task_id)?;
+    emit_tasks_changed(app, &task.workspace_id, "dependencies_changed");
+    Ok(task)
+}
+
 /// Update a task's blocked state.
 fn update_blocked(conn: &Connection, task_id: &str, blocked: bool) -> Result<(), AppError> {
     let ts = db::now();

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod dependencies;
 pub mod hygiene;
+pub mod spawn;
 pub mod template;
 pub mod templates;
 pub mod triggers;
@@ -126,6 +127,28 @@ pub fn emit_tasks_changed(app: &AppHandle, workspace_id: &str, reason: &str) {
         &TasksChangedEvent {
             workspace_id: workspace_id.to_string(),
             reason: reason.to_string(),
+        },
+    );
+}
+
+/// Global event emitted when a non-task entity (workspace, column, script) is
+/// mutated out of band — e.g. by MCP or the chef. `kind` is one of
+/// `workspace` | `column` | `script`. The frontend's entity-sync hook reloads
+/// the matching store so external changes refresh the UI (the per-entity stores
+/// otherwise only refresh via optimistic updates after a direct invoke()).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntitiesChangedEvent {
+    pub workspace_id: String,
+    pub kind: String,
+}
+
+pub fn emit_entities_changed(app: &AppHandle, workspace_id: &str, kind: &str) {
+    let _ = app.emit(
+        "entities:changed",
+        &EntitiesChangedEvent {
+            workspace_id: workspace_id.to_string(),
+            kind: kind.to_string(),
         },
     );
 }
@@ -481,6 +504,168 @@ pub fn fire_trigger(
 
     // No trigger configured, stay idle
     Ok(task.clone())
+}
+
+/// The single create-a-task service path. Every human/agent surface (Tauri
+/// command, HTTP API, MCP-via-API) funnels through here so a task created from
+/// anywhere is identical: same DB row (via [`db::insert_task_full`]), same
+/// blocked-from-dependencies derivation, same trigger-firing rule, same
+/// `tasks:changed` event.
+///
+/// `fire_triggers` lets callers opt out of trigger firing (e.g. bulk import);
+/// when true, the on-entry trigger fires only if the task is not blocked by
+/// unmet dependencies — matching the long-standing UI/chef behavior.
+pub fn create_task_service(
+    conn: &Connection,
+    app: &AppHandle,
+    new: &db::NewTask,
+    fire_triggers: bool,
+) -> Result<Task, AppError> {
+    if new.title.trim().is_empty() {
+        return Err(AppError::InvalidInput(
+            "Task title cannot be empty".to_string(),
+        ));
+    }
+
+    let task = db::insert_task_full(conn, new)?;
+
+    let task = if fire_triggers && !task.blocked {
+        let column = db::get_column(conn, &task.column_id)?;
+        fire_trigger(conn, app, &task, &column)?
+    } else {
+        task
+    };
+
+    emit_tasks_changed(app, new.workspace_id, "task_created");
+    Ok(task)
+}
+
+/// The single move-a-task path. Updates column+position, and when the column
+/// changes runs the full transition: cancel a running agent (unless the target
+/// also spawns one), fire the old column's `on_exit`, clean up a worktree if the
+/// target is terminal, re-check dependents against the post-move state, emit
+/// `tasks:changed`, and fire the target column's `on_entry`. Every surface
+/// (Tauri command, HTTP API, chef) funnels through here so the transition is
+/// identical and triggers fire exactly once.
+pub fn move_task_service(
+    conn: &Connection,
+    app: &AppHandle,
+    id: &str,
+    target_column_id: &str,
+    position: i64,
+) -> Result<Task, AppError> {
+    if position < 0 {
+        return Err(AppError::InvalidInput(
+            "Position must be non-negative".to_string(),
+        ));
+    }
+
+    let task_before = db::get_task(conn, id)?;
+    let old_column_id = task_before.column_id.clone();
+    let column_changed = old_column_id != target_column_id;
+
+    let ts = db::now();
+    if column_changed {
+        conn.execute(
+            "UPDATE tasks SET column_id = ?1, position = ?2, pipeline_state = 'idle', pipeline_triggered_at = NULL, pipeline_error = NULL, updated_at = ?3 WHERE id = ?4",
+            rusqlite::params![target_column_id, position, ts, id],
+        )?;
+    } else {
+        conn.execute(
+            "UPDATE tasks SET column_id = ?1, position = ?2, updated_at = ?3 WHERE id = ?4",
+            rusqlite::params![target_column_id, position, ts, id],
+        )?;
+    }
+
+    let task = db::get_task(conn, id)?;
+    if !column_changed {
+        return Ok(task);
+    }
+
+    let old_column = db::get_column(conn, &old_column_id)?;
+    let target_column = db::get_column(conn, target_column_id)?;
+
+    // Cancel a running agent if the target column has no spawn_cli trigger.
+    // If the target also has a trigger, the new agent replaces the old one.
+    if task_before.agent_status.as_deref() == Some("running") {
+        let target_has_trigger = target_column
+            .triggers
+            .as_deref()
+            .map(|t| t.contains("spawn_cli"))
+            .unwrap_or(false);
+        if !target_has_trigger {
+            crate::chat::tmux_transport::cancel_task_agent(
+                conn,
+                id,
+                task_before.agent_session_id.as_deref(),
+            );
+        }
+    }
+
+    let _ = triggers::fire_on_exit(conn, app, &task_before, &old_column, Some(&target_column));
+
+    let task = cleanup_task_worktree_if_terminal(conn, &task, &target_column, "manual_move")?;
+
+    emit_tasks_changed(app, &task.workspace_id, "task_moved");
+
+    // Second dependents pass with post-move state (fire_on_exit's pre-move pass
+    // only saw the old column).
+    let _ = dependencies::check_dependents(conn, app, &task);
+
+    fire_trigger(conn, app, &task, &target_column)
+}
+
+/// Optional field set for a task update. `None` = leave unchanged; `Some(None)`
+/// (for nullable fields) = set to NULL. Mirrors the Tauri command's argument
+/// shape so the command, HTTP API, and chef share one update path.
+#[derive(Debug, Default)]
+pub struct UpdateTaskFields<'a> {
+    pub title: Option<&'a str>,
+    pub description: Option<Option<&'a str>>,
+    pub column_id: Option<&'a str>,
+    pub position: Option<i64>,
+    pub agent_mode: Option<Option<&'a str>>,
+    pub priority: Option<&'a str>,
+    pub model: Option<Option<&'a str>>,
+    pub estimated_hours: Option<Option<f64>>,
+}
+
+/// The single field-update path. Applies the core columns via `db::update_task`,
+/// then the model and time-tracking side-updates, and emits `tasks:changed` so
+/// every surface refreshes the UI identically (the Tauri command historically
+/// emitted nothing; MCP wrote the DB directly and skipped the event entirely).
+pub fn update_task_service(
+    conn: &Connection,
+    app: &AppHandle,
+    id: &str,
+    fields: &UpdateTaskFields,
+) -> Result<Task, AppError> {
+    let mut task = db::update_task(
+        conn,
+        id,
+        fields.title,
+        fields.description,
+        fields.column_id,
+        fields.position,
+        fields.agent_mode,
+        fields.priority,
+    )?;
+
+    if let Some(model) = fields.model {
+        let ts = db::now();
+        conn.execute(
+            "UPDATE tasks SET model = ?1, updated_at = ?2 WHERE id = ?3",
+            rusqlite::params![model, ts, id],
+        )?;
+        task = db::get_task(conn, id)?;
+    }
+
+    if let Some(hours) = fields.estimated_hours {
+        task = db::update_task_time_tracking(conn, id, hours)?;
+    }
+
+    emit_tasks_changed(app, &task.workspace_id, "task_updated");
+    Ok(task)
 }
 
 /// Evaluate exit criteria for a task.

--- a/src-tauri/src/pipeline/spawn.rs
+++ b/src-tauri/src/pipeline/spawn.rs
@@ -1,0 +1,345 @@
+//! Single source of truth for resolving "run an agent" parameters.
+//!
+//! Every spawn entry point (headless trigger, managed trigger, interactive
+//! trigger, per-task chat turn, interactive restart) needs the same five
+//! things derived from a task: which CLI to run, which model, which runtime
+//! mode, which working directory, and the initial prompt. Historically each
+//! path re-derived these ad hoc and drifted. `resolve()` is the one place the
+//! documented precedence lives:
+//!
+//! ```text
+//! trigger > task > column > workspace > global > default
+//! ```
+//!
+//! It is deliberately **`AppHandle`-free and pure** (takes `&Task` / `&Column`
+//! / `&Workspace` and plain defaults, returns data) so it is fully
+//! unit-testable. All side effects — worktree creation, `.task.md` writing, DB
+//! writes, the actual process launch, event emission — stay in the thin
+//! spawn/emit wrappers that call this.
+
+use std::collections::HashMap;
+
+use crate::db::{Column, Task, Workspace};
+use crate::error::AppError;
+
+use super::template::{self, TemplateContext};
+use super::triggers::{normalize_agent_runtime_mode, resolve_model_override, resolve_working_dir};
+
+/// The token-optimized default prompt: point the agent at `.task.md` instead
+/// of inlining the full spec. Used by every spawn path that has no explicit
+/// prompt, mirroring the `.task.md` convention written by `execute_spawn_cli`.
+pub(crate) fn task_md_default_prompt(task: &Task) -> String {
+    format!("{}\n\nSee .task.md for full spec.", task.title)
+}
+
+/// Translate an already-resolved model into CLI args: a non-empty (trimmed)
+/// model becomes `["--model", model]`, anything else becomes `[]`. The single
+/// source of truth shared by the trigger, chat, and restart argv builders.
+pub(crate) fn model_to_args(model: Option<&str>) -> Vec<String> {
+    match model {
+        Some(m) if !m.trim().is_empty() => vec!["--model".to_string(), m.to_string()],
+        _ => Vec::new(),
+    }
+}
+
+/// Trigger-config overrides — the narrowest precedence tier. Each field, when
+/// `Some`/non-empty, wins over the task/column/workspace/global tiers that
+/// `resolve()` reads from its other arguments.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct SpawnOverrides<'a> {
+    pub cli: Option<&'a str>,
+    pub command: Option<&'a str>,
+    pub prompt_template: Option<&'a str>,
+    pub prompt: Option<&'a str>,
+    pub runtime_mode: Option<&'a str>,
+    pub model: Option<&'a str>,
+}
+
+/// Everything a spawn path needs, with all precedence already applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedAgentSpawn {
+    /// Validated CLI binary/path (`"claude"` | `"codex"` | canonicalized path).
+    pub cli_type: String,
+    /// Resolved model, empty-string-normalized; `None` means "CLI default".
+    pub model: Option<String>,
+    /// `"terminal"` | `"managed"` | `"interactive"` — already normalized
+    /// (interactive downgrades to terminal when the dev flag is off / CLI
+    /// unsupported, matching the legacy behavior).
+    pub runtime_mode: String,
+    /// Worktree-or-repo, resolved via [`resolve_working_dir`]. Callers still
+    /// apply their own filesystem-existence fallback for the spawn cwd.
+    pub working_dir: String,
+    /// Prompt with the `.task.md` default applied and any slash command
+    /// prepended.
+    pub initial_prompt: String,
+}
+
+/// Resolve the full spawn parameter set for a trigger-driven agent. Pure: no
+/// `AppHandle`, no DB, no filesystem writes. The only filesystem reads are the
+/// worktree-existence check inside [`resolve_working_dir`] and the CLI-path
+/// validation inside `validate_agent_cli_path`.
+///
+/// `default_cli` / `default_model` carry the workspace+global tiers (the caller
+/// derives them from `EffectivePipelineSettings`); `prev_column` feeds the
+/// template context so `{prev_column.*}` variables interpolate.
+pub(crate) fn resolve(
+    task: &Task,
+    column: &Column,
+    workspace: &Workspace,
+    prev_column: Option<&Column>,
+    overrides: &SpawnOverrides,
+    default_cli: &str,
+    default_model: Option<&str>,
+) -> Result<ResolvedAgentSpawn, AppError> {
+    let working_dir = resolve_working_dir(task, &workspace.repo_path);
+
+    // Prompt: explicit prompt > template > `.task.md` default.
+    let ctx = TemplateContext {
+        task,
+        column,
+        workspace,
+        prev_column,
+        next_column: None,
+        dep_tasks: HashMap::new(),
+    };
+    let resolved_prompt = if let Some(p) = overrides.prompt {
+        if !p.is_empty() {
+            template::interpolate(p, &ctx)
+        } else if let Some(tmpl) = overrides.prompt_template {
+            template::interpolate(tmpl, &ctx)
+        } else {
+            task_md_default_prompt(task)
+        }
+    } else if let Some(tmpl) = overrides.prompt_template {
+        template::interpolate(tmpl, &ctx)
+    } else {
+        task_md_default_prompt(task)
+    };
+
+    // CLI: trigger config > workspace/global default. User-editable JSON is
+    // normalized through the same backend allowlist used by direct agent
+    // commands before it reaches the shell launcher.
+    let raw_cli_type = overrides
+        .cli
+        .filter(|c| !c.trim().is_empty())
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| default_cli.to_string());
+    let cli_type = if raw_cli_type.trim() == "auto" {
+        "codex".to_string()
+    } else {
+        crate::commands::agent::validate_agent_cli_path(&raw_cli_type)?
+    };
+
+    // Prepend slash command if provided.
+    let initial_prompt = match overrides.command {
+        Some(cmd) if resolved_prompt.is_empty() => cmd.to_string(),
+        Some(cmd) => format!("{}\n\n{}", cmd, resolved_prompt),
+        None => resolved_prompt,
+    };
+
+    // Runtime mode: `normalize_agent_runtime_mode` downgrades `interactive`
+    // to `terminal` when the dev flag is unset or the CLI is unsupported.
+    let runtime_mode = normalize_agent_runtime_mode(overrides.runtime_mode, &cli_type).to_string();
+
+    // Model: task override > trigger config > workspace/global default.
+    let model = resolve_model_override(task.model.as_deref(), overrides.model, default_model);
+
+    Ok(ResolvedAgentSpawn {
+        cli_type,
+        model,
+        runtime_mode,
+        working_dir,
+        initial_prompt,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    /// Build a real workspace/column/task triple via the in-memory test DB so
+    /// the model structs match production exactly.
+    fn fixture() -> (db::Workspace, db::Column, db::Task, rusqlite::Connection) {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "Test", "/tmp/test-spawn").unwrap();
+        let col = db::insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        let task = db::insert_task(&conn, &ws.id, &col.id, "My Task", None).unwrap();
+        (ws, col, task, conn)
+    }
+
+    #[test]
+    fn model_to_args_skips_blank_and_emits_flag() {
+        assert_eq!(model_to_args(None), Vec::<String>::new());
+        assert_eq!(model_to_args(Some("   ")), Vec::<String>::new());
+        assert_eq!(
+            model_to_args(Some("opus")),
+            vec!["--model".to_string(), "opus".to_string()]
+        );
+    }
+
+    #[test]
+    fn task_md_default_prompt_points_at_task_md() {
+        let (_, _, task, _) = fixture();
+        assert_eq!(
+            task_md_default_prompt(&task),
+            "My Task\n\nSee .task.md for full spec."
+        );
+    }
+
+    #[test]
+    fn resolve_uses_default_cli_and_task_md_prompt_when_unspecified() {
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.cli_type, "claude");
+        assert_eq!(resolved.model, None);
+        // No dev flag in the test env → headless terminal.
+        assert_eq!(resolved.runtime_mode, "terminal");
+        // worktree_path unset → workspace repo_path.
+        assert_eq!(resolved.working_dir, ws.repo_path);
+        assert_eq!(resolved.initial_prompt, "My Task\n\nSee .task.md for full spec.");
+    }
+
+    #[test]
+    fn resolve_trigger_cli_and_model_override_default() {
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                cli: Some("codex"),
+                model: Some("gpt-5"),
+                ..Default::default()
+            },
+            "claude",
+            Some("sonnet"),
+        )
+        .unwrap();
+        assert_eq!(resolved.cli_type, "codex");
+        // Trigger model beats the global default.
+        assert_eq!(resolved.model.as_deref(), Some("gpt-5"));
+    }
+
+    #[test]
+    fn resolve_task_model_beats_trigger_and_default() {
+        let (ws, col, _task, conn) = fixture();
+        let task = db::insert_task_full(
+            &conn,
+            &db::NewTask {
+                workspace_id: &ws.id,
+                column_id: &col.id,
+                title: "Modeled Task",
+                model: Some("haiku"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                model: Some("sonnet"),
+                ..Default::default()
+            },
+            "claude",
+            Some("opus"),
+        )
+        .unwrap();
+        assert_eq!(resolved.model.as_deref(), Some("haiku"));
+    }
+
+    #[test]
+    fn resolve_auto_cli_maps_to_codex() {
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                cli: Some("auto"),
+                ..Default::default()
+            },
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.cli_type, "codex");
+    }
+
+    #[test]
+    fn resolve_explicit_prompt_wins_and_command_prepends() {
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                prompt: Some("do the thing"),
+                command: Some("/review"),
+                ..Default::default()
+            },
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.initial_prompt, "/review\n\ndo the thing");
+    }
+
+    #[test]
+    fn resolve_command_only_uses_command_as_prompt() {
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                prompt: Some(""),
+                command: Some("/review"),
+                ..Default::default()
+            },
+            "claude",
+            None,
+        )
+        .unwrap();
+        // Empty explicit prompt + no template → falls to the .task.md default,
+        // which is non-empty, so the command is prepended (not used alone).
+        assert_eq!(
+            resolved.initial_prompt,
+            "/review\n\nMy Task\n\nSee .task.md for full spec."
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_unknown_cli() {
+        let (ws, col, task, _conn) = fixture();
+        let err = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                cli: Some("aider"),
+                ..Default::default()
+            },
+            "claude",
+            None,
+        );
+        assert!(err.is_err());
+    }
+}

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
+use super::spawn;
 use super::template::{self, TemplateContext};
 use super::{emit_pipeline, PipelineState, EVT_ADVANCED, EVT_RUNNING, EVT_TRIGGERED};
 
@@ -211,6 +212,27 @@ pub struct ColumnTriggersV2 {
     /// UI writes it yet — Phase 4 adds the column-config picker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_runtime_mode: Option<String>,
+}
+
+/// The single validator for a column-triggers JSON string. Empty or `"{}"` is
+/// treated as "no triggers" (valid). Otherwise the string must deserialize into
+/// [`ColumnTriggersV2`], which enforces valid action types and required fields
+/// (e.g. `run_script` needs `script_id`). Used by the Tauri command, the HTTP
+/// API, and the chef executor so every surface validates triggers identically —
+/// previously the chef path accepted any JSON with no validation.
+pub fn validate_triggers_json(triggers: &str) -> Result<(), AppError> {
+    let trimmed = triggers.trim();
+    if trimmed.is_empty() || trimmed == "{}" {
+        return Ok(());
+    }
+    serde_json::from_str::<ColumnTriggersV2>(trimmed)
+        .map(|_| ())
+        .map_err(|e| {
+            AppError::InvalidInput(format!(
+                "Invalid trigger configuration: {}. Check that trigger types match: auto_setup, spawn_cli, move_column, trigger_task, run_script (requires script_id), create_pr, auto_merge, none.",
+                e
+            ))
+        })
 }
 
 /// Exit criteria (V2 format).
@@ -954,7 +976,7 @@ fn execute_batch_wait(
 }
 
 /// Resolve working directory for a task: worktree_path (if set and exists) > workspace.repo_path.
-fn resolve_working_dir(task: &Task, workspace_repo_path: &str) -> String {
+pub(crate) fn resolve_working_dir(task: &Task, workspace_repo_path: &str) -> String {
     if let Some(ref wt) = task.worktree_path {
         if !wt.is_empty() && std::path::Path::new(wt).exists() {
             return wt.clone();
@@ -963,7 +985,7 @@ fn resolve_working_dir(task: &Task, workspace_repo_path: &str) -> String {
     workspace_repo_path.to_string()
 }
 
-fn resolve_model_override(
+pub(crate) fn resolve_model_override(
     task_model: Option<&str>,
     trigger_model: Option<&str>,
     default_model: Option<&str>,
@@ -1583,7 +1605,31 @@ fn execute_spawn_cli(
         task.clone()
     };
 
-    let mut working_dir = resolve_working_dir(&task, &workspace.repo_path);
+    // Resolve cli / model / runtime-mode / prompt / cwd precedence in one
+    // place (see pipeline::spawn::resolve). All side effects below — worktree
+    // .task.md, DB writes, event emission, dispatch — stay here in the caller.
+    let resolved = spawn::resolve(
+        &task,
+        column,
+        &workspace,
+        other_column,
+        &spawn::SpawnOverrides {
+            cli,
+            command,
+            prompt_template,
+            prompt,
+            runtime_mode,
+            model,
+        },
+        &pipeline_settings.default_agent_cli,
+        pipeline_settings.default_model.as_deref(),
+    )?;
+    let cli_type = resolved.cli_type;
+    let initial_prompt = resolved.initial_prompt;
+    let runtime_mode = resolved.runtime_mode;
+    let resolved_model = resolved.model;
+
+    let mut working_dir = resolved.working_dir;
 
     // Belt-and-braces: if the resolved dir is gone (terminal-column case
     // where worktree was just removed, or any other race), fall back to the
@@ -1648,56 +1694,11 @@ fn execute_spawn_cli(
         }
     }
 
-    let ctx = TemplateContext {
-        task: &task,
-        column,
-        workspace: &workspace,
-        prev_column: other_column,
-        next_column: Option::None,
-        dep_tasks: HashMap::new(),
-    };
-
-    // Resolve prompt: direct prompt > template > .task.md pointer (token-optimized default)
-    let resolved_prompt = if let Some(p) = prompt {
-        if !p.is_empty() {
-            template::interpolate(p, &ctx)
-        } else if let Some(tmpl) = prompt_template {
-            template::interpolate(tmpl, &ctx)
-        } else {
-            format!("{}\n\nSee .task.md for full spec.", task.title)
-        }
-    } else if let Some(tmpl) = prompt_template {
-        template::interpolate(tmpl, &ctx)
-    } else {
-        format!("{}\n\nSee .task.md for full spec.", task.title)
-    };
-
-    // Resolve CLI: trigger config > workspace config > global settings.
-    // Stored trigger/workspace config is user-editable JSON, so normalize it
-    // through the same backend allowlist used by direct agent commands before
-    // it reaches the shell launcher.
-    let raw_cli_type = cli
-        .filter(|c| !c.trim().is_empty())
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| pipeline_settings.default_agent_cli.clone());
-    let cli_type = if raw_cli_type.trim() == "auto" {
-        "codex".to_string()
-    } else {
-        crate::commands::agent::validate_agent_cli_path(&raw_cli_type)?
-    };
-
-    // Prepend slash command if provided
-    let initial_prompt = match command {
-        Some(cmd) if resolved_prompt.is_empty() => cmd.to_string(),
-        Some(cmd) => format!("{}\n\n{}", cmd, resolved_prompt),
-        None => resolved_prompt,
-    };
-
-    // Store resolved prompt. `normalize_agent_runtime_mode` downgrades
-    // `interactive` to `terminal` when KAITENCODE_INTERACTIVE_MODE_ENABLED is
-    // unset (with a one-time warning) so existing pipelines aren't affected.
+    // `runtime_mode` (resolved above) is already normalized:
+    // `normalize_agent_runtime_mode` downgraded `interactive` to `terminal`
+    // when KAITENCODE_INTERACTIVE_MODE_ENABLED is unset (with a one-time
+    // warning) so existing pipelines aren't affected.
     let ts = db::now();
-    let runtime_mode = normalize_agent_runtime_mode(runtime_mode, &cli_type);
     if let Err(e) = conn.execute(
         "UPDATE tasks SET trigger_prompt = ?1, agent_mode = ?2, updated_at = ?3 WHERE id = ?4",
         rusqlite::params![initial_prompt, runtime_mode, ts, task.id],
@@ -1733,17 +1734,7 @@ fn execute_spawn_cli(
         Some(format!("CLI trigger: {}", cli_type)),
     );
 
-    // Resolve model: task override > trigger config > workspace config > global settings
-    let resolved_model = resolve_model_override(
-        task.model.as_deref(),
-        model,
-        pipeline_settings.default_model.as_deref(),
-    );
-    let mut cli_args = Vec::new();
-    if let Some(ref m) = resolved_model {
-        cli_args.push("--model".to_string());
-        cli_args.push(m.clone());
-    }
+    let mut cli_args = spawn::model_to_args(resolved_model.as_deref());
     if let Some(flags) = flags {
         cli_args.extend(flags.iter().cloned());
     }
@@ -1798,7 +1789,10 @@ fn execute_spawn_cli(
     Ok(updated_task)
 }
 
-fn normalize_agent_runtime_mode(runtime_mode: Option<&str>, cli_type: &str) -> &'static str {
+pub(crate) fn normalize_agent_runtime_mode(
+    runtime_mode: Option<&str>,
+    cli_type: &str,
+) -> &'static str {
     match runtime_mode {
         Some("managed") => "managed",
         Some("interactive") => {
@@ -3290,6 +3284,23 @@ pub fn resolve_column_target(
 mod tests {
     use super::*;
     use crate::db;
+
+    #[test]
+    fn test_validate_triggers_json() {
+        // Empty / "{}" means "no triggers" — valid.
+        assert!(validate_triggers_json("").is_ok());
+        assert!(validate_triggers_json("   ").is_ok());
+        assert!(validate_triggers_json("{}").is_ok());
+
+        // A well-formed V2 config validates.
+        let valid = r#"{"on_entry":{"type":"spawn_cli","cli":"claude"}}"#;
+        assert!(validate_triggers_json(valid).is_ok());
+
+        // Garbage / unknown action types are rejected (the chef path used to
+        // accept these silently).
+        assert!(validate_triggers_json("not json").is_err());
+        assert!(validate_triggers_json(r#"{"on_entry":{"type":"bogus_action"}}"#).is_err());
+    }
 
     fn setup() -> (
         rusqlite::Connection,


### PR DESCRIPTION
Third leg of the source-of-truth refactor (Fronts 1–2 already landed). Funnels every "run an agent" entry point through shared, behavior-preserving helpers.

## What changed
- **New pure `pipeline::spawn` module** — `ResolvedAgentSpawn` + `resolve()` centralize cli / model / runtime-mode / working-dir / prompt precedence (`AppHandle`-free, unit-tested). `model_to_args` + `task_md_default_prompt` single-sourced. `execute_spawn_cli` routes through `resolve()`; `agent_restart` and `build_task_input_line` reuse the shared helpers.
- **`bridge::persist_agent_session_started`** dedups the two trigger session-create paths and **fixes the empty-`workspace_id` `agent_session_created` emit** — the `tasks:changed` event was dropped by the frontend workspace filter, so the live card never refreshed.
- **Chef `move_task` parity (A1)** — now routes through `pipeline::move_task_service` via a new `TaskMoveRequested` outcome (keeps `execute_single_tool` `AppHandle`-free), gaining `on_exit` / agent-cancel / worktree cleanup / `on_entry` / 2nd dependents pass.
- **Shared Claude streaming flags** via `runtime::CLAUDE_STREAM_OUTPUT_FLAGS` so the managed/terminal argv builders can't drift on them. The argv families are otherwise intentionally left separate (different invocation shapes — collapsing would change the live headless render).

## Deliberate non-changes
- `agent_restart` cli/model precedence left as-is (task.model only) to avoid behavior change.
- `agent.rs` managed-turn emits still pass empty `workspace_id` (out of scope — different chat-turn path).
- argv families not fully collapsed (see above).

## Verification
`cargo test --lib` 478 passing · `mcp-server` 17 passing · `tsc --noEmit` + `eslint` clean. Precommit `cargo check --workspace` green.