### PR TITLE
refactor(panel): one PanelTabs atom + icons; Files tab in agent panel

### DIFF
--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -8,6 +8,9 @@ import { useAgentTranscriptStore } from '@/stores/agent-transcript-store'
 import { holdTask, killTaskSession } from '@/lib/ipc/agent'
 import { agentInjectMessage, agentRestart, interactiveModeDevFlag } from '@/lib/ipc/agent-interactive'
 import { setTaskRuntimeModeOverride } from '@/lib/ipc/task'
+import { PanelTabs, type PanelTab } from '@/components/shared/panel-tabs'
+import { ActivityIcon, TerminalIcon, ChangesIcon, FilesIcon } from '@/components/shared/tab-icons'
+import { WorkspaceFilesView } from './workspace-files-view'
 import { signalPtyInterrupt } from '@/lib/ipc/terminal'
 import { useResolvedRuntimeMode } from '@/hooks/use-resolved-runtime-mode'
 import { useTaskDetail } from '@/hooks/use-task-detail'
@@ -26,7 +29,7 @@ type AgentPanelProps = {
   onClose?: () => void
 }
 
-type PanelView = 'activity' | 'terminal' | 'changes'
+type PanelView = 'activity' | 'terminal' | 'changes' | 'files'
 
 /**
  * Dispatch the agent panel by resolved runtime mode.
@@ -229,29 +232,13 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
           </>
         }
         viewSlot={
-          <div className="inline-flex min-w-0 shrink-0 items-center gap-1">
-            <ViewButton
-              active={activeView === 'activity'}
-              onClick={() => { setActiveView('activity') }}
-              testId="agent-panel-tab-transcript"
-            >
-              Activity
-            </ViewButton>
-            <ViewButton
-              active={activeView === 'terminal'}
-              onClick={() => { setActiveView('terminal') }}
-              testId="agent-panel-tab-terminal"
-            >
-              Terminal
-            </ViewButton>
-            <ViewButton
-              active={activeView === 'changes'}
-              onClick={() => { setActiveView('changes') }}
-              testId="agent-panel-tab-changes"
-            >
-              Changes
-            </ViewButton>
-          </div>
+          <PanelTabs
+            className="shrink-0"
+            aria-label="Agent panel views"
+            value={activeView}
+            onChange={setActiveView}
+            tabs={AGENT_PANEL_TABS}
+          />
         }
         errorSlot={
           session.error ? (
@@ -312,7 +299,7 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
             workingDir={workingDir}
             allowSpawn={isAgentRunning}
           />
-        ) : (
+        ) : activeView === 'changes' ? (
           <div className="h-full overflow-auto bg-bg p-2" data-testid="agent-panel-changes-view">
             <div className="space-y-2">
               <DiffSection
@@ -336,6 +323,8 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
               </div>
             </div>
           </div>
+        ) : (
+          <WorkspaceFilesView workspaceId={task.workspaceId} />
         )}
       </div>
     </div>
@@ -711,36 +700,12 @@ function RuntimeModeToggle({ task }: { task: Task }) {
   )
 }
 
-function ViewButton({
-  active,
-  onClick,
-  children,
-  testId,
-}: {
-  active: boolean
-  onClick: () => void
-  children: ReactNode
-  testId: string
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      data-testid={testId}
-      className={`relative inline-flex min-w-0 items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium transition-colors ${
-        active
-          ? 'text-text-primary'
-          : 'text-text-secondary hover:text-text-primary'
-      }`}
-      style={{ cursor: 'pointer' }}
-    >
-      <span className="truncate">{children}</span>
-      {active && (
-        <span className="absolute inset-x-2 bottom-0 h-px rounded-full bg-accent" aria-hidden="true" />
-      )}
-    </button>
-  )
-}
+const AGENT_PANEL_TABS: readonly PanelTab<PanelView>[] = [
+  { value: 'activity', label: 'Activity', icon: <ActivityIcon />, testId: 'agent-panel-tab-transcript' },
+  { value: 'terminal', label: 'Terminal', icon: <TerminalIcon />, testId: 'agent-panel-tab-terminal' },
+  { value: 'changes', label: 'Changes', icon: <ChangesIcon />, testId: 'agent-panel-tab-changes' },
+  { value: 'files', label: 'Files', icon: <FilesIcon />, testId: 'agent-panel-tab-files' },
+]
 
 function HoldIcon() {
   return (

--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -19,7 +19,16 @@ import { buildPromptWithAttachments } from '@/types'
 import { useCliPath } from '@/hooks/use-cli-path'
 import { ChatHistory } from './chat-history'
 import { OrchestratorTerminalView } from './orchestrator-terminal-view'
-import { OrchestratorFilesView } from './orchestrator-files-view'
+import { WorkspaceFilesView } from './workspace-files-view'
+import { PanelTabs, type PanelTab } from '@/components/shared/panel-tabs'
+import { ChatIcon, TerminalIcon, FilesIcon } from '@/components/shared/tab-icons'
+
+type OrchestratorView = 'chat' | 'terminal' | 'files'
+const ORCHESTRATOR_TABS: readonly PanelTab<OrchestratorView>[] = [
+  { value: 'chat', label: 'Chat', icon: <ChatIcon />, testId: 'orchestrator-view-chat' },
+  { value: 'terminal', label: 'Terminal', icon: <TerminalIcon />, testId: 'orchestrator-view-terminal' },
+  { value: 'files', label: 'Files', icon: <FilesIcon />, testId: 'orchestrator-view-files' },
+]
 import { PanelSidebar } from './panel-sidebar'
 import { PipelineDashboard } from './pipeline-dashboard'
 import { PipelineV2Dashboard } from './pipeline-v2-dashboard'
@@ -97,7 +106,7 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
 
   // Local UI state
   const [sidebarMode, setSidebarMode] = useState<'history' | 'files' | 'dashboard' | 'v2-dashboard' | null>(null)
-  const [viewMode, setViewMode] = useState<'chat' | 'terminal' | 'files'>('chat')
+  const [viewMode, setViewMode] = useState<OrchestratorView>('chat')
   const [localMessages, setLocalMessages] = useState<ChatMessage[]>([])
   const [messagesLoading, setMessagesLoading] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
@@ -502,30 +511,19 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
             <ChatErrorBoundary panelName="Orchestrator Chat">
               <div className="flex flex-1 flex-col overflow-hidden">
                 {/* Chat ↔ Terminal toggle */}
