### PR TITLE
Spawn-path naming cleanup + MCP create_task dogfood fixes

### DIFF
--- a/.tickets/_docs/MCP_DOGFOOD_REPORT.md
+++ b/.tickets/_docs/MCP_DOGFOOD_REPORT.md
@@ -102,12 +102,12 @@ The current design intentionally pushes the responsibility to the **agent prompt
 
 ## Bugs / inconsistencies (filed as follow-ups)
 
-| # | What | Severity | File |
-|---|---|---|---|
-| 1 | `create_task` accepts `model` but the `/api/create_task` payload drops it | medium (silent no-op) | `.tickets/mcp-fix-create-task-model-dropped.md` |
-| 2 | `create_task` doesn't expose `trigger_prompt` (API supports it) | medium (feature gap) | `.tickets/mcp-fix-create-task-trigger-prompt.md` |
-| 3 | `mark_complete` / `add_dependency` / `remove_dependency` bypass the API → no `tasks:changed` | low (stale UI) | `.tickets/mcp-fix-direct-db-no-events.md` |
-| 4 | No source attribution / recursion guard | medium (safety) | `.tickets/mcp-add-source-attribution.md` |
+| # | What | Severity | File | Status |
+|---|---|---|---|---|
+| 1 | `create_task` accepts `model` but the `/api/create_task` payload drops it | medium (silent no-op) | `.tickets/done/mcp-fix-create-task-model-dropped.md` | ✅ fixed — `handle_create_task` forwards `model`; regression test `test_create_task_persists_options` |
+| 2 | `create_task` doesn't expose `trigger_prompt` (API supports it) | medium (feature gap) | `.tickets/done/mcp-fix-create-task-trigger-prompt.md` | ✅ fixed — schema + handler forward `trigger_prompt` (and `priority`/`dependencies`/`runtime_mode`) |
+| 3 | `mark_complete` / `add_dependency` / `remove_dependency` bypass the API → no `tasks:changed` | low (stale UI) | `.tickets/mcp-fix-direct-db-no-events.md` | open |
+| 4 | No source attribution / recursion guard | medium (safety) | `.tickets/mcp-add-source-attribution.md` | open |
 
 ## Recommendations
 

--- a/.tickets/done/mcp-fix-create-task-model-dropped.md
+++ b/.tickets/done/mcp-fix-create-task-model-dropped.md
@@ -1,5 +1,14 @@
 # MCP `create_task` silently drops `model` parameter
 
+> ✅ **RESOLVED 2026-06-05.** The API side was fixed by the Front 1
+> `create_task_service` refactor (`CreateTaskReq` now carries `model` →
+> `NewTask.model`, persisted before `fire_trigger`). The MCP side now reads
+> `model` and forwards it in the `api_call` body (`handle_create_task`,
+> `mcp-server/src/main.rs`). The test-only DB fallback was made faithful and a
+> regression test added: `test_create_task_persists_options` asserts
+> `model`/`priority`/`trigger_prompt`/`dependencies` round-trip. Original ticket
+> kept below for history.
+
 Found during MCP dogfood audit, 2026-05-12. See `.tickets/_docs/MCP_DOGFOOD_REPORT.md`.
 
 ## Symptom

--- a/.tickets/done/mcp-fix-create-task-trigger-prompt.md
+++ b/.tickets/done/mcp-fix-create-task-trigger-prompt.md
@@ -1,5 +1,12 @@
 # MCP `create_task` doesn't expose `trigger_prompt`
 
+> ✅ **RESOLVED 2026-06-05.** The `create_task` inputSchema now advertises
+> `trigger_prompt` (plus `model`/`priority`/`dependencies`/`runtime_mode`), and
+> `handle_create_task` forwards it in the `api_call` body. `/api/create_task`
+> already persisted it via `create_task_service` before the on_entry trigger
+> fires, so no backend change was needed. Covered by
+> `test_create_task_persists_options`. Original ticket kept below for history.
+
 Found during MCP dogfood audit, 2026-05-12. See `.tickets/_docs/MCP_DOGFOOD_REPORT.md`.
 
 ## Symptom

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -935,15 +935,31 @@ fn handle_create_task(conn: &Connection, args: &Value) -> Value {
         return json!({ "error": "Failed to reach app API — is the app running?" });
     }
 
