### PR TITLE
Docs refresh + pty-exit camelCase (A2) + close MCP bug #3

### DIFF
--- a/.tickets/_docs/MCP_DOGFOOD_REPORT.md
+++ b/.tickets/_docs/MCP_DOGFOOD_REPORT.md
@@ -106,7 +106,7 @@ The current design intentionally pushes the responsibility to the **agent prompt
 |---|---|---|---|---|
 | 1 | `create_task` accepts `model` but the `/api/create_task` payload drops it | medium (silent no-op) | `.tickets/done/mcp-fix-create-task-model-dropped.md` | ✅ fixed — `handle_create_task` forwards `model`; regression test `test_create_task_persists_options` |
 | 2 | `create_task` doesn't expose `trigger_prompt` (API supports it) | medium (feature gap) | `.tickets/done/mcp-fix-create-task-trigger-prompt.md` | ✅ fixed — schema + handler forward `trigger_prompt` (and `priority`/`dependencies`/`runtime_mode`) |
-| 3 | `mark_complete` / `add_dependency` / `remove_dependency` bypass the API → no `tasks:changed` | low (stale UI) | `.tickets/mcp-fix-direct-db-no-events.md` | open |
+| 3 | `mark_complete` / `add_dependency` / `remove_dependency` bypass the API → no `tasks:changed` | low (stale UI) | `.tickets/done/mcp-fix-direct-db-no-events.md` | ✅ fixed — all three route through `/api/mark_complete` + `/api/set_dependencies`, which emit `tasks:changed`; direct DB only under `allow_db_fallback()` |
 | 4 | No source attribution / recursion guard | medium (safety) | `.tickets/mcp-add-source-attribution.md` | open |
 
 ## Recommendations

--- a/.tickets/_docs/NEXT_STEPS.md
+++ b/.tickets/_docs/NEXT_STEPS.md
@@ -1,6 +1,12 @@
 # KaitenCode Next Steps
 
 > Updated: 2026-05-08.
+>
+> ⚠️ **Currency note (2026-06-05):** the terminal-harness B-series (B1–B4) and
+> Front 3 (agent-spawn) referenced as pending have all landed. The current
+> open-work list lives in [`handoffs/REMAINING_WORK.md`](./handoffs/REMAINING_WORK.md)
+> (MCP bugs #3/#4, A2 casing, codex interactive verification, C-section product
+> gaps).
 
 ## Current State
 

--- a/.tickets/_docs/STATUS.md
+++ b/.tickets/_docs/STATUS.md
@@ -2,6 +2,11 @@
 
 > Last updated: 2026-04-05
 >
+> ⚠️ **Currency note (2026-06-05):** the tiers below predate the source-of-truth
+> refactor (Fronts 1–3) and the terminal-harness B-series (B1–B4), which have all
+> since landed. For the authoritative "what's done / what's left" picture see
+> [`handoffs/REMAINING_WORK.md`](./handoffs/REMAINING_WORK.md).
+>
 > See also: [ARCHITECTURE.md](./ARCHITECTURE.md) for system overview
 
 ## Summary

--- a/.tickets/_docs/handoffs/FRONT3_AGENT_SPAWN.md
+++ b/.tickets/_docs/handoffs/FRONT3_AGENT_SPAWN.md
@@ -1,10 +1,20 @@
 # Handoff — Front 3: Unify the agent-spawn path (one `ResolvedAgentSpawn`)
 
-> **Status:** not started. This is the third and deepest leg of the
-> "single source of truth" refactor. Fronts 1 (task mutations) and 2 (entity
-> ops) are landed and green — see `git log` and the existing
-> `pipeline::create_task_service` / `move_task_service` / `update_task_service`
-> for the established pattern this front should mirror.
+> **Status: ✅ substantially complete (2026-06-05).** Step 1 (the
+> `ResolvedAgentSpawn` resolver) is landed: `pipeline::spawn::resolve()` plus the
+> shared `model_to_args` (b), `resolve_working_dir` (c), `task_md_default_prompt`
+> (d) helpers, and `persist_agent_session_started` for the agent_session writes
+> (e). The latent empty-`workspace_id` emit bug (e) is fixed across all
+> trigger-lifecycle emits. Helper names were disambiguated (2026-06-05) so the
+> remaining "duplication" reads as the by-design split it is.
+>
+> **What remains is optional and was judged not worth the risk:** Step 2 (collapse
+> the two argv families — terminal shell-string vs managed adapter args) touches
+> the live headless render for negative clarity gain, since the families encode
+> different sandbox/approval contracts. The full per-path agent_session-helper
+> merge (e) is similarly blocked by genuine reuse-vs-fresh / managed-vs-interactive
+> differences. Don't force a DRY merge there. The original plan follows for
+> reference.
 
 ## Why this exists
 