-                <div className="flex items-center gap-1 border-b border-border-default px-2 py-1">
-                  {(['chat', 'terminal', 'files'] as const).map((m) => (
-                    <button
-                      key={m}
-                      type="button"
-                      onClick={() => { setViewMode(m) }}
-                      data-testid={`orchestrator-view-${m}`}
-                      aria-pressed={viewMode === m}
-                      className={`rounded px-2 py-1 text-[11px] font-medium transition-colors ${
-                        viewMode === m
-                          ? 'bg-surface-hover text-text-primary'
-                          : 'text-text-secondary hover:text-text-primary'
-                      }`}
-                      style={{ cursor: 'pointer' }}
-                    >
-                      {m === 'chat' ? 'Chat' : m === 'terminal' ? 'Terminal' : 'Files'}
-                    </button>
-                  ))}
+                <div className="border-b border-border-default px-2 py-1">
+                  <PanelTabs
+                    aria-label="Orchestrator views"
+                    value={viewMode}
+                    onChange={setViewMode}
+                    tabs={ORCHESTRATOR_TABS}
+                  />
                 </div>
 
                 {viewMode === 'terminal' ? (
                   <OrchestratorTerminalView workspaceId={workspaceId} />
                 ) : viewMode === 'files' ? (
-                  <OrchestratorFilesView workspaceId={workspaceId} />
+                  <WorkspaceFilesView workspaceId={workspaceId} />
                 ) : (
                   <>
                     {/* CLI Detection Indicator */}

--- a/src/components/panel/workspace-files-view.test.tsx
+++ b/src/components/panel/workspace-files-view.test.tsx
@@ -24,11 +24,11 @@ vi.mock('./file-preview', () => ({
   FilePreview: ({ file }: { file: FileEntry }) => <div data-testid="file-preview">{file.name}</div>,
 }))
 
-import { OrchestratorFilesView } from './orchestrator-files-view'
+import { WorkspaceFilesView } from './workspace-files-view'
 
-describe('OrchestratorFilesView', () => {
+describe('WorkspaceFilesView', () => {
   it('shows an empty state until a file is selected, then renders its preview', () => {
-    render(<OrchestratorFilesView workspaceId="ws-1" />)
+    render(<WorkspaceFilesView workspaceId="ws-1" />)
 
     expect(screen.getByText('No file selected')).toBeInTheDocument()
     expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument()
@@ -40,7 +40,7 @@ describe('OrchestratorFilesView', () => {
   })
 
   it('exposes a refresh control that rescans workspace files', () => {
-    render(<OrchestratorFilesView workspaceId="ws-1" />)
+    render(<WorkspaceFilesView workspaceId="ws-1" />)
     fireEvent.click(screen.getByLabelText('Refresh files'))
     expect(refresh).toHaveBeenCalled()
   })

--- a/src/components/panel/workspace-files-view.tsx
+++ b/src/components/panel/workspace-files-view.tsx
@@ -1,10 +1,10 @@
 /**
- * Orchestrator Files view — a workspace-level markdown/plan viewer that sits
- * alongside Chat and Terminal in the orchestrator panel. Master-detail: the
- * file tree (context / tickets / notes) on the left, a rendered preview on the
- * right. Reuses the same `scan_workspace_files` / `read_file_content` IPC and
- * components as the sidebar files browser — just laid out for the wider main
- * area so plans are comfortable to read next to the terminal.
+ * Workspace Files view — a workspace-level markdown/plan viewer. Master-detail:
+ * the file tree (context / tickets / notes) on the left, a rendered preview on
+ * the right. Reuses the same `scan_workspace_files` / `read_file_content` IPC
+ * and components as the sidebar files browser — just laid out for the wider
+ * main area so plans are comfortable to read next to the terminal. Shared by
+ * the orchestrator panel and the per-task agent panel (both pass a workspaceId).
  */
 
 import { useState } from 'react'
@@ -14,13 +14,13 @@ import { useWorkspaceFiles } from '@/hooks/use-workspace-files'
 import { EmptyState } from '@/components/shared/empty-state'
 import type { FileEntry } from '@/lib/ipc'
 
-export function OrchestratorFilesView({ workspaceId }: { workspaceId: string }) {
+export function WorkspaceFilesView({ workspaceId }: { workspaceId: string }) {
   const { groupedFiles, loading, refresh } = useWorkspaceFiles(workspaceId)
   const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null)
 
   return (
     <div
-      data-testid="orchestrator-files-view"
+      data-testid="workspace-files-view"
       className="flex min-h-0 flex-1 overflow-hidden"
     >
       {/* Left: file tree */}

--- a/src/components/shared/panel-tabs.test.tsx
+++ b/src/components/shared/panel-tabs.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PanelTabs, type PanelTab } from './panel-tabs'
+
+type View = 'a' | 'b'
+const TABS: readonly PanelTab<View>[] = [
+  { value: 'a', label: 'Alpha', testId: 'tab-a' },
+  { value: 'b', label: 'Beta', testId: 'tab-b' },
+]
+
+describe('PanelTabs', () => {
+  it('marks the active tab via aria-pressed and fires onChange on click', () => {
+    const onChange = vi.fn()
+    render(<PanelTabs tabs={TABS} value="a" onChange={onChange} aria-label="Views" />)
+
+    expect(screen.getByTestId('tab-a')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('tab-b')).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Beta' }))
+    expect(onChange).toHaveBeenCalledWith('b')
+  })
+})

--- a/src/components/shared/panel-tabs.tsx
+++ b/src/components/shared/panel-tabs.tsx
@@ -1,0 +1,63 @@
+/**
+ * PanelTabs — the single source of truth for the view-switcher tab row used in
+ * the orchestrator and per-task agent panels. Underline-active style (lifted
+ * from the agent panel, which was the cleaner of the two), with optional icons.
+ * Generic over the tab value so each panel keeps its own typed union.
+ */
+
+import type { ReactNode } from 'react'
+
+export type PanelTab<T extends string> = {
+  value: T
+  label: string
+  icon?: ReactNode
+  testId?: string
+}
+
+type PanelTabsProps<T extends string> = {
+  tabs: readonly PanelTab<T>[]
+  value: T
+  onChange: (value: T) => void
+  /** Extra classes for the row container (e.g. border-b, padding). */
+  className?: string
+  'aria-label'?: string
+}
+
+export function PanelTabs<T extends string>({
+  tabs,
+  value,
+  onChange,
+  className = '',
+  'aria-label': ariaLabel,
+}: PanelTabsProps<T>) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={`inline-flex min-w-0 items-center gap-1 ${className}`}
+    >
+      {tabs.map((tab) => {
+        const active = tab.value === value
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            aria-pressed={active}
+            data-testid={tab.testId}
+            onClick={() => { onChange(tab.value) }}
+            className={`relative inline-flex min-w-0 items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium transition-colors ${
+              active ? 'text-text-primary' : 'text-text-secondary hover:text-text-primary'
+            }`}
+            style={{ cursor: 'pointer' }}
+          >
+            {tab.icon}
+            <span className="truncate">{tab.label}</span>
+            {active && (
+              <span className="absolute inset-x-2 bottom-0 h-px rounded-full bg-accent" aria-hidden="true" />
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/shared/tab-icons.tsx
+++ b/src/components/shared/tab-icons.tsx
@@ -1,0 +1,70 @@
+/**
+ * Shared panel-tab icons — one source of truth for the small glyphs used in
+ * panel view-switchers (Chat, Activity, Terminal, Files, Changes). Hand-drawn
+ * stroke SVGs (the project has no icon dependency) at a consistent 16×16 grid
+ * so they sit evenly in the tab row. Reused by the orchestrator and per-task
+ * agent panels via `PanelTabs`.
+ */
+
+type IconProps = { className?: string }
+
+const BASE = 'h-3.5 w-3.5 shrink-0'
+
+function Svg({ className, children }: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.4}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className ?? BASE}
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function ChatIcon({ className }: IconProps) {
+  return (
+    <Svg className={className}>
+      <path d="M2.5 7.2c0-2.3 2.3-4.2 5.5-4.2s5.5 1.9 5.5 4.2-2.3 4.2-5.5 4.2c-.7 0-1.4-.1-2-.3L3 12.5l.8-2.2c-.8-.8-1.3-1.8-1.3-3.1Z" />
+    </Svg>
+  )
+}
+
+export function ActivityIcon({ className }: IconProps) {
+  return (
+    <Svg className={className}>
+      <path d="M1.5 8h2.2l1.8 4.5 2.4-9 1.8 6 1.3-2.5h2" />
+    </Svg>
+  )
+}
+
+export function TerminalIcon({ className }: IconProps) {
+  return (
+    <Svg className={className}>
+      <rect x="1.8" y="2.8" width="12.4" height="10.4" rx="1.6" />
+      <path d="M4.5 6l2 2-2 2M8.5 10.2h3" />
+    </Svg>
+  )
+}
+
+export function FilesIcon({ className }: IconProps) {
+  return (
+    <Svg className={className}>
+      <path d="M4 1.8h4.5L12 5.3V13a1.2 1.2 0 0 1-1.2 1.2H4A1.2 1.2 0 0 1 2.8 13V3A1.2 1.2 0 0 1 4 1.8Z" />
+      <path d="M8.3 2v3.2h3.2M5.2 8.3h5.6M5.2 10.6h3.6" />
+    </Svg>
+  )
+}
+
+export function ChangesIcon({ className }: IconProps) {
+  return (
+    <Svg className={className}>
+      <path d="M10.5 2.2l3.3 3.3-3.3 3.3M5.5 13.8L2.2 10.5l3.3-3.3M13.4 5.5H6.2M9.8 10.5H2.6" />
+    </Svg>
+  )
+}


### PR DESCRIPTION
DRY the panel view-switchers into one PanelTabs atom (underline style, with icons) and add a Files tab to the per-task agent panel.

- shared/panel-tabs.tsx — generic PanelTabs<T> with icons + aria-pressed.
- shared/tab-icons.tsx — hand-drawn glyphs for Chat/Activity/Terminal/Files/Changes (one source of truth).
- Migrated agent-panel (removed ViewButton) + orchestrator-panel (removed inline pill map); testids preserved.
- OrchestratorFilesView -> WorkspaceFilesView; Files tab added to agent panel (Activity | Terminal | Changes | Files).

Full vitest 408 passed; tsc + lint clean.