### PR TITLE
refactor(panel): retire redundant chef files sidebar; responsive Files tree

### DIFF
--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -105,7 +105,7 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
   })
 
   // Local UI state
-  const [sidebarMode, setSidebarMode] = useState<'history' | 'files' | 'dashboard' | 'v2-dashboard' | null>(null)
+  const [sidebarMode, setSidebarMode] = useState<'history' | 'dashboard' | 'v2-dashboard' | null>(null)
   const [viewMode, setViewMode] = useState<OrchestratorView>('chat')
   const [localMessages, setLocalMessages] = useState<ChatMessage[]>([])
   const [messagesLoading, setMessagesLoading] = useState(false)
@@ -341,24 +341,6 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
               </button>
               <button
                 type="button"
-                onClick={() => { setSidebarMode(sidebarMode === 'files' ? null : 'files') }}
-                aria-label={sidebarMode === 'files' ? 'Hide files' : 'Show files'}
-                aria-pressed={sidebarMode === 'files'}
-                title="Files"
-                className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
-                  sidebarMode === 'files'
-                    ? 'bg-surface-hover text-text-primary'
-                    : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
-                }`}
-                style={{ cursor: 'pointer' }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4" aria-hidden="true">
-                  <path d="M3.75 3A1.75 1.75 0 0 0 2 4.75v3.26a3.235 3.235 0 0 1 1.75-.51h12.5c.644 0 1.245.188 1.75.51V6.75A1.75 1.75 0 0 0 16.25 5h-4.836a.25.25 0 0 1-.177-.073L9.823 3.513A1.75 1.75 0 0 0 8.586 3H3.75Z" />
-                  <path fillRule="evenodd" d="M2 9.25a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 .75.75v5a1.75 1.75 0 0 1-1.75 1.75H3.75A1.75 1.75 0 0 1 2 14.25v-5Z" clipRule="evenodd" />
-                </svg>
-              </button>
-              <button
-                type="button"
                 onClick={() => { setSidebarMode(sidebarMode === 'dashboard' ? null : 'dashboard') }}
                 aria-label={sidebarMode === 'dashboard' ? 'Hide pipeline dashboard' : 'Show pipeline dashboard'}
                 aria-pressed={sidebarMode === 'dashboard'}
@@ -499,7 +481,6 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
                 mode={sidebarMode}
                 sessions={sessions}
                 activeSessionId={activeSession?.id}
-                workspaceId={workspaceId}
                 isCurrentChatEmpty={localMessages.length === 0}
                 onNewChat={() => { void handleNewChat() }}
                 onSelectSession={(session) => { handleSelectSession(session) }}

--- a/src/components/panel/panel-sidebar.tsx
+++ b/src/components/panel/panel-sidebar.tsx
@@ -1,17 +1,15 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
-import type { ChatSession, FileEntry } from '@/lib/ipc'
-import { useWorkspaceFiles } from '@/hooks/use-workspace-files'
-import { FilesTree } from './files-tree'
-import { FilePreview } from './file-preview'
+import type { ChatSession } from '@/lib/ipc'
 
-type SidebarMode = 'history' | 'files' | null
+// Files now live in the dedicated Files tab (WorkspaceFilesView); the sidebar
+// is history-only to avoid two overlapping files affordances.
+type SidebarMode = 'history' | null
 
 type PanelSidebarProps = {
   mode: SidebarMode
   sessions: ChatSession[]
   activeSessionId?: string
-  workspaceId: string
   isCurrentChatEmpty?: boolean
   onNewChat?: () => void
   onSelectSession?: (session: ChatSession) => void
@@ -21,7 +19,6 @@ type PanelSidebarProps = {
 // Different constraints per mode
 const SIDEBAR_CONFIG = {
   history: { min: 160, max: 280, default: 200 },
-  files: { min: 200, max: 600, default: 280 },
 } as const
 
 const STORAGE_KEY = 'chef-sidebar-widths'
@@ -47,7 +44,6 @@ export function PanelSidebar({
   mode,
   sessions,
   activeSessionId,
-  workspaceId,
   isCurrentChatEmpty,
   onNewChat,
   onSelectSession,
@@ -120,24 +116,18 @@ export function PanelSidebar({
           <div className="flex flex-1 flex-col overflow-hidden">
             {/* Header */}
             <div className="flex items-center justify-between px-3 py-2 border-b border-border-default">
-              <span className="text-xs font-medium text-text-secondary">
-                {mode === 'history' ? 'History' : 'Files'}
-              </span>
+              <span className="text-xs font-medium text-text-secondary">History</span>
             </div>
 
             {/* Content */}
-            {mode === 'history' ? (
-              <HistoryContent
-                sessions={sessions}
-                activeSessionId={activeSessionId}
-                isCurrentChatEmpty={isCurrentChatEmpty}
-                onNewChat={onNewChat}
-                onSelectSession={onSelectSession}
-                onDeleteSession={onDeleteSession}
-              />
-            ) : (
-              <FilesContent workspaceId={workspaceId} />
-            )}
+            <HistoryContent
+              sessions={sessions}
+              activeSessionId={activeSessionId}
+              isCurrentChatEmpty={isCurrentChatEmpty}
+              onNewChat={onNewChat}
+              onSelectSession={onSelectSession}
+              onDeleteSession={onDeleteSession}
+            />
           </div>
 
           {/* Resize handle - outside overflow container */}
@@ -229,42 +219,5 @@ function HistoryContent({
         )}
       </div>
     </>
-  )
-}
-
-// Files sidebar content with tree and preview
-function FilesContent({ workspaceId }: { workspaceId: string }) {
-  const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null)
-
-  // Fetch files for the workspace
-  const { groupedFiles, loading } = useWorkspaceFiles(workspaceId)
-
-  const handleSelectFile = useCallback((file: FileEntry) => {
-    setSelectedFile(file)
-  }, [])
-
-  const handleClosePreview = useCallback(() => {
-    setSelectedFile(null)
-  }, [])
-
-  // Show preview when a file is selected
-  if (selectedFile) {
-    return (
-      <div className="flex-1 overflow-hidden">
-        <FilePreview workspaceId={workspaceId} file={selectedFile} onClose={handleClosePreview} />
-      </div>
-    )
-  }
-
-  // Show file tree
-  return (
-    <div className="flex-1 overflow-y-auto p-2">
-      <FilesTree
-        groupedFiles={groupedFiles}
-        selectedFile={selectedFile}
-        onSelectFile={handleSelectFile}
-        loading={loading}
-      />
-    </div>
   )
 }

--- a/src/components/panel/workspace-files-view.tsx
+++ b/src/components/panel/workspace-files-view.tsx
@@ -21,10 +21,11 @@ export function WorkspaceFilesView({ workspaceId }: { workspaceId: string }) {
   return (
     <div
       data-testid="workspace-files-view"
-      className="flex min-h-0 flex-1 overflow-hidden"
+      className="@container/files flex min-h-0 flex-1 overflow-hidden"
     >
-      {/* Left: file tree */}
-      <div className="flex w-60 shrink-0 flex-col border-r border-border-default">
+      {/* Left: file tree — narrower in tight panels (agent panel), roomier when
+          the container is wide (orchestrator) so the preview always has space. */}
+      <div className="flex w-44 shrink-0 flex-col border-r border-border-default @lg/files:w-60">
         <div className="flex items-center justify-between border-b border-border-default px-2 py-1">
           <span className="text-[11px] font-medium text-text-secondary">Plans &amp; files</span>
           <button


### PR DESCRIPTION
Two UI-audit fixups:

- **Redundant files affordance** — the chef panel had both a left-sidebar 'files' mode and the new **Files tab**. Retired the sidebar mode entirely (button, state union, the `FilesContent` component + its now-unused imports/prop in `panel-sidebar.tsx`). The Files tab is the single, better files surface; the sidebar is history-only now.
- **Cramped Files view** — `WorkspaceFilesView`'s master-detail was tight in the narrow agent panel (tree 240px → ~210px preview). Made the tree column responsive via a Tailwind v4 container query: `w-44` in tight panels, `w-60` once the container is wide (orchestrator), so the preview always has room.

tsc + lint clean; files-view + agent-panel tests 18/18.