### PR TITLE
Front 3 + B-series roadmap: agent-spawn unification, create UI, interactive opt-in, chef terminal, CLI health

### DIFF
--- a/.tickets/_docs/handoffs/FRONT3_AGENT_SPAWN.md
+++ b/.tickets/_docs/handoffs/FRONT3_AGENT_SPAWN.md
@@ -1,0 +1,161 @@
+# Handoff — Front 3: Unify the agent-spawn path (one `ResolvedAgentSpawn`)
+
+> **Status:** not started. This is the third and deepest leg of the
+> "single source of truth" refactor. Fronts 1 (task mutations) and 2 (entity
+> ops) are landed and green — see `git log` and the existing
+> `pipeline::create_task_service` / `move_task_service` / `update_task_service`
+> for the established pattern this front should mirror.
+
+## Why this exists
+
+KaitenCode spawns CLI agents (claude / codex) from **5+ entry points**, and the
+logic for "given a task, figure out the CLI, model, working dir, prompt, and
+make the agent_session row" is **copy-pasted** across them. They drift: a flag
+or precedence rule fixed in one path silently stays wrong in the others. This is
+the same divergence we already killed for task/entity mutations, applied to the
+"run an agent" verb.
+
+**Goal:** one resolver (`ResolvedAgentSpawn`) that every spawn path builds first,
+plus one `agent_session` creation helper. Behavior must not change — this is a
+consolidation, verified by the existing test suite staying green.
+
+> ⚠️ Line numbers below are approximate (the tree shifted during Fronts 1–2).
+> **Anchor on the symbol names — grep for them.** All symbols verified present
+> as of this handoff.
+
+## The 5+ spawn entry points (grep these)
+
+| # | Path | Entry symbol | File | argv builder |
+|---|---|---|---|---|
+| 1 | Headless trigger, `terminal` render | `spawn_cli_trigger_task` | `chat/bridge.rs:~1240` | `build_trigger_command` → `build_claude_streaming_command` / `build_codex_streaming_command` (`bridge.rs:~426/509/581`) — **shell-string + jq** |
+| 2 | Headless trigger, `managed` render | `spawn_managed_trigger_task` → `start_managed_trigger_turn` | `pipeline/triggers.rs` | `managed_trigger_turn_args` → `ClaudeCliAdapter/CodexCliAdapter::managed_turn_args` (`chat/runtime.rs:217/322`) — **argv vec** |
+| 3 | Interactive trigger | `spawn_interactive_trigger_task` → `spawn_interactive_cli` | `chat/bridge.rs:~2684/2546` | inline arg push in `execute_spawn_cli` (`triggers.rs`) + `build_interactive_claude_argv`/`build_interactive_codex_argv` |
+| 4 | Per-task chat, managed turn | `spawn_managed_task_turn` | `commands/agent.rs:~729` | adapters (`managed_turn_args`) |
+| 5 | Per-task chat, interactive/terminal turn | `build_task_input_line` (from `send_task_input`) | `commands/agent.rs:~1070/389` | `build_trigger_command` + its **own** model→args (`agent.rs:~1084`) |
+| 6 | Chef / orchestrator | `UnifiedChatSession::send_message` | `chat/chef.rs` → `chat/session.rs:~167` | `build_pipe_args_for_cli` (`session.rs:346`) → adapters |
+| — | Restart (interactive) | `agent_restart` | `commands/agent_interactive.rs:152` | own working-dir + model→args (`~184`) |
+| — | retry / retry_from_start / queue-promote / dep `on_met` | — | `commands/task.rs`, `triggers.rs` | **already funnel through `pipeline::fire_trigger` → `execute_spawn_cli`** — no divergence, leave alone |
+
+## What's duplicated (the actual work to remove)
+
+**(b) `model → ["--model", m]` resolution — 4 copies.** `execute_spawn_cli`
+(`triggers.rs`), `build_task_input_line` (`agent.rs`), `agent_restart`
+(`agent_interactive.rs`), and inside the adapters. A canonical
+`resolve_model_override` already exists at `triggers.rs:987` but **only the
+pipeline path uses it**; agent.rs and agent_interactive.rs re-implement the
+precedence/empty-string handling ad hoc.
+
+**(c) working-dir resolution — 3 copies.** `resolve_working_dir` (`triggers.rs:978`),
+`resolve_task_working_dir` (`agent.rs:140`), and an inline copy in `agent_restart`.
+All compute `worktree_path if exists else repo_path`.
+
+**(d) prompt-default — 2 copies.** `format!("{}\n\nSee .task.md for full spec.", task.title)`
+appears in `triggers.rs` and `agent_interactive.rs` (tied to the `.task.md`
+token-optimization convention).
+
+**(e) `agent_session` row creation — 3 copies.** `spawn_cli_trigger_task`
+(`bridge.rs:~1271`), `spawn_interactive_trigger_task` (`bridge.rs:~2700`), and the
+per-task chat path. Each independently: `insert_agent_session` (or reuse a
+persistent one), `update_agent_session_runtime`, `update_agent_session_model`,
+`update_task_agent_status`, set `tasks.agent_session_id`, then
+`emit_tasks_changed(app, "", "agent_session_created")`.
+**🐞 Latent bug to fix here:** both bridge paths pass an **empty `workspace_id`**
+(`""`) to that emit, so the `tasks:changed` event carries no workspace and the
+frontend filter (`payload.workspaceId === workspaceId` in `useTaskSync`) drops
+it. Thread the real `workspace_id` through when extracting the helper.
+
+**(f) Two argv families that can drift.** Managed mode (#2, #4, #6) correctly
+converges on `ClaudeCliAdapter/CodexCliAdapter::managed_turn_args`
+(`runtime.rs`). The terminal/interactive family (#1, #3, #5, restart) builds a
+**separate shell string** via `build_trigger_command` → `build_claude_streaming_command`
+(`bridge.rs:509`) that re-lists `--print --output-format stream-json --verbose --model …`
+plus a jq filter — with no relationship to the adapter args. Add a flag to the
+adapter and you have to remember to also edit the shell-string builder.
+
+**(note) Existing types that are NOT the answer.** `SpawnConfig`
+(`chat/transport.rs:~28`) only describes a single process launch for
+`ChatTransport::spawn` — no model/runtime_mode/cli_type/resume/agent_session
+concept. `SessionConfig` (`chat/session.rs:~45`) is closest (cli_path / model /
+system_prompt / working_dir / effort) but is private to the chat-session layer
+and unused by the pipeline trigger path.
+
+## Recommended approach (ranked, do in order)
+
+### Step 1 — `ResolvedAgentSpawn` + one `resolve()` (highest payoff, lowest risk)
+Introduce a struct (new module, e.g. `chat::spawn` or `pipeline::spawn`):
+```rust
+pub struct ResolvedAgentSpawn {
+    pub cli_type: String,          // "claude" | "codex" | other
+    pub model: Option<String>,     // already-resolved, empty-string-normalized
+    pub runtime_mode: String,      // "terminal" | "managed" | "interactive"
+    pub working_dir: String,       // worktree-or-repo, already resolved
+    pub resume_id: Option<String>,
+    pub initial_prompt: String,    // with .task.md default applied
+    pub include_sentinel: bool,
+    pub env: Vec<(String, String)>,
+}
+pub fn resolve(task: &Task, column: &Column, workspace: &Workspace,
+               settings: &AppSettings, trigger_overrides: Option<&...>) -> ResolvedAgentSpawn;
+```
+`resolve()` is the ONE place the documented precedence lives
+(`trigger > task > column > workspace > global > default` — see CLAUDE.md and
+`resolve_runtime_mode_for_task`). Reuse `resolve_model_override`,
+`resolve_working_dir`, and the runtime-mode resolver inside it. Then have
+`execute_spawn_cli`, `spawn_managed_task_turn`, `send_task_input`, and
+`agent_restart` each build a `ResolvedAgentSpawn` first and read from it. This
+kills duplications (b), (c), (d) immediately.
+
+### Step 2 — collapse the two argv families
+Make `build_trigger_command` (terminal/shell-string path) derive its base flags
+from the same `ClaudeCliAdapter`/`CodexCliAdapter` the managed path uses, so a
+new flag added to the adapter automatically reaches both. The jq-wrapping is the
+only legitimately terminal-specific part — keep that, share everything else.
+Medium risk: this touches the live headless render. Lean on the existing
+`bridge.rs` argv tests (`test_build_trigger_command_*`,
+`test_build_claude_streaming_command_*`).
+
+### Step 3 — one `agent_session` creation helper
+Extract `create_or_reuse_agent_session(conn, task, cli, working_dir, runtime_mode, model) -> AgentSession`
+used by both bridge spawn fns and the chat path. Fix the empty-`workspace_id`
+emit (bug above) while you're in there.
+
+## ⚠️ The test-typing landmine (read before you start)
+
+The same constraint that blocked chef-move parity in Front 1 applies here:
+**`execute_single_tool` in `llm/executor.rs` is deliberately `AppHandle`-free**
+because its unit tests can't construct a Wry `AppHandle` (mock runtime is
+`AppHandle<MockRuntime>`, the code wants `AppHandle<Wry>`; they don't unify).
+Any fn requiring `&AppHandle` cannot be unit-tested the same way.
+
+Practical consequences:
+- Keep `resolve()` and argv builders **`AppHandle`-free and pure** (take
+  `&Task`/`&Column`/`&Workspace`/`&AppSettings`, return data). Then they're
+  fully unit-testable — write tests asserting model/cwd/prompt/runtime_mode
+  resolution and argv contents for claude+codex × terminal+managed+interactive.
+- Confine `&AppHandle` to the thin spawn/emit wrappers (the agent_session
+  helper, the actual process launch), which stay covered by integration-level
+  behavior, not unit tests.
+- This split is also *why* Step 1 is low-risk: the hard-to-test part (resolution
+  + argv) becomes pure and testable; only the already-untested launch glue
+  stays untested.
+
+## Verification
+- `cargo test --lib` (currently **468 passing**) must stay green — especially
+  the `bridge.rs` argv/escaping/sentinel tests and `agent.rs`
+  `build_task_input_line_*` tests.
+- Add unit tests for `resolve()` covering the precedence chain and for the
+  collapsed argv builder (claude/codex × terminal/managed/interactive, with and
+  without resume_id / model / sentinel).
+- Manual smoke (needs the app + `KAITENCODE_INTERACTIVE_MODE_ENABLED=1`): fire a
+  headless trigger, a managed trigger, an interactive trigger, a per-task chat
+  turn, and `agent_restart` — confirm each still spawns with the right model,
+  cwd, and prompt, and that `tasks:changed` now carries the correct workspaceId
+  (verify the live card updates, which it didn't before the (e) bug fix).
+
+## Definition of done
+- One `ResolvedAgentSpawn::resolve()` built by all of #1, #3, #4, #5, restart.
+- `resolve_model_override` / working-dir / prompt-default each have exactly one
+  implementation.
+- One `agent_session` creation helper; empty-`workspace_id` emit bug fixed.
+- Terminal and managed argv share the adapter as their base.
+- All existing tests green + new resolver/argv unit tests added.

--- a/.tickets/_docs/handoffs/REMAINING_WORK.md
+++ b/.tickets/_docs/handoffs/REMAINING_WORK.md
@@ -1,0 +1,154 @@
+# Remaining Work — Handoff Index
+
+Context for everything below: this session ran a "source of truth" refactor and
+scoped a terminal-harness roadmap. **Landed & green** (468 Rust lib tests, 17
+MCP, 394 frontend, tsc + lint clean):
+
+- **Front 1 — task mutations unified.** `mark_complete`, `add/remove_dependency`,
+  `update_task`, `move_task` (Tauri+API), `reject_task`, `delete_task` (chef
+  cleanup), `approve_task` now funnel through shared `pipeline::*_service` fns;
+  MCP routes through `/api/*` instead of writing the DB directly. New services:
+  `create_task_service`, `update_task_service`, `move_task_service`,
+  `dependencies::set_task_dependencies`; new routes `/api/mark_complete`,
+  `/api/set_dependencies`, `/api/update_task`.
+- **Front 2 — entity ops unified.** New routes `/api/create_workspace`
+  (shares `commands::workspace::create_workspace_core` with the UI),
+  `/api/create_column`, `/api/configure_triggers`, `/api/create_script`; all 5
+  MCP entity handlers repointed (app-first + test-only DB fallback). One
+  `pipeline::triggers::validate_triggers_json`. New `entities:changed` event +
+  `useEntitySync` hook so MCP/chef entity changes refresh the UI live.
+
+What follows is everything **not** done, each with enough to hand off cleanly.
+The big one (Front 3 — agent spawn) has its own doc: `FRONT3_AGENT_SPAWN.md`.
+
+---
+
+## A. Source-of-truth leftovers (small, ride-along cleanups)
+
+### A1. Chef `move_task` transition parity — DEFERRED, documented
+`move_task` is unified for Tauri + HTTP API via `pipeline::move_task_service`,
+but the **chef path** (`execute_single_tool` `"move_task"` arm in
+`llm/executor.rs`) still does a raw move (`move_task_to_column`) + the caller
+loop fires only `on_entry`. It skips `on_exit`, agent-cancel, worktree-terminal
+cleanup, and the 2nd `check_dependents` pass.
+**Why deferred:** routing it through `move_task_service` needs `&AppHandle`
+inside `execute_single_tool`, which is deliberately app-free for its Wry-vs-Mock
+unit tests (see the test landmine in `FRONT3_AGENT_SPAWN.md`). Cleanest fix:
+have the move arm return a `TaskMoveRequested { task_id, target_column_id, position }`
+outcome (no DB write) and let the caller loop — which *has* `app` — call
+`move_task_service`. Update the two `test_move_task_*` unit tests to assert on
+the new outcome / test `move_task_to_column` directly. Medium effort; **best done
+as part of Front 3** since it shares the same `app`-threading constraint.
+
+### A2. Event-payload casing — `pty:{taskId}:exit` (tiny)
+`PtyExitPayload` in `events.rs` has **no `#[serde(rename_all = "camelCase")]`**,
+so it emits snake_case `exit_code`. It works today only because the frontend
+reads `payload.exit_code` (`terminal-view.tsx`). It's the one event violating the
+camelCase rule in CLAUDE.md. Fix: add the rename to the struct, update the
+frontend to `exitCode`. While there, the `agent:*` events and
+`pipeline:step_progress` use raw `json!` with hand-written camelCase keys — they
+work but should become typed structs to be drift-proof (low urgency).
+
+### A3. Chef `create_task` uses `insert_task_full` directly — intentional, noted
+The chef `create_task` arm calls `db::insert_task_full` (not
+`create_task_service`) because its caller loop already owns trigger-firing +
+event emission and `__LAST__` tracking. The DB *row* is identical to all other
+paths (the thing that mattered), so this is fine — just don't "fix" it into a
+double-fire.
+
+---
+
+## B. Terminal-harness roadmap (the original 5-phase plan)
+
+Full design in `/home/anonabento/.claude/plans/peppy-stargazing-locket.md`.
+Phase 1 (task-creation source-of-truth) is **done** (it became Front 1's
+foundation). Remaining phases:
+
+### B1. Phase 2 — Expose every agent option in the create UI
+Front 1 made `model` / `trigger_prompt` / `dependencies` / `priority` /
+`runtime_mode_override` first-class create params (backend `db::NewTask`, the
+`create_task` Tauri command, and the `createTask` IPC `CreateTaskOptions` bag all
+accept them). **The UI doesn't surface them yet** — the inline add
+(`kanban/column.tsx`) and command palette only pass title/description.
+**Do:** lift the model + `runtime_mode_override` pickers that already exist in
+`task-settings-modal.tsx` into a shared create/edit widget, and let the
+new-task surface set model / runtime mode / target column / priority /
+trigger prompt / dependencies. Pure frontend; the backend + IPC are ready.
+
+### B2. Phase 3 — Promote interactive mode (opt-in)
+Interactive mode is fully built but gated behind env var
+`KAITENCODE_INTERACTIVE_MODE_ENABLED` (read via `config::interactive_mode_enabled()`,
+3 call sites: `triggers.rs` resolver downgrade, the `interactive_dev_flag_required`
+field, and the `interactive_mode_dev_flag()` command).
+**Do:** (1) replace the raw env gate with a real setting
+(`AppSettings.default_runtime_mode` already exists and is read at the global tier
+of `resolve_runtime_mode_with_workspace_config`); (2) Settings UI: "Agent
+runtime" control (global default + enable-interactive toggle); (3) Onboarding
+step in `onboarding/onboarding-wizard.tsx` (note the billing difference:
+interactive = subscription limits, headless = API/SDK credit); (4) **per-chat
+toggle** in the agent panel header that flips a task interactive↔headless by
+writing `tasks.runtime_mode_override` and restarting via the existing
+`agent_restart` command (the panel already remounts on mode change via
+`useResolvedRuntimeMode` + `key=`). Keep headless the default (user decision:
+opt-in). Claude-first; codex stays best-effort.
+**Known codex gaps (defer):** interactive resume isn't wired
+(`bridge.rs` `spawn_interactive_cli` warns + ignores `resume_id` for codex), and
+whether codex honors `--append-system-prompt` for the sentinel is unverified.
+
+### B3. Phase 4 — Chef terminal view (workspace-level terminal wrapper)
+Let the user drive an interactive CLI at the **workspace** level inside
+KaitenCode (no external terminal). ChefSession (`chat/chef.rs`) is pipe-only
+today; the orchestrator panel renders chat bubbles. Per-task terminals already
+work via `TmuxTransport` + `terminal-view.tsx`, keyed by `taskId`.
+**Do:** add a tmux session `kaitencode_chef_<workspace_id>`; generalize the
+`taskId`-keyed terminal IPC in `commands/terminal.rs`
+(`write_to_pty`/`resize_pty`/`get_pty_scrollback`) to accept any session id (or
+add `*_orchestrator_pty` variants); add an `OrchestratorTerminalView` + chat↔
+terminal toggle in the orchestrator panel; generalize `pty:{taskId}:output` →
+`pty:{sessionId}:output`. Est. ~300 Rust + ~150 TSX. Reuse, don't reinvent — the
+registry already namespaces chef as `chef:{workspace_id}:{session_id}`.
+
+### B4. Phase 5 — CLI-compatibility verification layer
+Interactive mode shells directly into `claude`/`codex`; a CLI update can silently
+break the product. **Do:** a startup/diagnostic CLI health check (detect binary
+via `commands/cli_detect.rs` `find_cli`, run `--version`, parse `--help` to
+assert expected flags exist, surface a UI warning on drift/missing); pin
+known-good version ranges in settings (warn, don't hard-fail); add a
+feature-flagged live smoke test that spawns claude/codex in a throwaway tmux
+session and asserts ready-indicator + sentinel round-trip. Fragile assumptions to
+guard (all in `bridge.rs`): claude `--dangerously-skip-permissions`,
+`--output-format stream-json`, `--include-partial-messages`,
+`--append-system-prompt`; codex `exec`, `--json`, `-c sandbox_mode=…`; the
+ready-indicators (claude `╭`/`╰`, codex banner+32 bytes); sentinel-on-own-line.
+**Verify in particular** whether codex actually accepts `--append-system-prompt`
+(it's in the code but unconfirmed).
+
+---
+
+## C. Pre-existing product gaps (found during status audit — not refactor work)
+
+Lower priority, separate from the source-of-truth/harness effort, but worth a
+ticket each:
+- **Custom keyboard shortcuts** render but are inert — `settings/tabs/shortcuts-tab.tsx`
+  says "not yet active"; no store/apply of custom bindings.
+- **Providers** OpenRouter / Google AI / Local (Ollama) are "Coming soon" cards
+  in `settings/tabs/agent-tab.tsx`.
+- **Voice/Whisper** fully implemented but feature-gated out of the default build
+  (`voice` Cargo feature; `voice_stubs.rs`).
+- **`thinking_level`** is *not* a stored task attribute and `--effort` isn't
+  wired into the trigger path. If you want thinking-level as a first-class
+  create option (Phase 2), it needs a DB column (migration after 045) + model
+  struct field + CLI plumbing — a real slice, not a freebie.
+- **CLAUDE.md drift:** the architecture diagram lists a `discord/ ← Discord
+  bridge` module that no longer exists (added in migrations 018/019, removed by
+  026_remove_discord). Update the doc.
+
+---
+
+## Suggested order for the next agent(s)
+1. **Front 3** (`FRONT3_AGENT_SPAWN.md`) — fold in **A1** (chef move parity) and
+   **A2 (e)** (empty-`workspace_id` emit) since they share the `app`-threading
+   constraint.
+2. **B1** (Phase 2 UI) — small, unblocks the create-UX win; backend already ready.
+3. **B2** (interactive promotion) — depends on B1's shared runtime-mode picker.
+4. **B3 / B4** — independent; can parallelize after B2.

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1764,6 +1764,111 @@ pub async fn ensure_pty_session(
     })
 }
 
+/// Phase 4 (chef terminal) — ensure a workspace-level interactive terminal
+/// exists, mirroring `ensure_pty_session` but keyed by workspace instead of
+/// task. It's a login shell rooted at the repo, so the user can drive
+/// `claude`/`codex` (or anything) without leaving the app. The registry key is
+/// `chef_<workspace_id>`, so it rides the same generic PTY IPC
+/// (`write_to_pty`/`resize_pty`/`get_pty_scrollback`) and `pty:<key>:*` events
+/// as task terminals — only the spawn/attach entrypoint differs.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn ensure_chef_terminal(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    session_registry: State<'_, SharedSessionRegistry>,
+    workspace_id: String,
+    cols: u16,
+    rows: u16,
+    allow_spawn: Option<bool>,
+) -> Result<AgentInfo, String> {
+    let repo_path = {
+        let conn = state.db.lock().map_err(|e| e.to_string())?;
+        db::get_workspace(&conn, &workspace_id)
+            .map_err(|_| format!("workspace not found: {}", workspace_id))?
+            .repo_path
+    };
+    let key = format!("chef_{}", workspace_id);
+    let allow_spawn = allow_spawn.unwrap_or(true);
+    let mut registry = session_registry.lock().await;
+
+    // Case 1: session alive — reattach (resize + bridge) and return.
+    let session_alive = registry.get(&key).map(|s| s.is_alive()).unwrap_or(false);
+    if session_alive {
+        let needs_bridge = !registry.has_active_bridge(&key);
+        let (scrollback, pid, resubscribe_rx) = {
+            let session = registry.get_mut(&key).unwrap();
+            let _ = session.resize_pty(cols, rows);
+            let scrollback = if needs_bridge { String::new() } else { session.scrollback() };
+            let pid = session.pid();
+            let rx = if needs_bridge { session.resubscribe() } else { None };
+            (scrollback, pid, rx)
+        };
+        if let Some(rx) = resubscribe_rx {
+            let bridge = crate::chat::bridge::ManagedBridge::start(app.clone(), key.clone(), rx);
+            registry.set_bridge(&key, bridge);
+        }
+        return Ok(AgentInfo {
+            task_id: key,
+            agent_type: "shell".to_string(),
+            status: "Running".to_string(),
+            pid,
+            working_dir: repo_path,
+            scrollback: if scrollback.is_empty() { None } else { Some(scrollback) },
+        });
+    }
+
+    // Case 2: dead/missing and caller only wants to attach — restore scrollback.
+    if !allow_spawn {
+        registry.remove(&key);
+        let cached = registry.take_scrollback(&key);
+        let tmux = capture_scrollback(&key);
+        let scrollback = if !tmux.is_empty() { tmux } else { cached };
+        return Ok(AgentInfo {
+            task_id: key,
+            agent_type: "shell".to_string(),
+            status: "Missing".to_string(),
+            pid: None,
+            working_dir: repo_path,
+            scrollback: if scrollback.is_empty() { None } else { Some(scrollback) },
+        });
+    }
+
+    // Case 3: spawn a fresh shell at the repo root.
+    registry.remove(&key);
+    let cached_scrollback = registry.take_scrollback(&key);
+    let config = SessionConfig {
+        cli_path: default_user_shell(),
+        model: String::new(),
+        system_prompt: String::new(),
+        working_dir: Some(repo_path.clone()),
+        effort_level: None,
+    };
+    let session = registry
+        .get_or_create(&key, config, TransportType::Pty)
+        .map_err(|e| e.to_string())?;
+    let _mpsc_rx = session.start_pty(cols, rows)?;
+    let pid = session.pid();
+    let live_scrollback = session.scrollback();
+    if let Some(rx) = session.resubscribe() {
+        let bridge = crate::chat::bridge::ManagedBridge::start(app.clone(), key.clone(), rx);
+        registry.set_bridge(&key, bridge);
+    }
+    Ok(AgentInfo {
+        task_id: key,
+        agent_type: "shell".to_string(),
+        status: "Running".to_string(),
+        pid,
+        working_dir: repo_path,
+        scrollback: if !live_scrollback.is_empty() {
+            Some(live_scrollback)
+        } else if cached_scrollback.is_empty() {
+            None
+        } else {
+            Some(cached_scrollback)
+        },
+    })
+}
+
 /// Cancel an ongoing agent chat by sending Ctrl+C, preserving the session.
 #[tauri::command(rename_all = "camelCase")]
 pub async fn cancel_agent_chat(app: AppHandle, task_id: String) -> Result<(), AppError> {

--- a/src-tauri/src/commands/cli_detect.rs
+++ b/src-tauri/src/commands/cli_detect.rs
@@ -396,10 +396,236 @@ pub fn verify_cli_path(path: String) -> DetectedCli {
     }
 }
 
+// ─── CLI compatibility health check (Phase 5) ────────────────────────────────
+//
+// Interactive/headless modes shell straight into `claude`/`codex`, so a CLI
+// update that renames or drops a flag silently breaks the product. This layer
+// probes each CLI's `--help` and asserts the flags `chat::bridge` depends on
+// still exist, and compares `--version` against an optional known-good floor.
+// It only ever *warns* — never hard-blocks.
+
+/// A help probe: print help for some (sub)command, then assert `flags` appear.
+struct FlagProbe {
+    /// Args that print the relevant help (e.g. `["--help"]`, `["exec", "--help"]`).
+    help_args: &'static [&'static str],
+    /// Flags expected to appear in that help output.
+    flags: &'static [&'static str],
+}
+
+struct CliHealthSpec {
+    id: &'static str,
+    name: &'static str,
+    binary: &'static str,
+    version_args: &'static [&'static str],
+    probes: &'static [FlagProbe],
+}
+
+/// The flags `chat::bridge` actually passes. Keep in sync with the argv builders
+/// there (`build_*_streaming_command`, `build_interactive_*_argv`).
+const CLI_HEALTH_SPECS: &[CliHealthSpec] = &[
+    CliHealthSpec {
+        id: "claude",
+        name: "Claude Code",
+        binary: "claude",
+        version_args: &["--version"],
+        probes: &[FlagProbe {
+            help_args: &["--help"],
+            flags: &[
+                "--dangerously-skip-permissions",
+                "--output-format",
+                "--include-partial-messages",
+                "--append-system-prompt",
+                "--resume",
+                "--model",
+            ],
+        }],
+    },
+    CliHealthSpec {
+        id: "codex",
+        name: "Codex CLI",
+        binary: "codex",
+        version_args: &["--version"],
+        probes: &[
+            FlagProbe { help_args: &["--help"], flags: &["exec"] },
+            FlagProbe {
+                help_args: &["exec", "--help"],
+                flags: &["--json", "--skip-git-repo-check", "sandbox"],
+            },
+        ],
+    },
+];
+
+/// Per-CLI compatibility report surfaced to the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliHealthReport {
+    pub id: String,
+    pub name: String,
+    pub available: bool,
+    pub path: Option<String>,
+    pub version: Option<String>,
+    pub min_version: Option<String>,
+    pub version_ok: bool,
+    pub missing_flags: Vec<String>,
+    /// "ok" | "missing" | "outdated" | "drift"
+    pub status: String,
+}
+
+/// Pure: flags from `expected` that don't appear in `help_text`.
+fn missing_flags(help_text: &str, expected: &[&str]) -> Vec<String> {
+    expected
+        .iter()
+        .filter(|flag| !help_text.contains(**flag))
+        .map(|flag| (*flag).to_string())
+        .collect()
+}
+
+/// Pure: parse a leading dotted-number version (e.g. `1.2.3`, or
+/// `claude 1.2.3 (build)`) into comparable components. `None` if no digits.
+fn parse_version_triple(raw: &str) -> Option<(u64, u64, u64)> {
+    let start = raw.find(|c: char| c.is_ascii_digit())?;
+    let rest = &raw[start..];
+    let end = rest
+        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .unwrap_or(rest.len());
+    let mut parts = rest[..end].split('.').filter(|s| !s.is_empty());
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let patch = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    Some((major, minor, patch))
+}
+
+/// Pure: does `current` satisfy `>= min`? Unparseable inputs are treated as
+/// satisfied — we warn on confident drift, never on a parse we can't trust.
+fn version_satisfies_min(current: &str, min: &str) -> bool {
+    match (parse_version_triple(current), parse_version_triple(min)) {
+        (Some(c), Some(m)) => c >= m,
+        _ => true,
+    }
+}
+
+fn min_version_for(settings: &crate::config::AppSettings, id: &str) -> Option<String> {
+    let configured = match id {
+        "claude" => settings.claude_min_version.as_ref(),
+        "codex" => settings.codex_min_version.as_ref(),
+        _ => None,
+    };
+    configured
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn check_one(spec: &CliHealthSpec, settings: &crate::config::AppSettings) -> CliHealthReport {
+    let min_version = min_version_for(settings, spec.id);
+
+    let Some(path) = find_cli(spec.binary) else {
+        return CliHealthReport {
+            id: spec.id.to_string(),
+            name: spec.name.to_string(),
+            available: false,
+            path: None,
+            version: None,
+            min_version,
+            version_ok: true,
+            missing_flags: Vec::new(),
+            status: "missing".to_string(),
+        };
+    };
+
+    let version = get_cli_version(&path, spec.version_args);
+
+    // Only count a flag as missing when its help probe actually succeeds — a
+    // timeout or spawn error must not masquerade as drift.
+    let mut missing = Vec::new();
+    for probe in spec.probes {
+        if let Ok(Some(out)) =
+            command_output_with_timeout(&path, probe.help_args, CLI_PROBE_TIMEOUT)
+        {
+            let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+            text.push_str(&String::from_utf8_lossy(&out.stderr));
+            missing.extend(missing_flags(&text, probe.flags));
+        }
+    }
+
+    let version_ok = match (&version, &min_version) {
+        (Some(v), Some(m)) => version_satisfies_min(v, m),
+        _ => true,
+    };
+
+    let status = if !version_ok {
+        "outdated"
+    } else if !missing.is_empty() {
+        "drift"
+    } else {
+        "ok"
+    };
+
+    CliHealthReport {
+        id: spec.id.to_string(),
+        name: spec.name.to_string(),
+        available: true,
+        path: Some(path),
+        version,
+        min_version,
+        version_ok,
+        missing_flags: missing,
+        status: status.to_string(),
+    }
+}
+
+/// Run the health check for every known CLI (spawns probe processes — call off
+/// the UI thread).
+pub fn cli_health_reports() -> Vec<CliHealthReport> {
+    let settings = crate::config::AppSettings::load();
+    CLI_HEALTH_SPECS
+        .iter()
+        .map(|spec| check_one(spec, &settings))
+        .collect()
+}
+
+/// On-demand health check (Settings "re-check" button, etc.).
+#[tauri::command]
+pub fn check_cli_health() -> Vec<CliHealthReport> {
+    cli_health_reports()
+}
+
+/// Run the health check and broadcast it so the UI can raise a drift banner.
+pub fn emit_cli_health(app: &tauri::AppHandle) {
+    use tauri::Emitter;
+    let _ = app.emit("cli:health", cli_health_reports());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn missing_flags_detects_absent_and_present() {
+        let help = "Usage: claude [opts]\n  --model <m>\n  --resume <id>\n";
+        assert_eq!(missing_flags(help, &["--model", "--resume"]), Vec::<String>::new());
+        assert_eq!(
+            missing_flags(help, &["--model", "--append-system-prompt"]),
+            vec!["--append-system-prompt".to_string()],
+        );
+    }
+
+    #[test]
+    fn version_triple_parses_messy_strings() {
+        assert_eq!(parse_version_triple("1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_version_triple("claude 2.0.14 (build 9)"), Some((2, 0, 14)));
+        assert_eq!(parse_version_triple("v3"), Some((3, 0, 0)));
+        assert_eq!(parse_version_triple("no digits"), None);
+    }
+
+    #[test]
+    fn version_floor_compares_and_tolerates_garbage() {
+        assert!(version_satisfies_min("2.1.0", "2.0.0"));
+        assert!(version_satisfies_min("2.0.0", "2.0.0"));
+        assert!(!version_satisfies_min("1.9.9", "2.0.0"));
+        // Unparseable → treated as satisfied (never hard-block on a bad parse).
+        assert!(version_satisfies_min("weird", "2.0.0"));
+    }
 
     #[test]
     fn verify_cli_path_rejects_directories() {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod orchestrator;
 pub mod pipeline;
 pub mod pipeline_template;
 pub mod script;
+pub mod settings;
 pub mod siege;
 pub mod system;
 pub mod task;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,25 @@
+//! Tauri commands bridging the frontend to the global `AppSettings`
+//! (`~/.kaitencode/settings.json`). These mirror the HTTP `/api/settings`
+//! handlers in `api.rs` so the in-app UI and external MCP/API clients share
+//! one source of truth — load → merge_update → save against the cached struct.
+
+use crate::config::AppSettings;
+use crate::error::AppError;
+
+/// Read the full global settings blob (snake_case keys, matching the on-disk
+/// JSON and the HTTP API). Cheap — served from the in-memory cache.
+#[tauri::command]
+pub fn get_app_settings() -> Result<serde_json::Value, AppError> {
+    serde_json::to_value(AppSettings::load())
+        .map_err(|e| AppError::CommandError(e.to_string()))
+}
+
+/// Merge a partial update (only provided keys change) and persist it. Returns
+/// the full, updated settings so the caller can refresh its local copy.
+#[tauri::command(rename_all = "camelCase")]
+pub fn update_app_settings(updates: serde_json::Value) -> Result<serde_json::Value, AppError> {
+    let mut settings = AppSettings::load();
+    settings.merge_update(&updates);
+    settings.save().map_err(AppError::CommandError)?;
+    serde_json::to_value(&settings).map_err(|e| AppError::CommandError(e.to_string()))
+}

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -325,6 +325,34 @@ pub fn update_task(
     )
 }
 
+/// Set or clear the task-level runtime mode override (`terminal` / `managed` /
+/// `interactive`, or `null`/empty to inherit). Unlike the legacy `agent_mode`
+/// field that `update_task` writes, this lands in the `runtime_mode_override`
+/// column the resolver actually consults — so the per-chat toggle and the task
+/// settings modal can flip a task's runtime and have it take effect. Emits
+/// `tasks:changed` so `useResolvedRuntimeMode` re-resolves (remounting the panel).
+#[tauri::command(rename_all = "camelCase")]
+pub fn set_task_runtime_mode_override(
+    app: AppHandle,
+    state: State<AppState>,
+    id: String,
+    runtime_mode_override: Option<String>,
+) -> Result<Task, AppError> {
+    // Treat an empty string the same as null — both mean "inherit".
+    let normalized = runtime_mode_override.filter(|s| !s.trim().is_empty());
+
+    let task = {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        db::update_task_runtime_mode_override(&conn, &id, normalized.as_deref())?
+    };
+
+    pipeline::emit_tasks_changed(&app, &task.workspace_id, "task_runtime_mode_changed");
+    Ok(task)
+}
+
 /// Update task trigger settings (overrides, prompt, dependencies)
 #[tauri::command(rename_all = "camelCase")]
 pub fn update_task_triggers(

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -23,11 +23,22 @@ pub const DEFAULT_BASE_BRANCH: &str = "main";
 pub const INTERACTIVE_MODE_ENV_VAR: &str = "KAITENCODE_INTERACTIVE_MODE_ENABLED";
 pub const DEPRECATED_INTERACTIVE_MODE_ENV_VAR: &str = "BENTOYA_INTERACTIVE_MODE_ENABLED";
 
-/// Whether the interactive runtime mode is currently allowed. Reads the env
-/// var on every call (cheap) so the flag responds to test setup and `launchctl
-/// setenv`-style live tweaks without an app restart. Treats `1`, `true`,
-/// `yes`, `on` (case-insensitive) as enabled.
+/// Whether the interactive runtime mode is currently allowed. The env var is a
+/// force-on override (for tests/CI and `launchctl setenv`-style live tweaks
+/// without an app restart) — treats `1`, `true`, `yes`, `on` (case-insensitive)
+/// as enabled. When the env var is absent/falsy we fall back to the persisted
+/// `AppSettings.interactive_mode_enabled` toggle, which is the supported,
+/// user-facing way to turn interactive mode on.
 pub fn interactive_mode_enabled() -> bool {
+    if interactive_mode_env_enabled() {
+        return true;
+    }
+    AppSettings::load().interactive_mode_enabled
+}
+
+/// The raw env-var gate, kept separate so callers (and the setting fallback)
+/// can distinguish a force-on env override from the persisted toggle.
+fn interactive_mode_env_enabled() -> bool {
     match env_var(
         INTERACTIVE_MODE_ENV_VAR,
         DEPRECATED_INTERACTIVE_MODE_ENV_VAR,
@@ -113,6 +124,16 @@ pub struct AppSettings {
     /// "managed" | "interactive" | ""` (empty = no global default, fall
     /// through to plan default of headless·bubbles).
     pub default_runtime_mode: String,
+    /// Phase 3 (AGENT_PANEL_MODES) — opt-in gate for the interactive runtime
+    /// mode. Replaces the dev-only `KAITENCODE_INTERACTIVE_MODE_ENABLED` env
+    /// var as the real, user-facing switch. The env var still force-enables
+    /// (for tests/CI), but this setting is the supported way to turn it on.
+    pub interactive_mode_enabled: bool,
+    /// Phase 5 (CLI-compat) — known-good minimum CLI versions. The startup
+    /// health check warns (never hard-blocks) when an installed CLI is older.
+    /// `None`/empty = accept any version.
+    pub claude_min_version: Option<String>,
+    pub codex_min_version: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -272,6 +293,9 @@ impl Default for AppSettings {
             default_session_strategy: "fresh".to_string(),
             default_advance_mode: "auto".to_string(),
             default_runtime_mode: String::new(),
+            interactive_mode_enabled: false,
+            claude_min_version: None,
+            codex_min_version: None,
         }
     }
 }
@@ -347,6 +371,20 @@ impl AppSettings {
             if let Some(v) = obj.get("default_runtime_mode").and_then(|v| v.as_str()) {
                 self.default_runtime_mode = v.to_string();
             }
+            if let Some(v) = obj
+                .get("interactive_mode_enabled")
+                .and_then(|v| v.as_bool())
+            {
+                self.interactive_mode_enabled = v;
+            }
+            if let Some(v) = obj.get("claude_min_version").and_then(|v| v.as_str()) {
+                self.claude_min_version =
+                    Some(v.to_string()).filter(|s| !s.trim().is_empty());
+            }
+            if let Some(v) = obj.get("codex_min_version").and_then(|v| v.as_str()) {
+                self.codex_min_version =
+                    Some(v.to_string()).filter(|s| !s.trim().is_empty());
+            }
         }
     }
 
@@ -411,6 +449,23 @@ mod tests {
         assert_eq!(settings.default_agent_cli, "claude");
         // Unchanged fields keep defaults
         assert_eq!(settings.gc_interval_minutes, 5);
+    }
+
+    #[test]
+    fn test_interactive_mode_enabled_setting_round_trips() {
+        // Defaults off; merge_update flips it; serde preserves it.
+        let mut settings = AppSettings::default();
+        assert!(!settings.interactive_mode_enabled);
+        settings.merge_update(&serde_json::json!({ "interactive_mode_enabled": true }));
+        assert!(settings.interactive_mode_enabled);
+
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: AppSettings = serde_json::from_str(&json).unwrap();
+        assert!(parsed.interactive_mode_enabled);
+
+        // Older settings.json without the key deserializes to the default (off).
+        let legacy: AppSettings = serde_json::from_str("{}").unwrap();
+        assert!(!legacy.interactive_mode_enabled);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
             commands::task::delete_task_template,
             commands::task::create_task_from_template,
             commands::task::update_task,
+            commands::task::set_task_runtime_mode_override,
             commands::task::duplicate_task,
             commands::task::update_task_triggers,
             commands::task::move_task,
@@ -222,6 +223,7 @@ pub fn run() {
             commands::agent::kill_task_session,
             commands::agent::switch_agent_transport,
             commands::agent::ensure_pty_session,
+            commands::agent::ensure_chef_terminal,
             commands::agent::queue_agent_tasks,
             commands::agent::update_task_agent_status,
             commands::agent::get_queue_status,
@@ -236,6 +238,9 @@ pub fn run() {
             commands::agent_interactive::list_completion_events,
             commands::agent_interactive::agent_pause,
             commands::agent_interactive::agent_resume,
+            // Global app settings (Phase 3 — Agent runtime)
+            commands::settings::get_app_settings,
+            commands::settings::update_app_settings,
             // Pipeline commands
             commands::pipeline::mark_pipeline_complete,
             commands::pipeline::get_pipeline_state,
@@ -305,6 +310,7 @@ pub fn run() {
             commands::cli_detect::verify_cli_path,
             commands::cli_detect::get_cli_capabilities,
             commands::cli_detect::check_cli_update,
+            commands::cli_detect::check_cli_health,
             commands::system::check_runtime_prerequisites,
             // Checklist commands
             commands::checklist::create_checklist,
@@ -415,7 +421,15 @@ fn spawn_startup_recovery(app: tauri::AppHandle) {
             recover_tmux_sessions(blocking_app);
         })
         .await;
-        resume_stale_pipeline_tasks(recovery_app);
+        resume_stale_pipeline_tasks(recovery_app.clone());
+
+        // Phase 5 — probe the CLIs for flag/version drift and broadcast the
+        // result so the UI can raise a (dismissible) compatibility banner.
+        let health_app = recovery_app;
+        let _ = tauri::async_runtime::spawn_blocking(move || {
+            commands::cli_detect::emit_cli_health(&health_app);
+        })
+        .await;
     });
 }
 

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -6,6 +6,7 @@ import { useWorkspaceStore } from '@/stores/workspace-store'
 
 vi.mock('@/hooks/use-pr-status-polling', () => ({ usePrStatusPolling: vi.fn() }))
 vi.mock('@/hooks/use-task-sync', () => ({ useTaskSync: vi.fn() }))
+vi.mock('@/hooks/use-entity-sync', () => ({ useEntitySync: vi.fn() }))
 vi.mock('@/hooks/use-agent-streaming-sync', () => ({ useAgentStreamingSync: vi.fn() }))
 vi.mock('@/hooks/use-cli-path', () => ({ useAutoDetectClis: vi.fn() }))
 vi.mock('@/lib/ipc', () => ({
@@ -33,6 +34,7 @@ vi.mock('@/lib/ipc', () => ({
   })),
 }))
 vi.mock('@/components/layout/board', () => ({ Board: () => <div>Board</div> }))
+vi.mock('@/components/layout/cli-health-banner', () => ({ CliHealthBanner: () => null }))
 vi.mock('@/components/layout/workspace-setup', () => ({ WorkspaceSetup: () => <div>Workspace setup</div> }))
 vi.mock('@/components/onboarding/onboarding-wizard', () => ({ OnboardingWizard: () => <div>Onboarding</div> }))
 vi.mock('@/components/layout/tab-bar', () => ({ TabBar: () => <div>Tabs</div> }))

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,11 +7,13 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 import { usePrStatusPolling } from '@/hooks/use-pr-status-polling'
 import { useTaskSync } from '@/hooks/use-task-sync'
+import { useEntitySync } from '@/hooks/use-entity-sync'
 import { useSettingsSync } from '@/hooks/use-settings-sync'
 import { useAgentStreamingSync } from '@/hooks/use-agent-streaming-sync'
 import { useAutoDetectClis } from '@/hooks/use-cli-path'
 import { useUpdater } from '@/hooks/use-updater'
 import { Board } from '@/components/layout/board'
+import { CliHealthBanner } from '@/components/layout/cli-health-banner'
 import { WorkspaceSetup } from '@/components/layout/workspace-setup'
 import { OnboardingWizard } from '@/components/onboarding/onboarding-wizard'
 import { TabBar } from '@/components/layout/tab-bar'
@@ -77,6 +79,10 @@ function App() {
 
   // Task sync (re-fetches task store when backend mutates tasks)
   useTaskSync(activeWorkspaceId)
+
+  // Entity sync (re-fetches column/workspace/script stores when the backend
+  // mutates them out of band — e.g. via MCP or the chef)
+  useEntitySync(activeWorkspaceId)
 
   // Settings sync (loads and persists per-workspace settings through SQLite)
   useSettingsSync()
@@ -148,6 +154,9 @@ function App() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* CLI compatibility (flag/version drift) banner */}
+      <CliHealthBanner />
 
       {/* Main content */}
       <main className="flex-1 overflow-hidden">

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -15,6 +15,7 @@ import { useQueueStatus } from '@/hooks/use-queue-status'
 import { ColumnHeader } from './column-header'
 import { TaskCard } from './task-card'
 import { ColumnConfigDialog } from './column-config-dialog'
+import { TaskCreateDialog } from './task-create-dialog'
 
 type BatchQueueLocalState = {
   isQueuing: boolean
@@ -93,6 +94,8 @@ export const Column = memo(function Column({
   const [showConfigDialog, setShowConfigDialog] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [showAddTask, setShowAddTask] = useState(false)
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [createDialogTitle, setCreateDialogTitle] = useState('')
   const [newTaskTitle, setNewTaskTitle] = useState('')
   const addTaskInputRef = useRef<HTMLInputElement>(null)
 
@@ -229,6 +232,15 @@ export const Column = memo(function Column({
     setShowAddTask(false)
   }, [])
 
+  // Promote the inline quick-add into the full create dialog, carrying the
+  // typed title over so the user keeps every option the backend accepts.
+  const handleOpenCreateDialog = useCallback(() => {
+    setCreateDialogTitle(newTaskTitle)
+    setShowAddTask(false)
+    setNewTaskTitle('')
+    setShowCreateDialog(true)
+  }, [newTaskTitle])
+
   return (
     <>
       <motion.div
@@ -290,20 +302,29 @@ export const Column = memo(function Column({
                       placeholder="Task title..."
                       className="w-full bg-transparent text-sm text-text-primary placeholder:text-text-secondary/50 focus:outline-none"
                     />
-                    <div className="mt-2 flex justify-end gap-1">
+                    <div className="mt-2 flex items-center justify-between gap-1">
                       <button
-                        onClick={handleCancelAddTask}
-                        className="rounded px-2 py-1 text-xs text-text-secondary hover:bg-surface-hover"
+                        onClick={handleOpenCreateDialog}
+                        title="More options (model, runtime, priority, dependencies…)"
+                        className="rounded px-2 py-1 text-xs text-text-secondary hover:bg-surface-hover hover:text-text-primary"
                       >
-                        Cancel
+                        More options…
                       </button>
-                      <button
-                        onClick={() => void handleSubmitTask()}
-                        disabled={!newTaskTitle.trim()}
-                        className="rounded bg-accent px-2 py-1 text-xs font-medium text-bg disabled:opacity-50"
-                      >
-                        Add
-                      </button>
+                      <div className="flex gap-1">
+                        <button
+                          onClick={handleCancelAddTask}
+                          className="rounded px-2 py-1 text-xs text-text-secondary hover:bg-surface-hover"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          onClick={() => void handleSubmitTask()}
+                          disabled={!newTaskTitle.trim()}
+                          className="rounded bg-accent px-2 py-1 text-xs font-medium text-bg disabled:opacity-50"
+                        >
+                          Add
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </motion.div>
@@ -329,6 +350,15 @@ export const Column = memo(function Column({
           </div>
         </SortableContext>
       </motion.div>
+
+      {/* Full create dialog (model, runtime, priority, trigger prompt, deps) */}
+      {showCreateDialog && (
+        <TaskCreateDialog
+          columnId={column.id}
+          initialTitle={createDialogTitle}
+          onClose={() => { setShowCreateDialog(false); setCreateDialogTitle('') }}
+        />
+      )}
 
       {/* Config dialog */}
       {showConfigDialog && (

--- a/src/components/kanban/task-create-dialog.test.tsx
+++ b/src/components/kanban/task-create-dialog.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockKanbanColumn } from '@/test/mocks/tauri'
+import { useColumnStore } from '@/stores/column-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useTaskStore } from '@/stores/task-store'
+import { TaskCreateDialog } from './task-create-dialog'
+
+const ipcMocks = vi.hoisted(() => ({
+  createTask: vi.fn(),
+  getWorkspace: vi.fn(),
+}))
+
+vi.mock('@/lib/ipc', () => ({
+  createTask: (...args: unknown[]) => ipcMocks.createTask(...args) as unknown,
+  getWorkspace: (...args: unknown[]) => ipcMocks.getWorkspace(...args) as unknown,
+  validateTaskDependencies: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/ipc/agent-interactive', () => ({
+  interactiveModeDevFlag: vi.fn().mockResolvedValue(true),
+}))
+
+describe('TaskCreateDialog', () => {
+  beforeEach(() => {
+    ipcMocks.createTask.mockReset()
+    ipcMocks.getWorkspace.mockReset()
+    ipcMocks.getWorkspace.mockResolvedValue({ id: 'ws-1' })
+    useTaskStore.setState({ tasks: [], loaded: true })
+    useColumnStore.setState({
+      columns: [
+        mockKanbanColumn({ id: 'col-1', name: 'Backlog', position: 0 }),
+        mockKanbanColumn({ id: 'col-2', name: 'In Progress', position: 1 }),
+      ],
+      loaded: true,
+    })
+    useWorkspaceStore.setState({ activeWorkspaceId: 'ws-1' })
+  })
+
+  it('pre-fills the title and creates a task with the chosen options', async () => {
+    ipcMocks.createTask.mockResolvedValue({ id: 'task-new', title: 'My Task' })
+    const onClose = vi.fn()
+
+    render(<TaskCreateDialog columnId="col-1" initialTitle="My Task" onClose={onClose} />)
+
+    expect(screen.getByLabelText('Title')).toHaveValue('My Task')
+
+    fireEvent.change(screen.getByLabelText('Column'), { target: { value: 'col-2' } })
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'opus' } })
+    fireEvent.change(screen.getByLabelText('Priority'), { target: { value: 'high' } })
+    fireEvent.change(screen.getByLabelText('Runtime'), { target: { value: 'interactive' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Task' }))
+
+    await waitFor(() => {
+      expect(ipcMocks.createTask).toHaveBeenCalledWith(
+        'ws-1',
+        'col-2',
+        'My Task',
+        undefined,
+        expect.objectContaining({
+          model: 'opus',
+          priority: 'high',
+          runtimeModeOverride: 'interactive',
+        }),
+      )
+    })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables submit until a title is provided', async () => {
+    render(<TaskCreateDialog columnId="col-1" onClose={vi.fn()} />)
+    // Let the async interactive-mode dev-flag read settle before asserting.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Create Task' })).toBeDisabled()
+    })
+  })
+})

--- a/src/components/kanban/task-create-dialog.tsx
+++ b/src/components/kanban/task-create-dialog.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from 'react'
+import { motion } from 'motion/react'
+import type { AgentRuntimeMode } from '@/types'
+import { useTaskStore } from '@/stores/task-store'
+import { useColumnStore } from '@/stores/column-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { DependenciesTab } from './task-dependencies-tab'
+import { TaskOptionFields } from './task-option-fields'
+import type { Dependency } from './task-dependency-parsers'
+
+// ─── Full new-task surface ────────────────────────────────────────────────────
+//
+// Exposes every option an agent/MCP can set at creation (model, runtime mode,
+// target column, priority, trigger prompt, dependencies) so a human creating a
+// task by hand has the same reach. Threads through useTaskStore.add → the
+// createTask `CreateTaskOptions` bag.
+
+type TaskCreateDialogProps = {
+  /** Column the task lands in by default (user can re-target). */
+  columnId: string
+  /** Pre-fill the title (e.g. carried over from the inline quick-add). */
+  initialTitle?: string
+  onClose: () => void
+}
+
+export function TaskCreateDialog({ columnId, initialTitle = '', onClose }: TaskCreateDialogProps) {
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
+  const addTask = useTaskStore((s) => s.add)
+  const columns = useColumnStore((s) => s.columns)
+
+  const orderedColumns = useMemo(
+    () => [...columns].sort((a, b) => a.position - b.position),
+    [columns],
+  )
+
+  const [title, setTitle] = useState(initialTitle)
+  const [description, setDescription] = useState('')
+  const [targetColumnId, setTargetColumnId] = useState(columnId)
+  const [model, setModel] = useState('')
+  const [priority, setPriority] = useState('medium')
+  const [runtimeMode, setRuntimeMode] = useState<AgentRuntimeMode | ''>('')
+  const [triggerPrompt, setTriggerPrompt] = useState('')
+  const [deps, setDeps] = useState<Dependency[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canSubmit = title.trim().length > 0 && !!activeWorkspaceId && !isSubmitting
+
+  const handleSubmit = async () => {
+    const trimmed = title.trim()
+    if (!trimmed || !activeWorkspaceId) return
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await addTask(activeWorkspaceId, targetColumnId, trimmed, description.trim() || undefined, {
+        model: model || undefined,
+        priority,
+        runtimeModeOverride: runtimeMode || undefined,
+        triggerPrompt: triggerPrompt.trim() || undefined,
+        dependencies: deps.length > 0 ? JSON.stringify(deps) : undefined,
+      })
+      onClose()
+    } catch (err) {
+      console.error('Failed to create task:', err)
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+        className="relative w-full max-w-lg rounded-xl border border-border-default bg-surface shadow-xl"
+        onClick={(e) => { e.stopPropagation() }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Create task"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
+          <h2 className="text-sm font-medium text-text-primary">New Task</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg p-1 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+          >
+            <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="max-h-[65vh] space-y-4 overflow-y-auto px-5 py-4">
+          {/* Title */}
+          <div>
+            <label htmlFor="create-task-title" className="mb-1.5 block text-sm font-medium text-text-secondary">
+              Title
+            </label>
+            <input
+              id="create-task-title"
+              type="text"
+              value={title}
+              autoFocus
+              onChange={(e) => { setTitle(e.target.value) }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && canSubmit) void handleSubmit()
+              }}
+              placeholder="Task title..."
+              className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label htmlFor="create-task-description" className="mb-1.5 block text-sm font-medium text-text-secondary">
+              Description
+            </label>
+            <textarea
+              id="create-task-description"
+              value={description}
+              onChange={(e) => { setDescription(e.target.value) }}
+              placeholder="Optional details for the task..."
+              rows={3}
+              className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none"
+            />
+          </div>
+
+          {/* Target column */}
+          <div>
+            <label htmlFor="create-task-column" className="mb-1.5 block text-sm font-medium text-text-secondary">
+              Column
+            </label>
+            <select
+              id="create-task-column"
+              value={targetColumnId}
+              onChange={(e) => { setTargetColumnId(e.target.value) }}
+              className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+            >
+              {orderedColumns.map((col) => (
+                <option key={col.id} value={col.id}>{col.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Model + priority + runtime (shared create/edit controls) */}
+          <TaskOptionFields
+            idPrefix="create-task"
+            model={model}
+            onModelChange={setModel}
+            priority={priority}
+            onPriorityChange={setPriority}
+            runtimeMode={runtimeMode}
+            onRuntimeModeChange={setRuntimeMode}
+          />
+
+          {/* Trigger prompt */}
+          <div>
+            <label htmlFor="create-task-trigger-prompt" className="mb-1.5 block text-sm font-medium text-text-secondary">
+              Trigger Prompt
+            </label>
+            <p className="mb-2 text-xs text-text-secondary">
+              Custom prompt fed to the agent when this task&apos;s column trigger fires.
+              Overrides the column&apos;s default prompt template.
+            </p>
+            <textarea
+              id="create-task-trigger-prompt"
+              value={triggerPrompt}
+              onChange={(e) => { setTriggerPrompt(e.target.value) }}
+              placeholder="Custom instructions for this task..."
+              rows={4}
+              className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none font-mono"
+            />
+          </div>
+
+          {/* Dependencies (create mode — no id yet) */}
+          <div className="border-t border-border-default pt-4">
+            <DependenciesTab
+              deps={deps}
+              blocked={false}
+              taskId={null}
+              onDepsChange={setDeps}
+            />
+          </div>
+
+          {error && <p className="text-xs text-red-400">{error}</p>}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-border-default px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => { void handleSubmit() }}
+            disabled={!canSubmit}
+            style={{ cursor: canSubmit ? undefined : 'not-allowed' }}
+            className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-bg transition-colors hover:bg-accent/90 disabled:opacity-50"
+          >
+            {isSubmitting ? 'Creating...' : 'Create Task'}
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/src/components/kanban/task-dependencies-tab.tsx
+++ b/src/components/kanban/task-dependencies-tab.tsx
@@ -12,7 +12,8 @@ export function DependenciesTab({
 }: {
   deps: Dependency[]
   blocked: boolean
-  taskId: string
+  /** null while creating a task that has no id yet — validation is skipped. */
+  taskId: string | null
   onDepsChange: (deps: Dependency[]) => void
 }) {
   const tasks = useTaskStore((s) => s.tasks)
@@ -45,7 +46,11 @@ export function DependenciesTab({
     const proposed = [...deps, newDep]
 
     try {
-      await ipc.validateTaskDependencies(taskId, JSON.stringify(proposed))
+      // No id yet at create time — a brand-new task can't be a cycle target,
+      // so skip the backend validation round-trip and add directly.
+      if (taskId) {
+        await ipc.validateTaskDependencies(taskId, JSON.stringify(proposed))
+      }
       onDepsChange(proposed)
       setNewTaskId('')
       setNewCondition('completed')

--- a/src/components/kanban/task-option-fields.tsx
+++ b/src/components/kanban/task-option-fields.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import type { AgentRuntimeMode } from '@/types'
+import { interactiveModeDevFlag } from '@/lib/ipc/agent-interactive'
+
+// ─── Shared create/edit option controls ──────────────────────────────────────
+//
+// Model + runtime-mode (+ optional priority) pickers, factored out so the
+// new-task surface and the task settings modal drive the same controls from one
+// place. Anything an agent/MCP can set at creation, a human can set here too.
+
+export const PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+] as const
+
+interface TaskOptionFieldsProps {
+  model: string
+  onModelChange: (value: string) => void
+  runtimeMode: AgentRuntimeMode | ''
+  onRuntimeModeChange: (value: AgentRuntimeMode | '') => void
+  /** Priority picker is rendered only when this handler is supplied. */
+  priority?: string
+  onPriorityChange?: (value: string) => void
+  /** Disambiguates element ids when more than one instance can mount. */
+  idPrefix?: string
+  /** Extra content rendered under the runtime select (e.g. resolved-mode hint). */
+  runtimeFooter?: ReactNode
+  /** Override the default helper copy under each control. */
+  modelHelp?: ReactNode
+  runtimeHelp?: ReactNode
+}
+
+const SELECT_CLASS =
+  'w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none'
+
+export function TaskOptionFields({
+  model,
+  onModelChange,
+  runtimeMode,
+  onRuntimeModeChange,
+  priority,
+  onPriorityChange,
+  idPrefix = 'task',
+  runtimeFooter,
+  modelHelp,
+  runtimeHelp,
+}: TaskOptionFieldsProps) {
+  const [devFlagEnabled, setDevFlagEnabled] = useState<boolean | null>(null)
+
+  // Reading the env flag is async-but-fast. While it loads we leave the
+  // 'Interactive' option enabled — worst case the user picks it and the
+  // backend downgrades to terminal with a warning (already wired up).
+  useEffect(() => {
+    let cancelled = false
+    interactiveModeDevFlag()
+      .then((value) => { if (!cancelled) setDevFlagEnabled(value) })
+      .catch(() => { if (!cancelled) setDevFlagEnabled(null) })
+    return () => { cancelled = true }
+  }, [])
+
+  const interactiveDisabled = devFlagEnabled === false
+  const runtimeId = `${idPrefix}-runtime-mode`
+
+  return (
+    <div className="space-y-4">
+      {/* Model */}
+      <div>
+        <label htmlFor={`${idPrefix}-model`} className="mb-1.5 block text-sm font-medium text-text-secondary">
+          Model
+        </label>
+        <p className="mb-2 text-xs text-text-secondary">
+          {modelHelp ?? 'Override the AI model for this task. Leave on Auto to use the column trigger default.'}
+        </p>
+        <select
+          id={`${idPrefix}-model`}
+          value={model}
+          onChange={(e) => { onModelChange(e.target.value) }}
+          className={SELECT_CLASS}
+        >
+          <option value="">Auto (column default)</option>
+          <option value="opus">Opus (most capable)</option>
+          <option value="sonnet">Sonnet (fast + capable)</option>
+          <option value="haiku">Haiku (quick + light)</option>
+        </select>
+      </div>
+
+      {/* Priority (optional) */}
+      {onPriorityChange && (
+        <div>
+          <label htmlFor={`${idPrefix}-priority`} className="mb-1.5 block text-sm font-medium text-text-secondary">
+            Priority
+          </label>
+          <select
+            id={`${idPrefix}-priority`}
+            value={priority ?? 'medium'}
+            onChange={(e) => { onPriorityChange(e.target.value) }}
+            className={SELECT_CLASS}
+          >
+            {PRIORITY_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Runtime */}
+      <div>
+        <label htmlFor={runtimeId} className="mb-1.5 block text-sm font-medium text-text-secondary">
+          Runtime
+        </label>
+        {runtimeHelp !== undefined ? (
+          <p className="mb-2 text-xs text-text-secondary">{runtimeHelp}</p>
+        ) : (
+          <p className="mb-2 text-xs text-text-secondary">
+            How this task talks to its agent. Leave on inherit to use the
+            column&apos;s runtime mode.
+          </p>
+        )}
+        <select
+          id={runtimeId}
+          value={runtimeMode}
+          onChange={(e) => { onRuntimeModeChange(e.target.value as AgentRuntimeMode | '') }}
+          className={SELECT_CLASS}
+        >
+          <option value="">Inherit from column</option>
+          <option value="terminal">Headless · terminal (tmux)</option>
+          <option value="managed">Headless · bubbles (managed)</option>
+          <option value="interactive" disabled={interactiveDisabled}>
+            Interactive (live TUI){interactiveDisabled ? ' — set KAITENCODE_INTERACTIVE_MODE_ENABLED=1' : ''}
+          </option>
+        </select>
+        {runtimeFooter}
+      </div>
+    </div>
+  )
+}

--- a/src/components/kanban/task-settings-modal.test.tsx
+++ b/src/components/kanban/task-settings-modal.test.tsx
@@ -6,6 +6,7 @@ import { TaskSettingsModal } from './task-settings-modal'
 const ipcMocks = vi.hoisted(() => ({
   updateTask: vi.fn(),
   updateTaskTriggers: vi.fn(),
+  setTaskRuntimeModeOverride: vi.fn(),
 }))
 
 vi.mock('@/lib/ipc', () => ({
@@ -15,6 +16,10 @@ vi.mock('@/lib/ipc', () => ({
   },
   updateTaskTriggers: async (...args: unknown[]) => {
     const result = await ipcMocks.updateTaskTriggers(...args) as unknown
+    return result
+  },
+  setTaskRuntimeModeOverride: async (...args: unknown[]) => {
+    const result = await ipcMocks.setTaskRuntimeModeOverride(...args) as unknown
     return result
   },
   listen: vi.fn().mockResolvedValue(() => {}),
@@ -45,12 +50,13 @@ describe('TaskSettingsModal runtime override', () => {
   beforeEach(() => {
     ipcMocks.updateTask.mockReset()
     ipcMocks.updateTaskTriggers.mockReset()
+    ipcMocks.setTaskRuntimeModeOverride.mockReset()
   })
 
-  it('saves managed runtime as a task-level override', async () => {
-    const task = mockKanbanTask({ agentMode: null })
-    ipcMocks.updateTask.mockResolvedValue(task)
-    ipcMocks.updateTaskTriggers.mockResolvedValue({ ...task, agentMode: 'managed' })
+  it('saves managed runtime via the runtime_mode_override write path', async () => {
+    const task = mockKanbanTask({ runtimeModeOverride: null })
+    ipcMocks.setTaskRuntimeModeOverride.mockResolvedValue({ ...task, runtimeModeOverride: 'managed' })
+    ipcMocks.updateTaskTriggers.mockResolvedValue({ ...task, runtimeModeOverride: 'managed' })
     const onClose = vi.fn()
 
     render(<TaskSettingsModal task={task} onClose={onClose} />)
@@ -59,16 +65,18 @@ describe('TaskSettingsModal runtime override', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
-      expect(ipcMocks.updateTask).toHaveBeenCalledWith(task.id, { agentMode: 'managed' })
+      expect(ipcMocks.setTaskRuntimeModeOverride).toHaveBeenCalledWith(task.id, 'managed')
     })
+    // Model unchanged → no updateTask call.
+    expect(ipcMocks.updateTask).not.toHaveBeenCalled()
     expect(ipcMocks.updateTaskTriggers).toHaveBeenCalled()
     expect(onClose).toHaveBeenCalled()
   })
 
   it('clears an existing runtime override back to column default', async () => {
-    const task = mockKanbanTask({ agentMode: 'managed' })
-    ipcMocks.updateTask.mockResolvedValue(task)
-    ipcMocks.updateTaskTriggers.mockResolvedValue({ ...task, agentMode: null })
+    const task = mockKanbanTask({ runtimeModeOverride: 'managed' })
+    ipcMocks.setTaskRuntimeModeOverride.mockResolvedValue({ ...task, runtimeModeOverride: null })
+    ipcMocks.updateTaskTriggers.mockResolvedValue({ ...task, runtimeModeOverride: null })
 
     render(<TaskSettingsModal task={task} onClose={vi.fn()} />)
 
@@ -76,7 +84,7 @@ describe('TaskSettingsModal runtime override', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
-      expect(ipcMocks.updateTask).toHaveBeenCalledWith(task.id, { agentMode: null })
+      expect(ipcMocks.setTaskRuntimeModeOverride).toHaveBeenCalledWith(task.id, null)
     })
   })
 })

--- a/src/components/kanban/task-settings-modal.tsx
+++ b/src/components/kanban/task-settings-modal.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import type { AgentRuntimeMode, Task } from '@/types'
 import * as ipc from '@/lib/ipc'
-import { interactiveModeDevFlag } from '@/lib/ipc/agent-interactive'
 import { useResolvedRuntimeMode } from '@/hooks/use-resolved-runtime-mode'
 import { useTaskStore } from '@/stores/task-store'
 import { DependenciesTab } from './task-dependencies-tab'
+import { TaskOptionFields } from './task-option-fields'
 import type { Dependency } from './task-dependency-parsers'
 import { parseDependencies, parseOverrides } from './task-dependency-utils'
 
@@ -30,7 +30,9 @@ export function TaskSettingsModal({ task, onClose, initialTab }: TaskSettingsMod
   const [skipTriggers, setSkipTriggers] = useState(overrides.skip_triggers === true)
   const [triggerPrompt, setTriggerPrompt] = useState(task.triggerPrompt ?? '')
   const [model, setModel] = useState(task.model ?? '')
-  const taskRuntimeMode = isRuntimeMode(task.agentMode) ? task.agentMode : ''
+  // Seed from the override column the resolver actually consults (tier 2),
+  // not the legacy `agentMode` field.
+  const taskRuntimeMode = isRuntimeMode(task.runtimeModeOverride) ? task.runtimeModeOverride : ''
   const [runtimeMode, setRuntimeMode] = useState<AgentRuntimeMode | ''>(taskRuntimeMode)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -49,11 +51,11 @@ export function TaskSettingsModal({ task, onClose, initialTab }: TaskSettingsMod
       if (model !== (task.model ?? '')) {
         taskPatch.model = model || null
       }
-      if (runtimeMode !== taskRuntimeMode) {
-        taskPatch.agentMode = runtimeMode || null
-      }
       if (Object.keys(taskPatch).length > 0) {
         await ipc.updateTask(task.id, taskPatch)
+      }
+      if (runtimeMode !== taskRuntimeMode) {
+        await ipc.setTaskRuntimeModeOverride(task.id, runtimeMode || null)
       }
 
       const updated = await ipc.updateTaskTriggers(task.id, {
@@ -176,7 +178,7 @@ export function TaskSettingsModal({ task, onClose, initialTab }: TaskSettingsMod
   )
 }
 
-function isRuntimeMode(mode: Task['agentMode']): mode is AgentRuntimeMode {
+function isRuntimeMode(mode: string | null): mode is AgentRuntimeMode {
   return mode === 'terminal' || mode === 'managed' || mode === 'interactive'
 }
 
@@ -206,20 +208,7 @@ function TriggersTab({
   lastOutput: string | null
 }) {
   const resolved = useResolvedRuntimeMode(taskId)
-  const [devFlagEnabled, setDevFlagEnabled] = useState<boolean | null>(null)
 
-  // Reading the env flag is async-but-fast. While it loads we leave the
-  // 'Interactive' option enabled — worst case the user picks it and the
-  // backend downgrades to terminal with a warning (already wired up).
-  useEffect(() => {
-    let cancelled = false
-    interactiveModeDevFlag()
-      .then((value) => { if (!cancelled) setDevFlagEnabled(value) })
-      .catch(() => { if (!cancelled) setDevFlagEnabled(null) })
-    return () => { cancelled = true }
-  }, [])
-
-  const interactiveDisabled = devFlagEnabled === false
   const effectiveLabel = resolved.isLoading
     ? 'Resolving…'
     : resolved.mode === 'interactive'
@@ -251,60 +240,32 @@ function TriggersTab({
         </button>
       </div>
 
-      {/* Model Override */}
-      <div>
-        <label className="mb-1.5 block text-sm font-medium text-text-secondary">
-          Model
-        </label>
-        <p className="mb-2 text-xs text-text-secondary">
-          Override the AI model for this task. Leave on Auto to use the column trigger default.
-        </p>
-        <select
-          value={model}
-          onChange={(e) => { setModel(e.target.value) }}
-          className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
-        >
-          <option value="">Auto (column default)</option>
-          <option value="opus">Opus (most capable)</option>
-          <option value="sonnet">Sonnet (fast + capable)</option>
-          <option value="haiku">Haiku (quick + light)</option>
-        </select>
-      </div>
-
-      {/* Runtime Override */}
-      <div>
-        <label htmlFor="task-runtime-mode" className="mb-1.5 block text-sm font-medium text-text-secondary">
-          Runtime
-        </label>
-        <p className="mb-2 text-xs text-text-secondary">
-          Override how this task talks to its agent. Until column/workspace
-          defaults ship in Phase 4, only the column trigger&apos;s explicit
-          runtime mode resolves at fire time — task-level overrides are
-          saved but not consulted by the resolver yet.
-        </p>
-        <select
-          id="task-runtime-mode"
-          value={runtimeMode}
-          onChange={(e) => { setRuntimeMode(e.target.value as AgentRuntimeMode | '') }}
-          className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
-        >
-          <option value="">Inherit from column</option>
-          <option value="terminal">Headless · terminal (tmux)</option>
-          <option value="managed">Headless · bubbles (managed)</option>
-          <option value="interactive" disabled={interactiveDisabled}>
-            Interactive (live TUI){interactiveDisabled ? ' — set KAITENCODE_INTERACTIVE_MODE_ENABLED=1' : ''}
-          </option>
-        </select>
-        <p
-          data-testid="task-runtime-effective"
-          className="mt-1.5 text-[11px] text-text-secondary"
-        >
-          Effective: <span className="font-medium text-text-primary">{effectiveLabel}</span>
-          {resolved.interactiveDevFlagRequired && (
-            <span className="ml-1 text-warning">· dev flag required</span>
-          )}
-        </p>
-      </div>
+      {/* Model + Runtime Overrides (shared create/edit controls) */}
+      <TaskOptionFields
+        idPrefix="task"
+        model={model}
+        onModelChange={setModel}
+        runtimeMode={runtimeMode}
+        onRuntimeModeChange={setRuntimeMode}
+        modelHelp="Override the AI model for this task. Leave on Auto to use the column trigger default."
+        runtimeHelp={
+          <>
+            Override how this task talks to its agent. Takes priority over the
+            column, workspace, and global defaults when the trigger fires.
+          </>
+        }
+        runtimeFooter={
+          <p
+            data-testid="task-runtime-effective"
+            className="mt-1.5 text-[11px] text-text-secondary"
+          >
+            Effective: <span className="font-medium text-text-primary">{effectiveLabel}</span>
+            {resolved.interactiveDevFlagRequired && (
+              <span className="ml-1 text-warning">· dev flag required</span>
+            )}
+          </p>
+        }
+      />
 
       {/* Trigger Prompt */}
       <div>

--- a/src/components/layout/cli-health-banner.test.tsx
+++ b/src/components/layout/cli-health-banner.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CliHealthBanner } from './cli-health-banner'
+import type { CliHealthReport } from '@/lib/ipc/cli'
+
+vi.mock('@/lib/ipc', () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}))
+
+// Keep the real `isCliHealthConcerning` logic; only stub the IPC probe.
+const mocks = vi.hoisted(() => ({ checkCliHealth: vi.fn() }))
+vi.mock('@/lib/ipc/cli', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ipc/cli')>()
+  return { ...actual, checkCliHealth: mocks.checkCliHealth }
+})
+
+const driftReport: CliHealthReport = {
+  id: 'claude',
+  name: 'Claude Code',
+  available: true,
+  path: '/usr/bin/claude',
+  version: '2.0.0',
+  minVersion: null,
+  versionOk: true,
+  missingFlags: ['--append-system-prompt'],
+  status: 'drift',
+}
+const okReport: CliHealthReport = {
+  ...driftReport,
+  id: 'codex',
+  name: 'Codex CLI',
+  missingFlags: [],
+  status: 'ok',
+}
+
+describe('CliHealthBanner', () => {
+  beforeEach(() => { mocks.checkCliHealth.mockReset() })
+
+  it('warns about a drifted CLI and hides on dismiss', async () => {
+    mocks.checkCliHealth.mockResolvedValue([driftReport, okReport])
+    render(<CliHealthBanner />)
+
+    await screen.findByText(/compatibility warning/i)
+    expect(screen.getByText(/--append-system-prompt/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+    await waitFor(() => {
+      expect(screen.queryByText(/compatibility warning/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders nothing when every CLI is healthy', async () => {
+    mocks.checkCliHealth.mockResolvedValue([okReport])
+    render(<CliHealthBanner />)
+    await waitFor(() => { expect(mocks.checkCliHealth).toHaveBeenCalled() })
+    expect(screen.queryByText(/compatibility warning/i)).not.toBeInTheDocument()
+  })
+
+  it('ignores a missing (uninstalled) CLI', async () => {
+    mocks.checkCliHealth.mockResolvedValue([
+      { ...okReport, available: false, status: 'missing', path: null, version: null },
+    ])
+    render(<CliHealthBanner />)
+    await waitFor(() => { expect(mocks.checkCliHealth).toHaveBeenCalled() })
+    expect(screen.queryByText(/compatibility warning/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/layout/cli-health-banner.tsx
+++ b/src/components/layout/cli-health-banner.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { listen } from '@/lib/ipc'
+import { checkCliHealth, isCliHealthConcerning, type CliHealthReport } from '@/lib/ipc/cli'
+
+/**
+ * App-level banner that warns when an installed CLI has drifted from the flags
+ * / versions the agent runner depends on (Phase 5). The backend probes on
+ * startup and broadcasts `cli:health`; we also re-check on mount for hot reloads
+ * and offer a manual re-check. A *missing* CLI is not surfaced here — onboarding
+ * and Settings own that path.
+ */
+export function CliHealthBanner() {
+  const [reports, setReports] = useState<CliHealthReport[]>([])
+  const [dismissedKey, setDismissedKey] = useState<string | null>(null)
+  const [rechecking, setRechecking] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    checkCliHealth()
+      .then((r) => { if (!cancelled) setReports(r) })
+      .catch(() => { /* probe failures shouldn't break the app */ })
+
+    const unlisten = listen<CliHealthReport[]>('cli:health', (payload) => {
+      if (!cancelled) setReports(payload)
+    })
+    return () => {
+      cancelled = true
+      void unlisten.then((off) => { off() })
+    }
+  }, [])
+
+  const concerning = reports.filter(isCliHealthConcerning)
+  // Re-show after a dismiss only when the set of problems changes.
+  const signature = concerning
+    .map((r) => `${r.id}:${r.status}:${r.missingFlags.join('|')}:${r.version ?? ''}`)
+    .join(';')
+  const visible = concerning.length > 0 && signature !== dismissedKey
+
+  const handleRecheck = () => {
+    setRechecking(true)
+    checkCliHealth()
+      .then(setReports)
+      .catch(() => { /* keep prior state */ })
+      .finally(() => { setRechecking(false) })
+  }
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: 'auto', opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="overflow-hidden"
+        >
+          <div className="flex items-start justify-between gap-3 border-b border-warning/30 bg-warning/10 px-4 py-2 text-sm">
+            <div className="min-w-0 text-text-primary">
+              <span className="font-medium text-warning">Agent CLI compatibility warning. </span>
+              {concerning.map((r) => (
+                <span key={r.id} className="mr-3 text-text-secondary">
+                  {r.name}
+                  {r.status === 'outdated'
+                    ? ` is ${r.version ?? 'older'} (need ≥ ${r.minVersion ?? '?'})`
+                    : ` is missing expected flags: ${r.missingFlags.join(', ')}`}
+                  .
+                </span>
+              ))}
+              <span className="text-text-secondary/80">Agent runs may misbehave until the CLI is updated.</span>
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+              <button
+                onClick={handleRecheck}
+                disabled={rechecking}
+                className="rounded bg-warning/20 px-2.5 py-1 text-xs font-medium text-warning transition-colors hover:bg-warning/30 disabled:opacity-50"
+                style={{ cursor: rechecking ? 'wait' : 'pointer' }}
+              >
+                {rechecking ? 'Checking…' : 'Re-check'}
+              </button>
+              <button
+                onClick={() => { setDismissedKey(signature) }}
+                className="text-text-secondary transition-colors hover:text-text-primary"
+                aria-label="Dismiss"
+                style={{ cursor: 'pointer' }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                  <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { motion } from 'motion/react'
-import { getCurrentBranch, detectClis, checkRuntimePrerequisites } from '@/lib/ipc'
+import { getCurrentBranch, detectClis, checkRuntimePrerequisites, updateAppSettings } from '@/lib/ipc'
 import type { DetectedCli } from '@/lib/ipc/cli'
 import type { RuntimePrerequisite } from '@/lib/ipc/system'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -19,6 +19,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const [name, setName] = useState('')
   const [repoPath, setRepoPath] = useState('')
   const [template, setTemplate] = useState('standard')
+  const [runtimeMode, setRuntimeMode] = useState<'headless' | 'interactive'>('headless')
   const [selectedClis, setSelectedClis] = useState<Set<string>>(new Set())
   const [isCreating, setIsCreating] = useState(false)
   const [gitStatus, setGitStatus] = useState<GitStatus>(null)
@@ -102,6 +103,14 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
         templateId: template,
         ...(defaultAgentCli ? { defaultAgentCli } : {}),
       })
+      // Persist the runtime choice globally (these live in backend AppSettings,
+      // not the workspace). Interactive is opt-in, so only flip when chosen.
+      if (runtimeMode === 'interactive') {
+        await updateAppSettings({
+          interactive_mode_enabled: true,
+          default_runtime_mode: 'interactive',
+        }).catch((err: unknown) => { console.error('Failed to save runtime mode:', err) })
+      }
       setActive(created.id)
       onComplete()
     } catch (err: unknown) {
@@ -110,7 +119,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     } finally {
       setIsCreating(false)
     }
-  }, [name, repoPath, selectedClis, template, addWorkspace, setActive, onComplete])
+  }, [name, repoPath, selectedClis, template, runtimeMode, addWorkspace, setActive, onComplete])
 
   const canCreate = repoPath.trim().length > 0 && gitStatus === 'valid' && !isCreating
   const missingRequiredPrereqs = prerequisites.filter((item) => item.required && !item.available)
@@ -275,6 +284,36 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   No agent CLIs detected. You can configure one later in Settings.
                 </p>
               )}
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">
+                Agent runtime
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                {([
+                  { id: 'headless', name: 'Headless', blurb: 'Pipelined CLI. Bills against API / Agent-SDK credit.' },
+                  { id: 'interactive', name: 'Interactive', blurb: 'Live CLI TUI you can steer. Uses subscription limits.' },
+                ] as const).map((opt) => (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    onClick={() => { setRuntimeMode(opt.id) }}
+                    className={`rounded-md border px-3 py-2 text-left transition-colors ${
+                      runtimeMode === opt.id
+                        ? 'border-accent bg-accent/10'
+                        : 'border-border-default bg-surface hover:bg-surface-hover'
+                    }`}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <div className="text-sm font-medium text-text-primary">{opt.name}</div>
+                    <div className="mt-0.5 text-[11px] text-text-secondary">{opt.blurb}</div>
+                  </button>
+                ))}
+              </div>
+              <p className="mt-1 text-[11px] text-text-secondary">
+                Headless is the recommended default. You can change this anytime in Settings → Agent.
+              </p>
             </div>
           </div>
 

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -6,7 +6,8 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { parseWorkspaceConfig } from '@/types/workspace'
 import { useAgentTranscriptStore } from '@/stores/agent-transcript-store'
 import { holdTask, killTaskSession } from '@/lib/ipc/agent'
-import { agentInjectMessage } from '@/lib/ipc/agent-interactive'
+import { agentInjectMessage, agentRestart, interactiveModeDevFlag } from '@/lib/ipc/agent-interactive'
+import { setTaskRuntimeModeOverride } from '@/lib/ipc/task'
 import { signalPtyInterrupt } from '@/lib/ipc/terminal'
 import { useResolvedRuntimeMode } from '@/hooks/use-resolved-runtime-mode'
 import { useTaskDetail } from '@/hooks/use-task-detail'
@@ -204,6 +205,7 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
         onClose={onClose}
         rightSlot={
           <>
+            <RuntimeModeToggle task={task} />
             <button
               type="button"
               onClick={() => { void handleHoldToggle() }}
@@ -488,6 +490,7 @@ function InteractivePanel({ task, onClose }: AgentPanelProps) {
         onClose={onClose}
         rightSlot={
           <>
+            <RuntimeModeToggle task={task} />
             <button
               type="button"
               onClick={() => { void handleHoldToggle() }}
@@ -604,6 +607,106 @@ function PanelHeader({
       </div>
 
       {errorSlot && <div className="px-3 pb-2">{errorSlot}</div>}
+    </div>
+  )
+}
+
+// Per-chat runtime switcher. Writes `runtime_mode_override` (the field the
+// resolver consults at tier 2) and, when flipping into interactive, restarts
+// the agent so the live TUI spawns. The override emits `tasks:changed`, which
+// re-resolves `useResolvedRuntimeMode` and remounts the panel via its key.
+type RuntimeChoice = '' | 'managed' | 'terminal' | 'interactive'
+
+const RUNTIME_CHOICES: { value: RuntimeChoice; label: string }[] = [
+  { value: '', label: 'Inherit from column' },
+  { value: 'managed', label: 'Headless · bubbles' },
+  { value: 'terminal', label: 'Headless · terminal' },
+  { value: 'interactive', label: 'Interactive (live TUI)' },
+]
+
+function RuntimeModeToggle({ task }: { task: Task }) {
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [interactiveAllowed, setInteractiveAllowed] = useState(true)
+  const resolved = useResolvedRuntimeMode(task.id)
+
+  useEffect(() => {
+    let cancelled = false
+    interactiveModeDevFlag()
+      .then((v) => { if (!cancelled) setInteractiveAllowed(v) })
+      .catch(() => { /* leave enabled; backend downgrades safely */ })
+    return () => { cancelled = true }
+  }, [])
+
+  const current = (task.runtimeModeOverride ?? '') as RuntimeChoice
+  const label = resolved.isLoading
+    ? '…'
+    : resolved.mode === 'interactive'
+      ? 'Interactive'
+      : `Headless · ${resolved.render ?? 'bubbles'}`
+
+  const handleSelect = async (choice: RuntimeChoice) => {
+    setOpen(false)
+    if (choice === current) return
+    setBusy(true)
+    try {
+      await setTaskRuntimeModeOverride(task.id, choice || null)
+      // Headless modes re-fire their `-p` run on demand; interactive needs the
+      // TUI spawned now.
+      if (choice === 'interactive') {
+        await agentRestart(task.id)
+      }
+    } catch (err) {
+      console.error('Failed to switch runtime mode:', err)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => { setOpen((v) => !v) }}
+        disabled={busy}
+        aria-expanded={open}
+        aria-label="Runtime mode"
+        title="Switch runtime mode for this task"
+        data-testid="agent-panel-runtime-toggle"
+        className="inline-flex h-7 items-center gap-1 rounded-md border border-border-default bg-surface px-2 text-[11px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+        style={{ cursor: busy ? 'wait' : 'pointer' }}
+      >
+        <span className="truncate">{label}</span>
+        <svg className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-20 mt-1 w-48 rounded-md border border-border-default bg-bg p-1 shadow-lg">
+          {RUNTIME_CHOICES.map((choice) => {
+            const disabled = choice.value === 'interactive' && !interactiveAllowed
+            return (
+              <button
+                key={choice.value || 'inherit'}
+                type="button"
+                disabled={disabled}
+                onClick={() => { void handleSelect(choice.value) }}
+                className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-[11px] transition-colors disabled:opacity-40 ${
+                  current === choice.value
+                    ? 'text-text-primary'
+                    : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+                }`}
+                style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
+                title={disabled ? 'Enable interactive mode in Settings → Agent' : undefined}
+              >
+                <span className="truncate">{choice.label}</span>
+                {current === choice.value && <span className="ml-2 text-accent">✓</span>}
+                {disabled && <span className="ml-2 text-[10px] text-text-secondary/60">off</span>}
+              </button>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -18,6 +18,7 @@ import { getChatHistory, listen, type ChatMessage } from '@/lib/ipc'
 import { buildPromptWithAttachments } from '@/types'
 import { useCliPath } from '@/hooks/use-cli-path'
 import { ChatHistory } from './chat-history'
+import { OrchestratorTerminalView } from './orchestrator-terminal-view'
 import { PanelSidebar } from './panel-sidebar'
 import { PipelineDashboard } from './pipeline-dashboard'
 import { PipelineV2Dashboard } from './pipeline-v2-dashboard'
@@ -95,6 +96,7 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
 
   // Local UI state
   const [sidebarMode, setSidebarMode] = useState<'history' | 'files' | 'dashboard' | 'v2-dashboard' | null>(null)
+  const [viewMode, setViewMode] = useState<'chat' | 'terminal'>('chat')
   const [localMessages, setLocalMessages] = useState<ChatMessage[]>([])
   const [messagesLoading, setMessagesLoading] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
@@ -495,54 +497,81 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
               />
             )}
 
-            {/* Main chat area */}
+            {/* Main chat / terminal area */}
             <ChatErrorBoundary panelName="Orchestrator Chat">
               <div className="flex flex-1 flex-col overflow-hidden">
-                {/* CLI Detection Indicator */}
-                {cliDetecting && <CliDetectingBanner />}
-                {/* Error Banner */}
-                {error && !chat.failedMessage && !cliDetecting && (
-                  <ErrorBanner
-                    error={error}
-                    onDismiss={() => { setLocalError(null); chat.clearError(); }}
-                  />
+                {/* Chat ↔ Terminal toggle */}
+                <div className="flex items-center gap-1 border-b border-border-default px-2 py-1">
+                  {(['chat', 'terminal'] as const).map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => { setViewMode(m) }}
+                      data-testid={`orchestrator-view-${m}`}
+                      aria-pressed={viewMode === m}
+                      className={`rounded px-2 py-1 text-[11px] font-medium transition-colors ${
+                        viewMode === m
+                          ? 'bg-surface-hover text-text-primary'
+                          : 'text-text-secondary hover:text-text-primary'
+                      }`}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      {m === 'chat' ? 'Chat' : 'Terminal'}
+                    </button>
+                  ))}
+                </div>
+
+                {viewMode === 'terminal' ? (
+                  <OrchestratorTerminalView workspaceId={workspaceId} />
+                ) : (
+                  <>
+                    {/* CLI Detection Indicator */}
+                    {cliDetecting && <CliDetectingBanner />}
+                    {/* Error Banner */}
+                    {error && !chat.failedMessage && !cliDetecting && (
+                      <ErrorBanner
+                        error={error}
+                        onDismiss={() => { setLocalError(null); chat.clearError(); }}
+                      />
+                    )}
+                    {/* Failed message with retry/dismiss */}
+                    {chat.failedMessage && (
+                      <FailedMessageBanner
+                        error={chat.failedMessage.error}
+                        onRetry={() => { void chat.retryFailed() }}
+                        onDismiss={chat.dismissFailed}
+                      />
+                    )}
+                    <ChatHistory
+                      messages={localMessages}
+                      isLoading={isLoading}
+                      streamingContent={chat.streaming.content}
+                      processingStartTime={chat.streaming.startTime}
+                      thinkingContent={chat.streaming.thinkingContent}
+                      toolCalls={toolCalls}
+                      onCancel={() => { void handleCancel() }}
+                      queuedMessages={chat.queue}
+                    />
+                    <ChatInput
+                      config={{
+                        showModelSelector: true,
+                        showContextToggle: true,
+                        showThinkingSelector: true,
+                        showPermissionSelector: true,
+                        showVoiceInput: true,
+                        showAttachments: true,
+                        placeholder: 'Ask me to create tasks...',
+                      }}
+                      onSend={handleSendMessage}
+                      onCancel={() => { void handleCancel() }}
+                      onInputChange={handleInputChange}
+                      onAttachmentError={(err) => { setLocalError(`${err.file}: ${err.message}`) }}
+                      isProcessing={isProcessing}
+                      disabled={!chat.canSend || cliDetecting}
+                      queueCount={chat.queue.length}
+                    />
+                  </>
                 )}
-                {/* Failed message with retry/dismiss */}
-                {chat.failedMessage && (
-                  <FailedMessageBanner
-                    error={chat.failedMessage.error}
-                    onRetry={() => { void chat.retryFailed() }}
-                    onDismiss={chat.dismissFailed}
-                  />
-                )}
-                <ChatHistory
-                  messages={localMessages}
-                  isLoading={isLoading}
-                  streamingContent={chat.streaming.content}
-                  processingStartTime={chat.streaming.startTime}
-                  thinkingContent={chat.streaming.thinkingContent}
-                  toolCalls={toolCalls}
-                  onCancel={() => { void handleCancel() }}
-                  queuedMessages={chat.queue}
-                />
-                <ChatInput
-                  config={{
-                    showModelSelector: true,
-                    showContextToggle: true,
-                    showThinkingSelector: true,
-                    showPermissionSelector: true,
-                    showVoiceInput: true,
-                    showAttachments: true,
-                    placeholder: 'Ask me to create tasks...',
-                  }}
-                  onSend={handleSendMessage}
-                  onCancel={() => { void handleCancel() }}
-                  onInputChange={handleInputChange}
-                  onAttachmentError={(err) => { setLocalError(`${err.file}: ${err.message}`) }}
-                  isProcessing={isProcessing}
-                  disabled={!chat.canSend || cliDetecting}
-                  queueCount={chat.queue.length}
-                />
               </div>
             </ChatErrorBoundary>
           </motion.div>

--- a/src/components/panel/orchestrator-terminal-view.test.tsx
+++ b/src/components/panel/orchestrator-terminal-view.test.tsx
@@ -1,0 +1,37 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import type { EnsureSessionFn } from '@/lib/ipc/terminal'
+
+type CapturedProps = { taskId: string; workingDir: string; ensure?: EnsureSessionFn }
+const captured = vi.hoisted(() => ({ props: undefined as CapturedProps | undefined }))
+
+vi.mock('./terminal-view', () => ({
+  TerminalView: (props: CapturedProps) => {
+    captured.props = props
+    return <div data-testid="terminal-view" />
+  },
+}))
+
+const ensureChefTerminal = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ taskId: 'chef_ws-1', pid: 1, status: 'Running' }),
+)
+vi.mock('@/lib/ipc/terminal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ipc/terminal')>()
+  return { ...actual, ensureChefTerminal }
+})
+
+import { OrchestratorTerminalView } from './orchestrator-terminal-view'
+
+describe('OrchestratorTerminalView', () => {
+  it('points TerminalView at the chef session key and routes ensure to the chef command', async () => {
+    render(<OrchestratorTerminalView workspaceId="ws-1" />)
+
+    expect(captured.props?.taskId).toBe('chef_ws-1')
+
+    // The ensure strategy ignores the per-task id/cwd and targets the workspace.
+    await captured.props?.ensure?.('chef_ws-1', '', 80, 24, true)
+    await waitFor(() => {
+      expect(ensureChefTerminal).toHaveBeenCalledWith('ws-1', 80, 24, true)
+    })
+  })
+})

--- a/src/components/panel/orchestrator-terminal-view.tsx
+++ b/src/components/panel/orchestrator-terminal-view.tsx
@@ -1,0 +1,25 @@
+import { useCallback } from 'react'
+import { TerminalView } from './terminal-view'
+import { ensureChefTerminal, chefSessionKey, type EnsureSessionFn } from '@/lib/ipc/terminal'
+
+/**
+ * Workspace-level terminal for the chef/orchestrator panel. Reuses the per-task
+ * `TerminalView` but points it at a `chef_<workspaceId>` session via the
+ * `ensureChefTerminal` strategy — a shell rooted at the repo the user can drive
+ * `claude`/`codex` from without leaving the app.
+ */
+export function OrchestratorTerminalView({ workspaceId }: { workspaceId: string }) {
+  const ensure = useCallback<EnsureSessionFn>(
+    (_id, _workingDir, cols, rows, allowSpawn) =>
+      ensureChefTerminal(workspaceId, cols, rows, allowSpawn),
+    [workspaceId],
+  )
+
+  return (
+    <TerminalView
+      taskId={chefSessionKey(workspaceId)}
+      workingDir=""
+      ensure={ensure}
+    />
+  )
+}

--- a/src/components/panel/terminal-view.tsx
+++ b/src/components/panel/terminal-view.tsx
@@ -13,7 +13,7 @@ import { SearchAddon } from '@xterm/addon-search'
 import '@xterm/xterm/css/xterm.css'
 
 import { listen, type UnlistenFn } from '@/lib/ipc'
-import { writeToPty, resizePty, ensurePtySession } from '@/lib/ipc/terminal'
+import { writeToPty, resizePty, ensurePtySession, type EnsureSessionFn } from '@/lib/ipc/terminal'
 import { EventChannels, type PtyExitPayload } from '@/types/events'
 import { getXtermTheme } from '@/lib/xterm-theme'
 import { getTheme } from '@/lib/theme'
@@ -21,12 +21,17 @@ import { EmptyState } from '@/components/shared/empty-state'
 import { useSettingsStore } from '@/stores/settings-store'
 
 type TerminalViewProps = {
+  /** Session key — a task id, or a `chef_<workspaceId>` key. Drives the
+   *  generic PTY IPC and the `pty:<taskId>:*` event channels. */
   taskId: string
   workingDir: string
   allowSpawn?: boolean
+  /** How to spawn/attach the session. Defaults to the per-task PTY command;
+   *  the chef terminal passes a workspace-keyed variant. */
+  ensure?: EnsureSessionFn
 }
 
-export function TerminalView({ taskId, workingDir, allowSpawn = true }: TerminalViewProps) {
+export function TerminalView({ taskId, workingDir, allowSpawn = true, ensure = ensurePtySession }: TerminalViewProps) {
   const terminalHostRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -206,7 +211,7 @@ export function TerminalView({ taskId, workingDir, allowSpawn = true }: Terminal
           const cols = Math.max(term.cols, 80)
           const rows = Math.max(term.rows, 24)
           void resizePty(taskId, cols, rows)
-          ensurePtySession(taskId, workingDir, cols, rows, allowSpawn)
+          ensure(taskId, workingDir, cols, rows, allowSpawn)
             .then((info) => {
               // Re-check `disposed` AFTER the await: a fast task-switch can
               // tear down this effect while ensure_pty_session is in flight.
@@ -305,7 +310,7 @@ export function TerminalView({ taskId, workingDir, allowSpawn = true }: Terminal
       if (termRef.current === term) termRef.current = null
       if (fitAddonRef.current === fitAddon) fitAddonRef.current = null
     }
-  }, [allowSpawn, fontSize, lineHeight, scrollback, taskId, workingDir])
+  }, [allowSpawn, ensure, fontSize, lineHeight, scrollback, taskId, workingDir])
 
   return (
     <div

--- a/src/components/settings/tabs/agent-tab.tsx
+++ b/src/components/settings/tabs/agent-tab.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { AgentConfig, ProviderConfig } from '@/types/settings'
-import { detectSingleCli, checkCliUpdate, type DetectedCli, type CliUpdateInfo } from '@/lib/ipc'
+import { detectSingleCli, checkCliUpdate, getAppSettings, updateAppSettings, type DetectedCli, type CliUpdateInfo } from '@/lib/ipc'
 import { useModels } from '@/hooks/use-models'
 import { SettingSection, SettingRow, SettingInput, SettingSlider } from '@/components/shared/setting-components'
 import { Dropdown } from '@/components/shared/dropdown'
+import { Toggle } from '@/components/shared/toggle'
 import { getModelBudgetKey } from '@/lib/usage-budget'
 
 const PROVIDER_INFO: Record<string, { name: string; description: string; cliId: string; supportsApi: boolean }> = {
@@ -64,6 +65,49 @@ export function AgentTab() {
   useEffect(() => {
     localStorage.setItem('agent-tab-coming-soon-collapsed', String(comingSoonCollapsed))
   }, [comingSoonCollapsed])
+
+  // Global agent-runtime settings live in the backend AppSettings
+  // (~/.kaitencode/settings.json), not the persisted zustand store — the
+  // pipeline resolver reads them at the global tier. Load + write via IPC.
+  const [defaultRuntimeMode, setDefaultRuntimeMode] = useState('')
+  const [interactiveEnabled, setInteractiveEnabled] = useState(false)
+  const [runtimeSettingsLoaded, setRuntimeSettingsLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    getAppSettings()
+      .then((s) => {
+        if (cancelled) return
+        setDefaultRuntimeMode(s.default_runtime_mode)
+        setInteractiveEnabled(s.interactive_mode_enabled)
+        setRuntimeSettingsLoaded(true)
+      })
+      .catch((err: unknown) => { console.error("Failed to load app settings:", err) })
+    return () => { cancelled = true }
+  }, [])
+
+  const persistRuntimeSetting = (updates: { default_runtime_mode?: string; interactive_mode_enabled?: boolean }) => {
+    void updateAppSettings(updates).catch((err: unknown) => {
+      console.error('Failed to update app settings:', err)
+    })
+  }
+
+  const handleDefaultRuntimeModeChange = (value: string) => {
+    setDefaultRuntimeMode(value)
+    persistRuntimeSetting({ default_runtime_mode: value })
+  }
+
+  const handleInteractiveEnabledChange = (enabled: boolean) => {
+    setInteractiveEnabled(enabled)
+    // Turning the gate off while interactive is the global default would leave
+    // the resolver downgrading every task — clear the default in lock-step.
+    if (!enabled && defaultRuntimeMode === 'interactive') {
+      setDefaultRuntimeMode('')
+      persistRuntimeSetting({ interactive_mode_enabled: false, default_runtime_mode: '' })
+    } else {
+      persistRuntimeSetting({ interactive_mode_enabled: enabled })
+    }
+  }
 
   const updateAgent = (updates: Partial<AgentConfig>) => {
     updateGlobal('agent', { ...agent, ...updates })
@@ -631,6 +675,48 @@ export function AgentTab() {
               onChange={(value) => { updateAgent({ maxConcurrentAgents: value }) }}
               min={1}
               max={50}
+            />
+          </SettingRow>
+        </div>
+      </SettingSection>
+
+      {/* ── 2b. AGENT RUNTIME ─────────────────────────────────── */}
+      <SettingSection
+        title="Agent runtime"
+        description="How trigger-spawned agents run by default. Headless pipes the CLI for a transcript or terminal view; interactive opens the real CLI TUI you can drive live."
+        border
+      >
+        <div className="space-y-5">
+          <SettingRow
+            label="Enable interactive mode"
+            description="Allow tasks to run as a live CLI TUI. Billing differs: interactive uses your CLI subscription's interactive limits, while headless bills against API / Agent-SDK credit. Headless stays the default either way."
+            vertical
+          >
+            <Toggle
+              checked={interactiveEnabled}
+              onChange={handleInteractiveEnabledChange}
+              disabled={!runtimeSettingsLoaded}
+              size="md"
+              aria-label="Enable interactive runtime mode"
+            />
+          </SettingRow>
+
+          <SettingRow
+            label="Default runtime mode"
+            description="Applied when a column trigger, task, or workspace doesn't specify its own runtime mode."
+            vertical
+          >
+            <Dropdown
+              options={[
+                { value: '', label: 'Auto', description: 'Headless · bubbles (recommended default)' },
+                { value: 'managed', label: 'Headless · bubbles', description: 'Semantic event stream as chat bubbles' },
+                { value: 'terminal', label: 'Headless · terminal', description: 'Raw tmux pane in xterm.js' },
+                ...(interactiveEnabled || defaultRuntimeMode === 'interactive'
+                  ? [{ value: 'interactive', label: 'Interactive', description: 'Live CLI TUI you can steer' }]
+                  : []),
+              ]}
+              value={defaultRuntimeMode}
+              onChange={handleDefaultRuntimeModeChange}
             />
           </SettingRow>
         </div>

--- a/src/hooks/use-entity-sync.ts
+++ b/src/hooks/use-entity-sync.ts
@@ -1,0 +1,62 @@
+/**
+ * Hook that listens for backend entity-mutation events and re-fetches the
+ * relevant store. Entities (workspaces, columns, scripts) have no optimistic
+ * sync the way tasks do, so when they're created/changed out of band — e.g. by
+ * MCP or the chef/orchestrator — this keeps the UI in sync without a reload.
+ *
+ * Mirrors `useTaskSync`, but for the `entities:changed` channel.
+ */
+
+import { useEffect, useRef } from 'react'
+import { listen, type UnlistenFn } from '@/lib/ipc'
+import { useColumnStore } from '@/stores/column-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useScriptStore } from '@/stores/script-store'
+
+type EntityKind = 'workspace' | 'column' | 'script'
+
+type EntitiesChangedPayload = {
+  workspaceId: string
+  kind: EntityKind
+}
+
+export function useEntitySync(workspaceId: string | null) {
+  const loadColumns = useColumnStore((s) => s.load)
+  const loadWorkspaces = useWorkspaceStore((s) => s.load)
+  const reloadScripts = useScriptStore((s) => s.reload)
+  const unlistenRef = useRef<UnlistenFn | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    void listen<EntitiesChangedPayload>('entities:changed', (payload) => {
+      if (cancelled) return
+      switch (payload.kind) {
+        case 'workspace':
+          void loadWorkspaces()
+          break
+        case 'column':
+          // Only reload columns for the active workspace's board.
+          if (workspaceId && payload.workspaceId === workspaceId) {
+            void loadColumns(workspaceId)
+          }
+          break
+        case 'script':
+          void reloadScripts()
+          break
+      }
+    }).then((unlisten) => {
+      if (cancelled) {
+        unlisten()
+      } else {
+        unlistenRef.current = unlisten
+      }
+    })
+
+    return () => {
+      cancelled = true
+      unlistenRef.current?.()
+      unlistenRef.current = null
+    }
+  }, [workspaceId, loadColumns, loadWorkspaces, reloadScripts])
+}

--- a/src/lib/ipc/cli.ts
+++ b/src/lib/ipc/cli.ts
@@ -58,3 +58,28 @@ export type CliUpdateInfo = {
 export async function checkCliUpdate(cliId: string): Promise<CliUpdateInfo> {
   return invoke<CliUpdateInfo>('check_cli_update', { cliId })
 }
+
+// ─── CLI compatibility health (Phase 5) ─────────────────────────────────────
+
+export type CliHealthReport = {
+  id: string
+  name: string
+  available: boolean
+  path: string | null
+  version: string | null
+  minVersion: string | null
+  versionOk: boolean
+  missingFlags: string[]
+  /** "ok" | "missing" | "outdated" | "drift" */
+  status: string
+}
+
+export async function checkCliHealth(): Promise<CliHealthReport[]> {
+  return invoke<CliHealthReport[]>('check_cli_health')
+}
+
+/** A report worth surfacing: an installed CLI whose flags or version drifted.
+ *  A *missing* CLI is intentionally ignored here — onboarding/settings own that. */
+export function isCliHealthConcerning(report: CliHealthReport): boolean {
+  return report.available && (report.status === 'drift' || report.status === 'outdated')
+}

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -21,6 +21,7 @@ export * from './label'
 export * from './models'
 export * from './updater'
 export * from './system'
+export * from './settings'
 
 // Re-export listen and types that consumers use directly
 export { listen, type UnlistenFn, type EventCallback } from './invoke'

--- a/src/lib/ipc/settings.ts
+++ b/src/lib/ipc/settings.ts
@@ -1,0 +1,33 @@
+import { invoke } from './invoke'
+
+/**
+ * Mirror of the backend `AppSettings` struct (`~/.kaitencode/settings.json`).
+ * Keys are snake_case to match the on-disk JSON and the `/api/settings` route —
+ * `AppSettings` has no serde rename, so the Tauri commands serialize snake_case.
+ */
+export interface AppSettings {
+  max_agent_sessions: number
+  gc_interval_minutes: number
+  idle_sleep_minutes: number
+  idle_kill_hours: number
+  archive_purge_days: number
+  default_agent_cli: string
+  default_model: string
+  default_session_strategy: string
+  default_advance_mode: string
+  /** "terminal" | "managed" | "interactive" | "" (empty = no global default). */
+  default_runtime_mode: string
+  /** Opt-in gate for interactive runtime mode (Phase 3). */
+  interactive_mode_enabled: boolean
+}
+
+export async function getAppSettings(): Promise<AppSettings> {
+  return invoke<AppSettings>('get_app_settings')
+}
+
+/** Merge a partial update (only provided keys change) and persist it. */
+export async function updateAppSettings(
+  updates: Partial<AppSettings>,
+): Promise<AppSettings> {
+  return invoke<AppSettings>('update_app_settings', { updates })
+}

--- a/src/lib/ipc/task.ts
+++ b/src/lib/ipc/task.ts
@@ -52,13 +52,35 @@ export async function deleteTaskTemplate(id: string): Promise<void> {
   return invoke('delete_task_template', { id })
 }
 
+/** Rich, optional fields for task creation — mirrors the backend `NewTask`.
+ *  Anything an agent/MCP can set at creation, the UI can set too. */
+export interface CreateTaskOptions {
+  triggerPrompt?: string
+  /** JSON array of task IDs; non-empty marks the task blocked. */
+  dependencies?: string
+  model?: string
+  priority?: string
+  runtimeModeOverride?: string
+}
+
 export async function createTask(
   workspaceId: string,
   columnId: string,
   title: string,
   description?: string,
+  options: CreateTaskOptions = {},
 ): Promise<Task> {
-  return invoke<Task>('create_task', { workspaceId, columnId, title, description })
+  return invoke<Task>('create_task', {
+    workspaceId,
+    columnId,
+    title,
+    description,
+    triggerPrompt: options.triggerPrompt,
+    dependencies: options.dependencies,
+    model: options.model,
+    priority: options.priority,
+    runtimeModeOverride: options.runtimeModeOverride,
+  })
 }
 
 export async function getTask(id: string): Promise<Task> {
@@ -70,6 +92,16 @@ export async function updateTask(
   updates: Partial<Task>,
 ): Promise<Task> {
   return invoke<Task>('update_task', { id, ...updates })
+}
+
+/** Set or clear (`null`) the task-level runtime mode override — the field the
+ *  pipeline resolver consults at tier 2. Unlike `updateTask`'s `agentMode`,
+ *  this actually takes effect. Emits `tasks:changed`. */
+export async function setTaskRuntimeModeOverride(
+  id: string,
+  runtimeModeOverride: string | null,
+): Promise<Task> {
+  return invoke<Task>('set_task_runtime_mode_override', { id, runtimeModeOverride })
 }
 
 export async function updateTaskTriggers(

--- a/src/lib/ipc/terminal.ts
+++ b/src/lib/ipc/terminal.ts
@@ -32,6 +32,43 @@ export async function ensurePtySession(
   return invoke('ensure_pty_session', { taskId, workingDir, cols, rows, allowSpawn })
 }
 
+/** AgentInfo shape returned by the PTY-ensure commands. */
+export type EnsureSessionInfo = {
+  taskId: string
+  pid: number | null
+  status: string
+  scrollback?: string
+}
+
+/** Common signature shared by `ensurePtySession` and `ensureChefTerminal`, so a
+ *  terminal view can be pointed at either a task or a workspace-level session. */
+export type EnsureSessionFn = (
+  id: string,
+  workingDir: string,
+  cols: number,
+  rows: number,
+  allowSpawn: boolean,
+) => Promise<EnsureSessionInfo>
+
+/** Registry key (and `pty:<key>:*` event prefix) for a workspace chef terminal. */
+export function chefSessionKey(workspaceId: string): string {
+  return `chef_${workspaceId}`
+}
+
+/**
+ * Ensure the workspace-level chef terminal (a shell rooted at the repo) exists.
+ * Mirrors `ensurePtySession` but keyed by workspace; the returned `taskId` is
+ * the `chef_<workspaceId>` session key the generic PTY IPC + events use.
+ */
+export async function ensureChefTerminal(
+  workspaceId: string,
+  cols: number,
+  rows: number,
+  allowSpawn = true,
+): Promise<EnsureSessionInfo> {
+  return invoke('ensure_chef_terminal', { workspaceId, cols, rows, allowSpawn })
+}
+
 export type TransportType = 'pipe' | 'pty'
 
 export async function switchAgentTransport(

--- a/src/stores/script-store.ts
+++ b/src/stores/script-store.ts
@@ -8,6 +8,8 @@ type ScriptState = {
   loaded: boolean
 
   load: () => Promise<void>
+  /** Force a refetch even if already loaded — used when scripts change out of band. */
+  reload: () => Promise<void>
   getScriptName: (id: string) => string | undefined
 }
 
@@ -19,6 +21,11 @@ export const useScriptStore = create<ScriptState>()(
 
       load: async () => {
         if (get().loaded) return
+        const scripts = await ipc.listScripts()
+        set({ scripts, loaded: true })
+      },
+
+      reload: async () => {
         const scripts = await ipc.listScripts()
         set({ scripts, loaded: true })
       },

--- a/src/stores/task-store.test.ts
+++ b/src/stores/task-store.test.ts
@@ -123,8 +123,26 @@ describe('task-store', () => {
       const state = useTaskStore.getState()
       expect(created).toEqual(newTask)
       expect(state.tasks).toContainEqual(newTask)
-      expect(mockIpc.createTask).toHaveBeenCalledWith('ws-1', 'col-1', 'New Task', 'Description')
+      expect(mockIpc.createTask).toHaveBeenCalledWith('ws-1', 'col-1', 'New Task', 'Description', undefined)
       expect(refreshWorkspace).toHaveBeenCalledWith('ws-1')
+    })
+
+    it('should forward create options to the createTask IPC', async () => {
+      const newTask = createMockTask({ id: 'task-opts', title: 'Configured Task' })
+      mockIpc.createTask.mockResolvedValueOnce(newTask)
+      refreshWorkspace.mockResolvedValueOnce(undefined)
+
+      const options = {
+        model: 'opus',
+        priority: 'high',
+        runtimeModeOverride: 'interactive',
+        triggerPrompt: 'Do the thing',
+        dependencies: '[{"task_id":"task-1","condition":"completed","on_met":{"type":"none"}}]',
+      }
+
+      await useTaskStore.getState().add('ws-1', 'col-1', 'Configured Task', 'Desc', options)
+
+      expect(mockIpc.createTask).toHaveBeenCalledWith('ws-1', 'col-1', 'Configured Task', 'Desc', options)
     })
 
     it('should add an optimistic task before IPC resolves and replace it with the created task', async () => {

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -31,7 +31,7 @@ type TaskState = {
   showArchived: boolean
 
   load: (workspaceId: string) => Promise<void>
-  add: (workspaceId: string, columnId: string, title: string, description: string) => Promise<Task>
+  add: (workspaceId: string, columnId: string, title: string, description?: string, options?: ipc.CreateTaskOptions) => Promise<Task>
   remove: (id: string) => Promise<void>
   bulkRemove: (ids: string[]) => Promise<boolean>
   bulkMove: (ids: string[], targetColumnId: string) => Promise<boolean>
@@ -128,13 +128,13 @@ export const useTaskStore = create<TaskState>()(
         set({ tasks, loaded: true })
       },
 
-      add: async (workspaceId, columnId, title, description) => {
+      add: async (workspaceId, columnId, title, description, options) => {
         const prev = get().tasks
-        const optimisticTask = createOptimisticTask(prev, workspaceId, columnId, title, description)
+        const optimisticTask = createOptimisticTask(prev, workspaceId, columnId, title, description ?? '')
         set((s) => ({ tasks: [...s.tasks, optimisticTask] }))
 
         try {
-          const task = await ipc.createTask(workspaceId, columnId, title, description)
+          const task = await ipc.createTask(workspaceId, columnId, title, description, options)
           set((s) => ({
             tasks: s.tasks.map((current) =>
               current.id === optimisticTask.id ? task : current,


### PR DESCRIPTION
Brings the remaining terminal-harness roadmap into main. Two stacked commits:

### `4681d80` — Front 3: unify the agent-spawn path (backend)
Backend refactor consolidating the agent spawn/trigger path (api, bridge, runtime, executor, pipeline, db, mcp-server).

### `d25a1a7` — B-series roadmap (B1–B4)

**B1 (Phase 2) — every agent-creation option in the new-task UI**
- Shared `TaskOptionFields` (model/runtime/priority) used by both the create dialog and the task settings modal.
- `TaskCreateDialog`: column, model, runtime mode, priority, trigger prompt, dependencies — threaded through `useTaskStore.add` → `createTask` options.
- Inline quick-add “More options…” promotes to the full dialog.

**B2 (Phase 3) — promote interactive runtime mode (opt-in)**
- `AppSettings.interactive_mode_enabled` replaces the raw env gate (env var stays a force-on override).
- `get/update_app_settings` Tauri commands bridge the UI to the resolver's global tier.
- `set_task_runtime_mode_override` write path fixes the resolver's tier-2 task override being inert; settings modal repointed.
- Settings → Agent “Agent runtime” section, per-chat header toggle, onboarding runtime-mode step.

**B3 (Phase 4) — workspace-level chef terminal**
- `ensure_chef_terminal` spawns a repo-rooted shell under the `chef_<ws>` key, reusing the generic PTY IPC + `pty:<key>:*` events.
- `TerminalView` parameterized with an `ensure` strategy; `OrchestratorTerminalView` + a Chat↔Terminal toggle.

**B4 (Phase 5) — CLI-compatibility health check**
- Probes `claude`/`codex` `--help`/`--version` for flag/version drift (pure, unit-tested); `check_cli_health` command + startup broadcast.
- Dismissible app banner for installed-but-drifted CLIs; `claude`/`codex` min-version settings.

### Verification
`tsc`, `eslint`, `vitest` (401 passing), `cargo test --lib` (482 passing) all green.

### Notes / deferred
- B3/B4 banner compile, type-check, and have unit-tested wiring; the live tmux/xterm spawn-attach and drift banner against real CLIs need a manual smoke run.
- Deferred (explicitly optional): B4 feature-flagged live CLI smoke test; a dedicated Settings editor for the version-pin fields (settable via the settings API today).