### PR TITLE
fix(agent-panel): stop tab row clipping (Playwright UI audit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ src-tauri/Frameworks/
 test-results/
 playwright-report/
 playwright/.cache/
+e2e/audit-screens/
 mcp-server/target/
 .worktrees/
 tsconfig.tsbuildinfo

--- a/e2e/ui-audit.spec.ts
+++ b/e2e/ui-audit.spec.ts
@@ -1,0 +1,75 @@
+import { test } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+/**
+ * UI audit — drives the key surfaces (board, orchestrator panel tabs, agent
+ * panel tabs, settings) against the Vite dev server (browser-mock data) and
+ * captures screenshots for a visual review of spacing / alignment / icons.
+ * Not an assertion suite; it's for eyeballing the nicknacks.
+ */
+
+const DIR = 'e2e/audit-screens'
+mkdirSync(DIR, { recursive: true })
+
+async function shot(page: import('@playwright/test').Page, name: string) {
+  await page.screenshot({ path: `${DIR}/${name}.png`, fullPage: false })
+}
+
+test('capture UI surfaces', async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 1000 })
+  await page.goto('/')
+  await page.waitForTimeout(1200)
+  await shot(page, '01-board')
+
+  // Orchestrator / chef panel — expand if collapsed, then each tab.
+  const expand = page.locator('[aria-label="Expand orchestrator panel"]')
+  if (await expand.count()) {
+    await expand.first().click().catch(() => {})
+    await page.waitForTimeout(600)
+  }
+  await shot(page, '02-orchestrator-default')
+
+  for (const view of ['chat', 'terminal', 'files']) {
+    const tab = page.locator(`[data-testid="orchestrator-view-${view}"]`)
+    if (await tab.count()) {
+      await tab.first().click().catch(() => {})
+      await page.waitForTimeout(700)
+      await shot(page, `03-orchestrator-${view}`)
+    }
+  }
+
+  // Detail clip of the chef tab header (sidebar-icon row + Chat/Terminal/Files).
+  await page.screenshot({ path: `${DIR}/02b-chef-header.png`, clip: { x: 0, y: 700, width: 700, height: 70 } })
+
+  // Open a task → agent panel, capture each tab.
+  const card = page.getByText('Revamp agent panel UX').first()
+  if (await card.count()) {
+    await card.click().catch(() => {})
+    await page.waitForTimeout(900)
+    await shot(page, '04-agent-panel-open')
+    // Detail clip of the agent panel header tabs.
+    await page.screenshot({ path: `${DIR}/04b-agent-header.png`, clip: { x: 1000, y: 40, width: 600, height: 60 } })
+    for (const t of ['transcript', 'terminal', 'changes', 'files']) {
+      const tab = page.locator(`[data-testid="agent-panel-tab-${t}"]`)
+      if (await tab.count()) {
+        await tab.first().click().catch(() => {})
+        await page.waitForTimeout(600)
+        await shot(page, `05-agent-${t}`)
+      }
+    }
+  }
+
+  // Settings → Models & Limits (Agent runtime section + segmented controls).
+  await page.keyboard.press('Escape').catch(() => {})
+  const settings = page.locator('button[title="Settings"]')
+  if (await settings.count()) {
+    await settings.first().click().catch(() => {})
+    await page.waitForTimeout(500)
+    const tab = page.locator('button:has-text("Models & Limits")')
+    if (await tab.count()) {
+      await tab.first().click().catch(() => {})
+      await page.waitForTimeout(500)
+    }
+    await shot(page, '06-settings')
+  }
+})

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -562,7 +562,8 @@ function PanelHeader({
 }: PanelHeaderProps) {
   return (
     <div className="border-b border-border-default bg-bg">
-      <div className="flex min-w-0 items-center gap-2 px-3 py-2">
+      {/* Controls row: close + runtime/session controls. */}
+      <div className="flex min-w-0 items-center gap-2 px-3 pt-2 pb-1">
           {onClose && (
             <button
               type="button"
@@ -588,12 +589,16 @@ function PanelHeader({
             </button>
           )}
 
-          <div className="min-w-0 flex-1">{viewSlot}</div>
+          <div className="min-w-0 flex-1" />
 
           <div className="inline-flex shrink-0 items-center gap-1 text-xs">
             {rightSlot}
           </div>
       </div>
+
+      {/* View tabs on their own full-width row so they never clip the runtime
+          controls (the agent panel is narrow). Mirrors the orchestrator. */}
+      {viewSlot && <div className="px-2 pb-1">{viewSlot}</div>}
 
       {errorSlot && <div className="px-3 pb-2">{errorSlot}</div>}
     </div>


### PR DESCRIPTION
A Playwright UI audit caught a regression from the tab-icons work: on the narrow agent panel, the runtime controls (Headless·bubbles / Hold / ⋯) shared a row with the 4 view tabs and took priority — truncating **Changes → 'Change'** and pushing **Files off-screen entirely**.

Fix: restructure `PanelHeader` into two rows like the orchestrator — close + runtime controls on top, the view tabs on their own full-width row below. All four tabs now render with icons, no clipping; the two panels are visually consistent.

Also adds `e2e/ui-audit.spec.ts` — a Playwright screenshot harness for eyeballing panel surfaces (output gitignored).

agent-panel tests 16/16; tsc + lint clean.

**Before:** `> Activity Terminal Change[…]  Headless·bubbles Hold ⋯` (Files hidden)
**After:** row 1 `>  …  Headless·bubbles Hold ⋯`; row 2 `Activity Terminal Changes Files`