-    // Test-only fallback: direct DB write
+    // Test-only fallback: direct DB write. Kept faithful to the fields the
+    // production `/api/create_task` path persists (model, priority,
+    // dependencies, trigger_prompt) so regression tests exercise the real
+    // forwarding contract — not a lossy stub. (runtime_mode_override is omitted
+    // only because the in-memory test schema predates that column.)
     let id = new_id();
     let ts = now();
     let position = max_task_position(conn, &col_id) + 1;
     match conn.execute(
         "INSERT INTO tasks (id, workspace_id, column_id, title, description, position, priority, \
-         pipeline_state, blocked, dependencies, retry_count, model, created_at, updated_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'medium', 'idle', 0, '[]', 0, ?7, ?8, ?8)",
-        params![id, ws_id, col_id, title, description, position, model, ts],
+         pipeline_state, blocked, dependencies, trigger_prompt, retry_count, model, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'idle', 0, ?8, ?9, 0, ?10, ?11, ?11)",
+        params![
+            id,
+            ws_id,
+            col_id,
+            title,
+            description,
+            position,
+            priority.unwrap_or("medium"),
+            dependencies.unwrap_or("[]"),
+            trigger_prompt,
+            model,
+            ts
+        ],
     ) {
         Ok(_) => json!({
             "task": { "id": id, "title": title, "column": col_name },
@@ -2626,6 +2642,45 @@ mod tests {
         );
         assert!(result.get("error").is_none(), "Got error: {:?}", result);
         assert_eq!(result["task"]["title"], "New Task");
+    }
+
+    #[test]
+    fn test_create_task_persists_options() {
+        // Regression for the two MCP dogfood bugs: create_task used to drop
+        // `model` and not expose `trigger_prompt`. Assert the full create-option
+        // set forwarded by handle_create_task actually lands on the task row.
+        let conn = setup_test_db();
+        create_test_workspace(&conn);
+
+        let result = handle_create_task(
+            &conn,
+            &json!({
+                "workspace": "Test WS",
+                "column": "Backlog",
+                "title": "Optioned Task",
+                "model": "sonnet",
+                "priority": "high",
+                "trigger_prompt": "apply the patch and run tests",
+                "dependencies": "[\"dep-1\"]",
+            }),
+        );
+        assert!(result.get("error").is_none(), "Got error: {:?}", result);
+
+        let row: (Option<String>, String, Option<String>, String) = conn
+            .query_row(
+                "SELECT model, priority, trigger_prompt, dependencies FROM tasks WHERE title = ?1",
+                params!["Optioned Task"],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0.as_deref(), Some("sonnet"), "model dropped");
+        assert_eq!(row.1, "high", "priority dropped");
+        assert_eq!(
+            row.2.as_deref(),
+            Some("apply the patch and run tests"),
+            "trigger_prompt dropped"
+        );
+        assert_eq!(row.3, "[\"dep-1\"]", "dependencies dropped");
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -137,7 +137,14 @@ fn canonical_existing_dir(path: &str) -> Result<PathBuf, AppError> {
     Ok(canonical)
 }
 
-fn resolve_task_working_dir(
+/// **Validate** a caller-supplied working directory against the task's allowed
+/// roots: it must canonicalize to either the workspace repo root or the task's
+/// worktree, else this errors. This is a guard on untrusted input, distinct
+/// from the spawn-time *resolver*
+/// [`crate::pipeline::triggers::resolve_working_dir`], which simply *picks*
+/// worktree-or-repo with no validation. Don't collapse the two — this one's job
+/// is to reject anything outside the sandbox.
+fn validate_requested_working_dir(
     task: &db::Task,
     workspace: &db::Workspace,
     requested_working_dir: &str,
@@ -173,7 +180,7 @@ fn validate_task_launch_inputs(
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
     let task = db::get_task(&conn, task_id)?;
     let workspace = db::get_workspace(&conn, &task.workspace_id)?;
-    let working_dir = resolve_task_working_dir(&task, &workspace, working_dir)?;
+    let working_dir = validate_requested_working_dir(&task, &workspace, working_dir)?;
     let cli = validate_agent_cli_path(cli_path.unwrap_or("claude"))?;
     Ok((working_dir, cli))
 }
@@ -459,7 +466,7 @@ pub async fn send_task_input(
         }
 
         let tmux_name = tmux_session_name_for_task(&task_id);
-        let runtime_mode = normalize_agent_runtime_mode(
+        let runtime_mode = chat_turn_runtime_mode(
             previous_task
                 .agent_mode
                 .as_deref()
@@ -718,7 +725,19 @@ fn agent_input_source(source: &str) -> AgentInputSource {
     }
 }
 
-fn normalize_agent_runtime_mode(runtime_mode: Option<&str>) -> &'static str {
+/// Classify a per-task **chat-turn** into the two runtime modes this path can
+/// actually deliver: `managed` (semantic event stream) or `terminal` (raw `-p`
+/// turn). It deliberately does **not** return `interactive` — interactive
+/// follow-up input is routed through `agent_inject_message`
+/// (`tmux send-keys`), never through this turn path, so an `interactive` task
+/// collapses to `terminal` here as a defensive fallback.
+///
+/// This is intentionally narrower than the full spawn-time resolver
+/// [`crate::pipeline::triggers::normalize_agent_runtime_mode`], which also
+/// applies the dev-flag / CLI-support gating and can return `interactive`.
+/// They share no logic on purpose: this one answers "how do I deliver a chat
+/// turn?", that one answers "how should a fresh agent be spawned?".
+fn chat_turn_runtime_mode(runtime_mode: Option<&str>) -> &'static str {
     match runtime_mode {
         Some("managed") => "managed",
         _ => "terminal",
@@ -2112,9 +2131,12 @@ mod tests {
             agent_adapter_kind_from_db("claude_cli"),
             AgentAdapterKind::ClaudeCli
         );
-        assert_eq!(normalize_agent_runtime_mode(Some("managed")), "managed");
-        assert_eq!(normalize_agent_runtime_mode(Some("terminal")), "terminal");
-        assert_eq!(normalize_agent_runtime_mode(Some("surprise")), "terminal");
+        assert_eq!(chat_turn_runtime_mode(Some("managed")), "managed");
+        assert_eq!(chat_turn_runtime_mode(Some("terminal")), "terminal");
+        assert_eq!(chat_turn_runtime_mode(Some("surprise")), "terminal");
+        // Interactive never flows through the chat-turn path; it collapses to
+        // terminal here (real interactive input goes via agent_inject_message).
+        assert_eq!(chat_turn_runtime_mode(Some("interactive")), "terminal");
     }
 
     #[test]

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -976,6 +976,10 @@ fn execute_batch_wait(
 }
 
 /// Resolve working directory for a task: worktree_path (if set and exists) > workspace.repo_path.
+///
+/// This *picks* the spawn cwd; it does not validate untrusted input. For the
+/// input-guard counterpart (caller-supplied dir must match an allowed root),
+/// see `commands::agent::validate_requested_working_dir`.
 pub(crate) fn resolve_working_dir(task: &Task, workspace_repo_path: &str) -> String {
     if let Some(ref wt) = task.worktree_path {
         if !wt.is_empty() && std::path::Path::new(wt).exists() {
@@ -1789,6 +1793,11 @@ fn execute_spawn_cli(
     Ok(updated_task)
 }
 
+/// Full spawn-time runtime-mode resolver: applies the dev-flag gate and
+/// CLI-support check, and can return `interactive`. This is the one used when
+/// *spawning a fresh agent* (via `spawn::resolve`). For the narrower per-task
+/// chat-turn classifier (managed-or-terminal only, no interactive), see
+/// `commands::agent::chat_turn_runtime_mode`.
 pub(crate) fn normalize_agent_runtime_mode(
     runtime_mode: Option<&str>,
     cli_type: &str,


### PR DESCRIPTION
Two small, independently-safe cleanups on top of the landed Front 3 work.

## 1. Disambiguate spawn-path helper names (`6dc138b`)
Front 3's consolidation is substantially complete (shared `spawn::resolve`, `model_to_args`, `task_md_default_prompt`, `resolve_working_dir`, `persist_agent_session_started`). What remained read as duplication but wasn't — two pairs of helpers echoed names across modules despite different contracts:

- `agent.rs::normalize_agent_runtime_mode` → `chat_turn_runtime_mode` (a 2-way managed/terminal classifier for chat turns; never returns interactive — interactive input routes via `agent_inject_message`). Distinct from the full spawn-time resolver `triggers.rs::normalize_agent_runtime_mode`.
- `agent.rs::resolve_task_working_dir` → `validate_requested_working_dir` (validates untrusted caller input against allowed roots). Distinct from `triggers.rs::resolve_working_dir` (picks worktree-or-repo). A prior scan misread this one as dead code — deleting it would have removed a sandbox guard.

Cross-reference docs added on both sides. No behavior change; +1 interactive-collapse test assertion.

## 2. Close MCP `create_task` dogfood bugs (`3af7a38`)
The two filed bugs (`model` silently dropped, `trigger_prompt` not exposed) were already fixed in the production path by the Front 1 `create_task_service` refactor + B-series create-options work — `handle_create_task` forwards `model`/`trigger_prompt`/`priority`/`dependencies`/`runtime_mode`, and `/api/create_task` persists them before the on_entry trigger fires.

This closes the remaining gap: the test-only direct-DB fallback was lossy (hardcoded priority/deps, dropped trigger_prompt), so no regression test could catch a forwarding regression. Made it faithful and added `test_create_task_persists_options`. Both tickets moved to `.tickets/done/`; dogfood report bug table updated.

## Verification
- `cargo test --lib`: 482 passed
- `cargo test -p kaitencode-mcp`: 18 passed
- `cargo check --workspace`: clean (precommit)