### PR TITLE
feat(orchestrator): Files view — markdown/plan viewer alongside Chat & Terminal

### DIFF
--- a/src/components/panel/orchestrator-files-view.test.tsx
+++ b/src/components/panel/orchestrator-files-view.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import type { FileEntry } from '@/lib/ipc'
+
+const planFile: FileEntry = { path: 'PLAN.md', name: 'PLAN.md', category: 'notes', modifiedAt: 0 }
+
+const refresh = vi.hoisted(() => vi.fn())
+vi.mock('@/hooks/use-workspace-files', () => ({
+  useWorkspaceFiles: () => ({
+    groupedFiles: { context: [], tickets: [], notes: [planFile] },
+    loading: false,
+    refresh,
+  }),
+}))
+
+// Stub the tree to a single selectable button, and the preview to echo the file
+// name — the view's own job (master-detail wiring + empty state) is what we test.
+vi.mock('./files-tree', () => ({
+  FilesTree: ({ onSelectFile }: { onSelectFile: (f: FileEntry) => void }) => (
+    <button data-testid="pick-plan" onClick={() => { onSelectFile(planFile) }}>PLAN.md</button>
+  ),
+}))
+vi.mock('./file-preview', () => ({
+  FilePreview: ({ file }: { file: FileEntry }) => <div data-testid="file-preview">{file.name}</div>,
+}))
+
+import { OrchestratorFilesView } from './orchestrator-files-view'
+
+describe('OrchestratorFilesView', () => {
+  it('shows an empty state until a file is selected, then renders its preview', () => {
+    render(<OrchestratorFilesView workspaceId="ws-1" />)
+
+    expect(screen.getByText('No file selected')).toBeInTheDocument()
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('pick-plan'))
+
+    expect(screen.getByTestId('file-preview')).toHaveTextContent('PLAN.md')
+    expect(screen.queryByText('No file selected')).not.toBeInTheDocument()
+  })
+
+  it('exposes a refresh control that rescans workspace files', () => {
+    render(<OrchestratorFilesView workspaceId="ws-1" />)
+    fireEvent.click(screen.getByLabelText('Refresh files'))
+    expect(refresh).toHaveBeenCalled()
+  })
+})