--- a/.tickets/_docs/handoffs/REMAINING_WORK.md
+++ b/.tickets/_docs/handoffs/REMAINING_WORK.md
@@ -66,7 +66,12 @@ outcome (no DB write) and let the caller loop — which *has* `app` — call
 the new outcome / test `move_task_to_column` directly. Medium effort; **best done
 as part of Front 3** since it shares the same `app`-threading constraint.
 
-### A2. Event-payload casing — `pty:{taskId}:exit` (tiny) — 🔲 STILL OPEN
+### A2. Event-payload casing — `pty:{taskId}:exit` (tiny) — ✅ DONE (2026-06-05)
+`PtyExitPayload` now has `#[serde(rename_all = "camelCase")]`; the frontend reads
+`payload.exitCode`. The second (raw-`json!`) emitter in `bridge.rs` was routed
+through the typed `events::emit_pty_exit` helper so the two emit sites can't drift
+again. The broader `agent:*` / `pipeline:step_progress` raw-`json!` typing remains
+a low-urgency follow-up. Original notes below.
 `PtyExitPayload` in `events.rs` has **no `#[serde(rename_all = "camelCase")]`**,
 so it emits snake_case `exit_code`. It works today only because the frontend
 reads `payload.exit_code` (`terminal-view.tsx`). It's the one event violating the
@@ -196,14 +201,14 @@ ticket each:
 ## Suggested order for the next agent(s)
 ~~Front 3, B1, B2, B3, B4~~ — **all landed (2026-06-05).** What's left, roughly
 by leverage:
-1. **MCP bug #3** (`mcp-fix-direct-db-no-events.md`) — route
-   `mark_complete`/`add_dependency`/`remove_dependency` through the API so they
-   emit `tasks:changed`. Small, scoped, removes a stale-UI footgun.
-2. **MCP bug #4** (`mcp-add-source-attribution.md`) — source attribution +
-   recursion guard on agent-spawned tasks (safety). Needs a migration.
-3. **A2** — `pty:{taskId}:exit` snake_case casing (tiny: add the serde rename +
-   one frontend read).
+1. ~~**MCP bug #3**~~ ✅ already done — all three handlers route through
+   `/api/mark_complete` + `/api/set_dependencies`, which emit `tasks:changed`
+   (verified 2026-06-05; ticket moved to `done/`).
+2. ~~**A2** — `pty:{taskId}:exit` casing~~ ✅ done 2026-06-05.
+3. **MCP bug #4** (`mcp-add-source-attribution.md`) — source attribution +
+   recursion guard on agent-spawned tasks (safety). Needs a migration. **The next
+   real chunk of work.**
 4. **B2 codex verification** — confirm codex `--resume` + `--append-system-prompt`
-   actually work in interactive mode.
+   actually work in interactive mode (needs the app + a codex binary).
 5. **C-section product gaps** — inert keyboard shortcuts, multi-provider stubs,
    `thinking_level` as a first-class attribute, voice un-gating.

--- a/.tickets/_docs/handoffs/REMAINING_WORK.md
+++ b/.tickets/_docs/handoffs/REMAINING_WORK.md
@@ -21,11 +21,37 @@ MCP, 394 frontend, tsc + lint clean):
 What follows is everything **not** done, each with enough to hand off cleanly.
 The big one (Front 3 — agent spawn) has its own doc: `FRONT3_AGENT_SPAWN.md`.
 
