### PR TITLE
feat(ui): 'spawned by' badge on agent-spawned task cards

### DIFF
--- a/src/components/kanban/task-card.test.tsx
+++ b/src/components/kanban/task-card.test.tsx
@@ -214,4 +214,29 @@ describe('TaskCard quick-action keyboard behavior', () => {
     expect(useUIStore.getState().expandedTaskId).toBe('t1')
     expect(screen.getByLabelText('Edit task description')).toBeInTheDocument()
   })
+
+  it('shows a "spawned by" badge resolving the parent task title', () => {
+    const parent = mockKanbanTask({ id: 'parent-1', title: 'Orchestrator task' })
+    const child = mockKanbanTask({
+      id: 'child-1',
+      title: 'Agent-spawned task',
+      createdByTaskId: 'parent-1',
+      recursionDepth: 1,
+    })
+    resetStores(child)
+    // Both tasks in the store so the badge can resolve the parent's title.
+    useTaskStore.setState({ tasks: [parent, child], loaded: true })
+
+    render(<TaskCard task={child} />)
+
+    expect(screen.getByText('spawned by Orchestrator task')).toBeInTheDocument()
+  })
+
+  it('omits the "spawned by" badge for human-created tasks', () => {
+    const task = mockKanbanTask({ createdByTaskId: null })
+    resetStores(task)
+    render(<TaskCard task={task} />)
+
+    expect(screen.queryByText(/spawned by/i)).not.toBeInTheDocument()
+  })
 })

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -295,6 +295,14 @@ export const TaskCard = memo(function TaskCard({
     return names.length > 0 ? names.join(', ') : null
   }, [task.blocked, task.dependencies])
 
+  // MCP attribution: when this task was spawned by another task's agent, resolve
+  // the parent's title for the "spawned by …" badge (falls back to the id).
+  const spawnedByLabel = useMemo(() => {
+    if (!task.createdByTaskId) return null
+    const parent = useTaskStore.getState().tasks.find(t => t.id === task.createdByTaskId)
+    return parent?.title ?? task.createdByTaskId
+  }, [task.createdByTaskId])
+
   // Find next column for "move right" action
   const nextColumnId = useMemo(() => {
     const sorted = [...columns].sort((a, b) => a.position - b.position)
@@ -386,6 +394,7 @@ export const TaskCard = memo(function TaskCard({
     task.heldByUser ||
     titleWorkspaceName ||
     task.model ||
+    task.createdByTaskId ||
     (cardSettings.showPrBadge && task.prNumber) ||
     (cardSettings.showCommentCount && task.prCommentCount > 0) ||
     (cardSettings.showLabels && taskLabels.length > 0) ||
@@ -606,6 +615,18 @@ export const TaskCard = memo(function TaskCard({
             {task.heldByUser && (
               <span className="inline-flex items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-warning">
                 Held
+              </span>
+            )}
+            {spawnedByLabel && (
+              <span
+                className="inline-flex max-w-[160px] items-center gap-1 truncate rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent"
+                title={`Spawned by an agent on "${spawnedByLabel}" (chain depth ${String(task.recursionDepth)})`}
+              >
+                <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M8 1.5v4M8 10.5v4M3.5 8h-2M14.5 8h-2" strokeLinecap="round" />
+                  <circle cx="8" cy="8" r="2.5" />
+                </svg>
+                <span className="truncate">spawned by {spawnedByLabel}</span>
               </span>
             )}
             {titleWorkspaceName && (


### PR DESCRIPTION
Part 3 polish for the MCP recursion-guard work (#222). When a task carries `createdByTaskId` (created by another task's agent via MCP), its kanban card shows a small accent badge resolving the **parent task's title**, with the chain depth in the tooltip. Human/UI-created tasks show nothing.

- Resolves the parent title from the task store (memoized, mirrors the existing `blockerInfo` lookup).
- Added to `hasMetadata` so the badge surfaces even on otherwise-bare cards.
- Compact metadata row only; expanded view unchanged.

Tests: badge resolves the parent title; absent for human-created tasks. `tsc` + `lint` clean; task-card suite 13 passed.