--- a/src/components/panel/orchestrator-files-view.tsx
+++ b/src/components/panel/orchestrator-files-view.tsx
@@ -1,0 +1,82 @@
+/**
+ * Orchestrator Files view — a workspace-level markdown/plan viewer that sits
+ * alongside Chat and Terminal in the orchestrator panel. Master-detail: the
+ * file tree (context / tickets / notes) on the left, a rendered preview on the
+ * right. Reuses the same `scan_workspace_files` / `read_file_content` IPC and
+ * components as the sidebar files browser — just laid out for the wider main
+ * area so plans are comfortable to read next to the terminal.
+ */
+
+import { useState } from 'react'
+import { FilesTree } from './files-tree'
+import { FilePreview } from './file-preview'
+import { useWorkspaceFiles } from '@/hooks/use-workspace-files'
+import { EmptyState } from '@/components/shared/empty-state'
+import type { FileEntry } from '@/lib/ipc'
+
+export function OrchestratorFilesView({ workspaceId }: { workspaceId: string }) {
+  const { groupedFiles, loading, refresh } = useWorkspaceFiles(workspaceId)
+  const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null)
+
+  return (
+    <div
+      data-testid="orchestrator-files-view"
+      className="flex min-h-0 flex-1 overflow-hidden"
+    >
+      {/* Left: file tree */}
+      <div className="flex w-60 shrink-0 flex-col border-r border-border-default">
+        <div className="flex items-center justify-between border-b border-border-default px-2 py-1">
+          <span className="text-[11px] font-medium text-text-secondary">Plans &amp; files</span>
+          <button
+            type="button"
+            onClick={() => { void refresh() }}
+            aria-label="Refresh files"
+            title="Rescan workspace files"
+            className="rounded p-1 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            style={{ cursor: 'pointer' }}
+          >
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" className="h-3.5 w-3.5">
+              <path d="M13.2 6A4.7 4.7 0 0 0 4.4 4.8L3 6.8" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M3 4v2.8h2.8" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M2.8 10A4.7 4.7 0 0 0 11.6 11.2L13 9.2" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M13 12V9.2h-2.8" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          <FilesTree
+            groupedFiles={groupedFiles}
+            selectedFile={selectedFile}
+            onSelectFile={setSelectedFile}
+            loading={loading}
+          />
+        </div>
+      </div>
+
+      {/* Right: preview */}
+      <div className="min-w-0 flex-1 overflow-hidden">
+        {selectedFile ? (
+          <FilePreview
+            workspaceId={workspaceId}
+            file={selectedFile}
+            onClose={() => { setSelectedFile(null) }}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center p-6">
+            <EmptyState
+              size="md"
+              title="No file selected"
+              description="Pick a plan, ticket, or note from the list to read it here — markdown is rendered, alongside your chat and terminal."
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-full w-full">
+                  <path d="M4 4a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4Z" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M13 2v5h5M8 13h8M8 17h5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              }
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -19,6 +19,7 @@ import { buildPromptWithAttachments } from '@/types'
 import { useCliPath } from '@/hooks/use-cli-path'
 import { ChatHistory } from './chat-history'
 import { OrchestratorTerminalView } from './orchestrator-terminal-view'
+import { OrchestratorFilesView } from './orchestrator-files-view'
 import { PanelSidebar } from './panel-sidebar'
 import { PipelineDashboard } from './pipeline-dashboard'
 import { PipelineV2Dashboard } from './pipeline-v2-dashboard'
@@ -96,7 +97,7 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
 
   // Local UI state
   const [sidebarMode, setSidebarMode] = useState<'history' | 'files' | 'dashboard' | 'v2-dashboard' | null>(null)
-  const [viewMode, setViewMode] = useState<'chat' | 'terminal'>('chat')
+  const [viewMode, setViewMode] = useState<'chat' | 'terminal' | 'files'>('chat')
   const [localMessages, setLocalMessages] = useState<ChatMessage[]>([])
   const [messagesLoading, setMessagesLoading] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
@@ -502,7 +503,7 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
               <div className="flex flex-1 flex-col overflow-hidden">
                 {/* Chat ↔ Terminal toggle */}
                 <div className="flex items-center gap-1 border-b border-border-default px-2 py-1">
-                  {(['chat', 'terminal'] as const).map((m) => (
+                  {(['chat', 'terminal', 'files'] as const).map((m) => (
                     <button
                       key={m}
                       type="button"
@@ -516,13 +517,15 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
                       }`}
                       style={{ cursor: 'pointer' }}
                     >
-                      {m === 'chat' ? 'Chat' : 'Terminal'}
+                      {m === 'chat' ? 'Chat' : m === 'terminal' ? 'Terminal' : 'Files'}
                     </button>
                   ))}
                 </div>
 
                 {viewMode === 'terminal' ? (
                   <OrchestratorTerminalView workspaceId={workspaceId} />
+                ) : viewMode === 'files' ? (
+                  <OrchestratorFilesView workspaceId={workspaceId} />
                 ) : (
                   <>
                     {/* CLI Detection Indicator */}


### PR DESCRIPTION
Adds a third view to the orchestrator (chef) panel: **Chat | Terminal | Files**. The Files view is a master-detail markdown viewer — the workspace file tree (context / tickets / notes) on the left, a rendered preview on the right — so plans, tickets, and notes are comfortable to read right next to the chat and terminal.

Pure composition over what already exists:
- `scan_workspace_files` / `read_file_content` IPC (with their path-traversal guards)
- the `useWorkspaceFiles` hook
- the `FilesTree` / `FilePreview` components already used by the sidebar

…just laid out for the wider main area, with a refresh control and an empty state.

## Tests
Empty-state → preview-on-select flow; refresh control rescans. `tsc` + `lint` clean; full vitest **407 passed**.

## Follow-ups
- Surface the same view in the per-task agent panel (Activity | Terminal | Changes | **Files**) — the component is workspace-scoped and reusable.
- Syntax-highlighted code files (shiki is already a dep; the workspace scan is markdown-only today, so this also needs a directory-listing IPC).