+> ### ✅ Update 2026-06-05 — most of this shipped
+> Since this index was written, the following all landed on `main` and are
+> verified (482 Rust lib tests, 18 MCP, real-app WebDriver pass):
+> - **Front 3 — agent spawn:** substantially complete. Shared `pipeline::spawn::resolve()`
+>   + `ResolvedAgentSpawn`, `model_to_args`, `task_md_default_prompt`,
+>   `resolve_working_dir`, `persist_agent_session_started` all exist and are used.
+>   The empty-`workspace_id` emit bug (A2(e)) is fixed across all trigger-lifecycle
+>   emits. Remaining bits (argv-family collapse (f), full session-helper merge) are
+>   by-design splits, not duplication — see `FRONT3_AGENT_SPAWN.md` notes.
+> - **A1 — chef move parity:** DONE. `execute_single_tool` returns
+>   `ToolOutcome::TaskMoveRequested`; the caller routes through `move_task_service`.
+> - **B1–B4** (Phase 2 create UI, Phase 3 interactive opt-in, Phase 4 chef terminal,
+>   Phase 5 CLI health check): all DONE.
+> - **CLAUDE.md discord drift:** fixed (diagram now lists `config/`).
+> - **MCP `create_task` model/trigger_prompt drops:** fixed (see
+>   `.tickets/done/mcp-fix-create-task-*.md`).
+>
+> **Still open:** A2 (the `pty:{taskId}:exit` snake_case casing — the (e) part is
+> done, the casing part isn't); the C-section product gaps; MCP bugs #3/#4
+> (`mcp-fix-direct-db-no-events.md`, `mcp-add-source-attribution.md`); the
+> interactive-mode codex verification (B2 known gaps). Item-level statuses below.
+
 ---
 
 ## A. Source-of-truth leftovers (small, ride-along cleanups)
 
-### A1. Chef `move_task` transition parity — DEFERRED, documented
+### A1. Chef `move_task` transition parity — ✅ DONE (2026-06-05)
+Implemented as designed: the move arm returns `ToolOutcome::TaskMoveRequested`
+(no DB write) and the caller loop calls `pipeline::move_task_service`. See
+`llm/executor.rs`. Original notes kept below for context.
+
 `move_task` is unified for Tauri + HTTP API via `pipeline::move_task_service`,
 but the **chef path** (`execute_single_tool` `"move_task"` arm in
 `llm/executor.rs`) still does a raw move (`move_task_to_column`) + the caller
@@ -40,7 +66,7 @@ outcome (no DB write) and let the caller loop — which *has* `app` — call
 the new outcome / test `move_task_to_column` directly. Medium effort; **best done
 as part of Front 3** since it shares the same `app`-threading constraint.
 
-### A2. Event-payload casing — `pty:{taskId}:exit` (tiny)
+### A2. Event-payload casing — `pty:{taskId}:exit` (tiny) — 🔲 STILL OPEN
 `PtyExitPayload` in `events.rs` has **no `#[serde(rename_all = "camelCase")]`**,
 so it emits snake_case `exit_code`. It works today only because the frontend
 reads `payload.exit_code` (`terminal-view.tsx`). It's the one event violating the
@@ -64,7 +90,11 @@ Full design in `/home/anonabento/.claude/plans/peppy-stargazing-locket.md`.
 Phase 1 (task-creation source-of-truth) is **done** (it became Front 1's
 foundation). Remaining phases:
 
-### B1. Phase 2 — Expose every agent option in the create UI
+### B1. Phase 2 — Expose every agent option in the create UI — ✅ DONE (2026-06-05)
+Shipped: shared `TaskOptionFields` widget + `TaskCreateDialog` (model / runtime /
+priority / target column / trigger prompt / dependencies), threaded through
+`addTask → ipc.createTask(options)`. Original notes below.
+
 Front 1 made `model` / `trigger_prompt` / `dependencies` / `priority` /
 `runtime_mode_override` first-class create params (backend `db::NewTask`, the
 `create_task` Tauri command, and the `createTask` IPC `CreateTaskOptions` bag all
@@ -75,7 +105,14 @@ accept them). **The UI doesn't surface them yet** — the inline add
 new-task surface set model / runtime mode / target column / priority /
 trigger prompt / dependencies. Pure frontend; the backend + IPC are ready.
 
-### B2. Phase 3 — Promote interactive mode (opt-in)
+### B2. Phase 3 — Promote interactive mode (opt-in) — ✅ DONE (2026-06-05)
+Shipped: `get_app_settings`/`update_app_settings` Tauri commands +
+`AppSettings.interactive_mode_enabled`, the Settings "Agent runtime" section
+(enable toggle + default runtime dropdown), onboarding step, and the per-chat
+`RuntimeModeToggle` in the agent panel header (writes `runtime_mode_override` +
+`agent_restart`). **Codex gaps below remain open** (resume + `--append-system-prompt`).
+Original notes below.
+
 Interactive mode is fully built but gated behind env var
 `KAITENCODE_INTERACTIVE_MODE_ENABLED` (read via `config::interactive_mode_enabled()`,
 3 call sites: `triggers.rs` resolver downgrade, the `interactive_dev_flag_required`
@@ -95,7 +132,12 @@ opt-in). Claude-first; codex stays best-effort.
 (`bridge.rs` `spawn_interactive_cli` warns + ignores `resume_id` for codex), and
 whether codex honors `--append-system-prompt` for the sentinel is unverified.
 
-### B3. Phase 4 — Chef terminal view (workspace-level terminal wrapper)
+### B3. Phase 4 — Chef terminal view (workspace-level terminal wrapper) — ✅ DONE (2026-06-05)
+Shipped: `ensure_chef_terminal` (keyed `chef_<workspace_id>`, repo-rooted shell),
+the `taskId`-keyed terminal IPC generalized to any session key,
+`OrchestratorTerminalView` + chat↔terminal toggle in the orchestrator panel.
+Original notes below.
+
 Let the user drive an interactive CLI at the **workspace** level inside
 KaitenCode (no external terminal). ChefSession (`chat/chef.rs`) is pipe-only
 today; the orchestrator panel renders chat bubbles. Per-task terminals already
@@ -108,7 +150,13 @@ terminal toggle in the orchestrator panel; generalize `pty:{taskId}:output` →
 `pty:{sessionId}:output`. Est. ~300 Rust + ~150 TSX. Reuse, don't reinvent — the
 registry already namespaces chef as `chef:{workspace_id}:{session_id}`.
 
-### B4. Phase 5 — CLI-compatibility verification layer
+### B4. Phase 5 — CLI-compatibility verification layer — ✅ DONE (2026-06-05)
+Shipped: `cli_detect::CLI_HEALTH_SPECS` + `check_cli_health()` command +
+`emit_cli_health` startup check + dismissible `CliHealthBanner`. Verified against
+real installed CLIs (claude 2.1.162, codex 0.131.0 — both "ok", no false drift).
+The live smoke-test (throwaway tmux round-trip) and the codex
+`--append-system-prompt` confirmation remain as follow-ups. Original notes below.
+
 Interactive mode shells directly into `claude`/`codex`; a CLI update can silently
 break the product. **Do:** a startup/diagnostic CLI health check (detect binary
 via `commands/cli_detect.rs` `find_cli`, run `--version`, parse `--help` to
@@ -139,16 +187,23 @@ ticket each:
   wired into the trigger path. If you want thinking-level as a first-class
   create option (Phase 2), it needs a DB column (migration after 045) + model
   struct field + CLI plumbing — a real slice, not a freebie.
-- **CLAUDE.md drift:** the architecture diagram lists a `discord/ ← Discord
-  bridge` module that no longer exists (added in migrations 018/019, removed by
-  026_remove_discord). Update the doc.
+- ~~**CLAUDE.md drift:** the architecture diagram lists a `discord/ ← Discord
+  bridge` module that no longer exists.~~ ✅ Fixed 2026-06-05 (diagram now lists
+  `config/`).
 
 ---
 
 ## Suggested order for the next agent(s)
-1. **Front 3** (`FRONT3_AGENT_SPAWN.md`) — fold in **A1** (chef move parity) and
-   **A2 (e)** (empty-`workspace_id` emit) since they share the `app`-threading
-   constraint.
-2. **B1** (Phase 2 UI) — small, unblocks the create-UX win; backend already ready.
-3. **B2** (interactive promotion) — depends on B1's shared runtime-mode picker.
-4. **B3 / B4** — independent; can parallelize after B2.
+~~Front 3, B1, B2, B3, B4~~ — **all landed (2026-06-05).** What's left, roughly
+by leverage:
+1. **MCP bug #3** (`mcp-fix-direct-db-no-events.md`) — route
+   `mark_complete`/`add_dependency`/`remove_dependency` through the API so they
+   emit `tasks:changed`. Small, scoped, removes a stale-UI footgun.
+2. **MCP bug #4** (`mcp-add-source-attribution.md`) — source attribution +
+   recursion guard on agent-spawned tasks (safety). Needs a migration.
+3. **A2** — `pty:{taskId}:exit` snake_case casing (tiny: add the serde rename +
+   one frontend read).
+4. **B2 codex verification** — confirm codex `--resume` + `--append-system-prompt`
+   actually work in interactive mode.
+5. **C-section product gaps** — inert keyboard shortcuts, multi-provider stubs,
+   `thinking_level` as a first-class attribute, voice un-gating.

--- a/.tickets/done/mcp-fix-direct-db-no-events.md
+++ b/.tickets/done/mcp-fix-direct-db-no-events.md
@@ -1,5 +1,14 @@
 # MCP `mark_complete` / `add_dependency` / `remove_dependency` bypass the API → stale UI
 
+> ✅ **RESOLVED (verified 2026-06-05).** Fixed via option A. The routes
+> `/api/mark_complete` and `/api/set_dependencies` exist (the latter serves both
+> add/remove). `handle_mark_complete`, `handle_add_dependency`, and
+> `handle_remove_dependency` all `api_call(...)` first and fall back to direct DB
+> only under `allow_db_fallback()`. The API handlers emit `tasks:changed`
+> (`mark_complete_with_error`; `dependencies::set_task_dependencies`), so the UI
+> refreshes live. The `require_app()` check on `mark_complete` is now accurate.
+> Original ticket kept below for history.
+
 Found during MCP dogfood audit, 2026-05-12. See `.tickets/_docs/MCP_DOGFOOD_REPORT.md`.
 
 ## Symptom

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ src/                                   src-tauri/src/
 │   ├── shared/      Reusable atoms    ├── pipeline/        ← Trigger engine
 │   ├── layout/      App shell         ├── chat/            ← tmux transport + bridge
 │   └── ...          Feature panels    ├── llm/             ← LLM integration
-├── hooks/                             ├── discord/         ← Discord bridge
+├── hooks/                             ├── config/          ← Settings + feature flags
 │   ├── chat-session/  Unified chat    ├── whisper/         ← Voice transcription
 │   └── use-*.ts       Feature hooks   └── git/             ← Git operations
 ├── stores/            Zustand state

--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -292,9 +292,14 @@ async fn handle_bridge_event(
                 None,
                 runtime_event,
             );
-            let _ = app.emit(
-                &format!("pty:{}:exit", task_id),
-                serde_json::json!({ "task_id": task_id, "exit_code": exit_code }),
+            // Use the typed helper so the payload stays camelCase in lockstep
+            // with the other `pty:{taskId}:exit` emitter (events::emit_pty_exit).
+            crate::events::emit_pty_exit(
+                app,
+                crate::events::PtyExitPayload {
+                    task_id: task_id.to_string(),
+                    exit_code: *exit_code,
+                },
             );
             let _ = app.emit(
                 "agent:complete",

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -43,6 +43,7 @@ pub struct PtyOutputPayload {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PtyExitPayload {
     pub task_id: String,
     pub exit_code: Option<i32>,

--- a/src/components/panel/terminal-view.tsx
+++ b/src/components/panel/terminal-view.tsx
@@ -185,7 +185,7 @@ export function TerminalView({ taskId, workingDir, allowSpawn = true, ensure = e
     listenerPromises.push(
       listen<PtyExitPayload>(EventChannels.ptyExit(taskId), (payload) => {
         if (disposed) return
-        const code = String(payload.exit_code ?? 0)
+        const code = String(payload.exitCode ?? 0)
         term.write(`\r\n\x1b[90m--- Process exited (code ${code}) ---\x1b[0m\r\n`)
       }),
     )

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -21,8 +21,8 @@ export interface PtyOutputPayload {
 }
 
 export interface PtyExitPayload {
-  task_id: string
-  exit_code: number | null
+  taskId: string
+  exitCode: number | null
 }
 
 export type AgentTranscriptEventType =


### PR DESCRIPTION
## Docs refresh
The handoff/status docs had drifted behind the code (still listing B1–B4, Front 3, A1 as pending though all landed), costing real rediscovery time. Brought current:
- `CLAUDE.md` — architecture diagram listed a non-existent `discord/` module → replaced with the real `config/`.
- `handoffs/REMAINING_WORK.md` — dated banner + per-item status; A1/A2/B1–B4 marked done; Front 3 substantially complete; suggested-order rewritten to the actually-open work.
- `handoffs/FRONT3_AGENT_SPAWN.md` — "not started" → "substantially complete".
- `STATUS.md` / `NEXT_STEPS.md` — currency-note banners pointing at `REMAINING_WORK.md`.

## A2 — pty exit payload casing (the one event violating the camelCase rule)
`PtyExitPayload` emitted snake_case `exit_code`/`task_id`. Added `#[serde(rename_all = "camelCase")]`, updated the TS type + `terminal-view.tsx` reader to `exitCode`. Routed the second, raw-`json!` emitter in `bridge.rs` through the typed `events::emit_pty_exit` helper so the two emit sites can't drift again.

## MCP bug #3 — already fixed, verified + closed
`mark_complete`/`add_dependency`/`remove_dependency` were reported as bypassing the API. They already route through `/api/mark_complete` + `/api/set_dependencies` (which emit `tasks:changed`), with direct DB only under `allow_db_fallback()`. Verified, ticket moved to `done/`, dogfood report updated.

## Verification
- `cargo test --lib`: 482 passed
- `npx tsc --noEmit`: clean · `npm run lint`: clean
- `cargo check --workspace`: clean (precommit)