### PR TITLE
feat(files): full repo browser + syntax-highlighted code viewer

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -18,6 +18,32 @@ pub struct FileEntry {
     pub modified_at: i64,
 }
 
+/// A single entry in a workspace directory listing (for the file browser).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DirEntry {
+    /// Path relative to the workspace root, forward-slashed.
+    pub path: String,
+    pub name: String,
+    pub is_dir: bool,
+}
+
+/// Directories never worth surfacing in the file browser (huge / noisy / VCS).
+const IGNORED_DIRS: &[&str] = &[
+    ".git",
+    ".worktrees",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    ".cache",
+    "coverage",
+    ".svelte-kit",
+    "__pycache__",
+];
+
 /// Dialog-selected attachment data returned to the frontend.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -339,6 +365,58 @@ pub fn read_file_content(
     read_file_content_in_root(&root, &file_path)
 }
 
+/// List the immediate children of a directory inside the workspace, for the
+/// file browser's lazy tree. `rel_path` empty / None = the repo root. Hidden
+/// directories in [`IGNORED_DIRS`] are skipped; everything else (including
+/// dotfiles) is returned, dirs first then alphabetical.
+fn list_dir_in_root(root: &Path, rel_path: &str) -> Result<Vec<DirEntry>, AppError> {
+    let dir = if rel_path.is_empty() {
+        root.to_path_buf()
+    } else {
+        let relative = ensure_relative_workspace_path(rel_path)?;
+        ensure_path_in_workspace(root, &root.join(relative))?
+    };
+    if !dir.is_dir() {
+        return Err(AppError::InvalidInput(format!(
+            "Not a directory: {}",
+            rel_path
+        )));
+    }
+
+    let mut entries: Vec<DirEntry> = Vec::new();
+    let read = fs::read_dir(&dir)
+        .map_err(|e| AppError::InvalidInput(format!("Failed to read directory: {}", e)))?;
+    for entry in read.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        if is_dir && IGNORED_DIRS.contains(&name.as_str()) {
+            continue;
+        }
+        let path = if rel_path.is_empty() {
+            name.clone()
+        } else {
+            format!("{}/{}", rel_path.trim_end_matches('/'), name)
+        };
+        entries.push(DirEntry { path, name, is_dir });
+    }
+    entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+    Ok(entries)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn list_workspace_dir(
+    state: State<AppState>,
+    workspace_id: String,
+    rel_path: Option<String>,
+) -> Result<Vec<DirEntry>, AppError> {
+    let root = state_workspace_root(state, &workspace_id)?;
+    list_dir_in_root(&root, rel_path.as_deref().unwrap_or(""))
+}
+
 /// Open the native file picker and read the selected attachment files.
 #[tauri::command]
 pub async fn pick_attachment_files(app: AppHandle) -> Result<Vec<AttachmentFile>, AppError> {
@@ -414,6 +492,39 @@ mod tests {
 
         assert_eq!(created.name, "notes.md");
         assert_eq!(fs::read_to_string(repo.join("notes.md")).unwrap(), "hello");
+    }
+
+    #[test]
+    fn list_dir_in_root_skips_ignored_dirs_and_sorts_dirs_first() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        fs::create_dir(&repo).unwrap();
+        fs::write(repo.join("README.md"), "x").unwrap();
+        fs::create_dir(repo.join("src")).unwrap();
+        fs::write(repo.join("src").join("main.rs"), "fn main(){}").unwrap();
+        fs::create_dir(repo.join("node_modules")).unwrap();
+
+        let root = repo.canonicalize().unwrap();
+        let entries = list_dir_in_root(&root, "").unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        // node_modules skipped; directory sorts before the file.
+        assert_eq!(names, vec!["src", "README.md"]);
+        assert!(entries[0].is_dir && !entries[1].is_dir);
+
+        // Nested listing builds forward-slashed relative paths.
+        let nested = list_dir_in_root(&root, "src").unwrap();
+        assert_eq!(nested.len(), 1);
+        assert_eq!(nested[0].path, "src/main.rs");
+        assert!(!nested[0].is_dir);
+    }
+
+    #[test]
+    fn list_dir_in_root_rejects_path_traversal() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        fs::create_dir(&repo).unwrap();
+        let root = repo.canonicalize().unwrap();
+        assert!(list_dir_in_root(&root, "../").is_err());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -331,6 +331,7 @@ pub fn run() {
             // Files commands
             commands::files::scan_workspace_files,
             commands::files::read_file_content,
+            commands::files::list_workspace_dir,
             commands::files::create_note_file,
             commands::files::pick_attachment_files,
             // Script commands

--- a/src/components/panel/file-browser.test.tsx
+++ b/src/components/panel/file-browser.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import type { DirEntry } from '@/lib/ipc'
+
+const listWorkspaceDir = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/ipc', () => ({ listWorkspaceDir }))
+
+import { FileBrowser } from './file-browser'
+
+describe('FileBrowser', () => {
+  it('lists the root, lazily expands a directory, and selects a file', async () => {
+    const root: DirEntry[] = [
+      { path: 'src', name: 'src', isDir: true },
+      { path: 'README.md', name: 'README.md', isDir: false },
+    ]
+    const srcChildren: DirEntry[] = [{ path: 'src/main.rs', name: 'main.rs', isDir: false }]
+    listWorkspaceDir.mockImplementation((_ws: string, rel?: string) =>
+      Promise.resolve(rel === 'src' ? srcChildren : root),
+    )
+
+    const onSelectFile = vi.fn()
+    render(<FileBrowser workspaceId="ws-1" selectedPath={null} onSelectFile={onSelectFile} />)
+
+    // Root loads lazily.
+    await screen.findByText('src')
+    expect(screen.getByText('README.md')).toBeInTheDocument()
+
+    // Expanding a directory fetches and shows its children.
+    fireEvent.click(screen.getByText('src'))
+    await screen.findByText('main.rs')
+    expect(listWorkspaceDir).toHaveBeenCalledWith('ws-1', 'src')
+
+    // Selecting a file bubbles up the relative path + name.
+    fireEvent.click(screen.getByText('main.rs'))
+    expect(onSelectFile).toHaveBeenCalledWith({ path: 'src/main.rs', name: 'main.rs' })
+  })
+})

--- a/src/components/panel/file-browser.tsx
+++ b/src/components/panel/file-browser.tsx
@@ -1,0 +1,205 @@
+/**
+ * FileBrowser — a lazy, expandable tree of the workspace repo for the Files
+ * view's "Browse" mode. Each directory fetches its children on first expand
+ * (via list_workspace_dir); selecting a file bubbles up to the preview pane.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { listWorkspaceDir, type DirEntry } from '@/lib/ipc'
+
+type SelectedFile = { path: string; name: string }
+
+type FileBrowserProps = {
+  workspaceId: string
+  selectedPath: string | null
+  onSelectFile: (file: SelectedFile) => void
+}
+
+export function FileBrowser({ workspaceId, selectedPath, onSelectFile }: FileBrowserProps) {
+  const [root, setRoot] = useState<DirEntry[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setRoot(null)
+    setError(null)
+    listWorkspaceDir(workspaceId)
+      .then((entries) => { if (!cancelled) setRoot(entries) })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to list files')
+      })
+    return () => { cancelled = true }
+  }, [workspaceId])
+
+  if (error) {
+    return <p className="px-2 py-3 text-[11px] text-red-400">{error}</p>
+  }
+  if (root === null) {
+    return <p className="px-2 py-3 text-[11px] text-text-secondary/60">Loading…</p>
+  }
+  if (root.length === 0) {
+    return <p className="px-2 py-3 text-[11px] text-text-secondary/60">Empty repository</p>
+  }
+
+  return (
+    <div className="py-1">
+      {root.map((entry) =>
+        entry.isDir ? (
+          <DirNode
+            key={entry.path}
+            workspaceId={workspaceId}
+            entry={entry}
+            depth={0}
+            selectedPath={selectedPath}
+            onSelectFile={onSelectFile}
+          />
+        ) : (
+          <FileNode
+            key={entry.path}
+            entry={entry}
+            depth={0}
+            selectedPath={selectedPath}
+            onSelectFile={onSelectFile}
+          />
+        ),
+      )}
+    </div>
+  )
+}
+
+function Row({
+  depth,
+  active,
+  onClick,
+  children,
+}: {
+  depth: number
+  active?: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{ paddingLeft: 8 + depth * 12, cursor: 'pointer' }}
+      className={`flex w-full items-center gap-1.5 py-0.5 pr-2 text-left text-[11px] transition-colors ${
+        active
+          ? 'bg-surface-hover text-text-primary'
+          : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function DirNode({
+  workspaceId,
+  entry,
+  depth,
+  selectedPath,
+  onSelectFile,
+}: {
+  workspaceId: string
+  entry: DirEntry
+  depth: number
+  selectedPath: string | null
+  onSelectFile: (file: SelectedFile) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [children, setChildren] = useState<DirEntry[] | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const toggle = useCallback(() => {
+    setOpen((wasOpen) => {
+      const next = !wasOpen
+      if (next && children === null && !loading) {
+        setLoading(true)
+        listWorkspaceDir(workspaceId, entry.path)
+          .then((c) => { setChildren(c) })
+          .catch(() => { setChildren([]) })
+          .finally(() => { setLoading(false) })
+      }
+      return next
+    })
+  }, [children, loading, workspaceId, entry.path])
+
+  return (
+    <div>
+      <Row depth={depth} onClick={toggle}>
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className={`h-3 w-3 shrink-0 transition-transform ${open ? 'rotate-90' : ''}`}
+          aria-hidden="true"
+        >
+          <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <svg viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5 shrink-0 text-text-secondary/80" aria-hidden="true">
+          <path d="M2 4.5A1.5 1.5 0 0 1 3.5 3h3l1.2 1.5h4.8A1.5 1.5 0 0 1 14 6v5.5A1.5 1.5 0 0 1 12.5 13h-9A1.5 1.5 0 0 1 2 11.5v-7Z" />
+        </svg>
+        <span className="truncate">{entry.name}</span>
+      </Row>
+      {open && (
+        <div>
+          {loading && children === null && (
+            <p className="py-0.5 text-[11px] text-text-secondary/50" style={{ paddingLeft: 8 + (depth + 1) * 12 }}>
+              …
+            </p>
+          )}
+          {children?.map((child) =>
+            child.isDir ? (
+              <DirNode
+                key={child.path}
+                workspaceId={workspaceId}
+                entry={child}
+                depth={depth + 1}
+                selectedPath={selectedPath}
+                onSelectFile={onSelectFile}
+              />
+            ) : (
+              <FileNode
+                key={child.path}
+                entry={child}
+                depth={depth + 1}
+                selectedPath={selectedPath}
+                onSelectFile={onSelectFile}
+              />
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FileNode({
+  entry,
+  depth,
+  selectedPath,
+  onSelectFile,
+}: {
+  entry: DirEntry
+  depth: number
+  selectedPath: string | null
+  onSelectFile: (file: SelectedFile) => void
+}) {
+  return (
+    <Row
+      depth={depth}
+      active={entry.path === selectedPath}
+      onClick={() => { onSelectFile({ path: entry.path, name: entry.name }) }}
+    >
+      {/* spacer to align with dir chevron */}
+      <span className="h-3 w-3 shrink-0" aria-hidden="true" />
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" className="h-3.5 w-3.5 shrink-0 text-text-secondary/70" aria-hidden="true">
+        <path d="M4 1.8h4.5L12 5.3V13a1.2 1.2 0 0 1-1.2 1.2H4A1.2 1.2 0 0 1 2.8 13V3A1.2 1.2 0 0 1 4 1.8Z" strokeLinejoin="round" />
+        <path d="M8.3 2v3.2h3.2" strokeLinejoin="round" />
+      </svg>
+      <span className="truncate">{entry.name}</span>
+    </Row>
+  )
+}

--- a/src/components/panel/file-preview.tsx
+++ b/src/components/panel/file-preview.tsx
@@ -1,11 +1,24 @@
 import { useState, useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { readFileContent, type FileEntry } from '@/lib/ipc'
+import {
+  detectLanguage,
+  tokenizeCode,
+  getCurrentShikiTheme,
+  type ShikiTheme,
+  type ThemedToken,
+} from '@/lib/shiki'
 
 type FilePreviewProps = {
   workspaceId: string
-  file: FileEntry
+  /** Either a categorized markdown FileEntry, or any file by relative path. */
+  file: FileEntry | { path: string; name: string }
   onClose: () => void
+}
+
+function isMarkdown(name: string): boolean {
+  const ext = name.toLowerCase().split('.').pop()
+  return ext === 'md' || ext === 'markdown'
 }
 
 export function FilePreview({ workspaceId, file, onClose }: FilePreviewProps) {
@@ -15,33 +28,25 @@ export function FilePreview({ workspaceId, file, onClose }: FilePreviewProps) {
 
   useEffect(() => {
     let cancelled = false
-
     async function loadContent() {
       try {
         setLoading(true)
         setError(null)
         const text = await readFileContent(workspaceId, file.path)
-        if (!cancelled) {
-          setContent(text)
-        }
+        if (!cancelled) setContent(text)
       } catch (err) {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'Failed to load file'
-          setError(message)
+          setError(err instanceof Error ? err.message : 'Failed to load file')
         }
       } finally {
-        if (!cancelled) {
-          setLoading(false)
-        }
+        if (!cancelled) setLoading(false)
       }
     }
-
     void loadContent()
-
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [workspaceId, file.path])
+
+  const markdown = isMarkdown(file.name)
 
   return (
     <div className="flex flex-col h-full">
@@ -51,12 +56,13 @@ export function FilePreview({ workspaceId, file, onClose }: FilePreviewProps) {
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5 shrink-0 text-text-secondary">
             <path fillRule="evenodd" d="M4 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.414A2 2 0 0 0 13.414 6L10 2.586A2 2 0 0 0 8.586 2H4Zm5 2a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h1a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H9Z" clipRule="evenodd" />
           </svg>
-          <span className="text-xs font-medium text-text-primary truncate">{file.name}</span>
+          <span className="text-xs font-medium text-text-primary truncate" title={file.path}>{file.name}</span>
         </div>
         <button
           type="button"
           onClick={onClose}
           className="p-1 rounded text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
+          aria-label="Close file preview"
         >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
             <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
@@ -65,7 +71,7 @@ export function FilePreview({ workspaceId, file, onClose }: FilePreviewProps) {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-3">
+      <div className="flex-1 overflow-auto">
         {loading && (
           <div className="flex items-center justify-center py-8">
             <div className="h-4 w-4 animate-spin rounded-full border-2 border-text-secondary/30 border-t-text-secondary" />
@@ -73,17 +79,60 @@ export function FilePreview({ workspaceId, file, onClose }: FilePreviewProps) {
         )}
 
         {error && (
-          <div className="py-4 text-center">
+          <div className="py-4 px-3 text-center">
             <p className="text-xs text-red-400">{error}</p>
           </div>
         )}
 
         {!loading && !error && content !== null && (
-          <article className="prose prose-sm prose-invert max-w-none prose-headings:text-text-primary prose-p:text-text-secondary prose-a:text-blue-400 prose-strong:text-text-primary prose-code:text-amber-300 prose-code:bg-surface-hover prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-surface-hover prose-pre:border prose-pre:border-border-default prose-li:text-text-secondary prose-blockquote:border-l-text-secondary/30 prose-blockquote:text-text-secondary/80">
-            <ReactMarkdown>{content}</ReactMarkdown>
-          </article>
+          markdown ? (
+            <article className="prose prose-sm prose-invert max-w-none p-3 prose-headings:text-text-primary prose-p:text-text-secondary prose-a:text-blue-400 prose-strong:text-text-primary prose-code:text-amber-300 prose-code:bg-surface-hover prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-surface-hover prose-pre:border prose-pre:border-border-default prose-li:text-text-secondary prose-blockquote:border-l-text-secondary/30 prose-blockquote:text-text-secondary/80">
+              <ReactMarkdown>{content}</ReactMarkdown>
+            </article>
+          ) : (
+            <CodeView content={content} filePath={file.path} />
+          )
         )}
       </div>
     </div>
+  )
+}
+
+/** Syntax-highlighted (shiki) read-only code, falling back to plain monospace
+ *  for unknown languages. Re-tokenizes on theme change. */
+function CodeView({ content, filePath }: { content: string; filePath: string }) {
+  const [tokens, setTokens] = useState<ThemedToken[][] | null>(null)
+  const [theme, setTheme] = useState<ShikiTheme>(() => getCurrentShikiTheme())
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => { setTheme(getCurrentShikiTheme()) })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
+    return () => { observer.disconnect() }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const lang = detectLanguage(filePath)
+    if (!lang) { setTokens(null); return }
+    void tokenizeCode(content, lang, theme).then((t) => { if (!cancelled) setTokens(t) })
+    return () => { cancelled = true }
+  }, [content, filePath, theme])
+
+  return (
+    <pre className="overflow-x-auto p-3 font-mono text-xs leading-relaxed text-text-primary">
+      <code>
+        {tokens
+          ? tokens.map((line, i) => (
+              <div key={i} className="whitespace-pre">
+                {line.length === 0
+                  ? ' '
+                  : line.map((tok, j) => (
+                      <span key={j} style={{ color: tok.color }}>{tok.content}</span>
+                    ))}
+              </div>
+            ))
+          : content}
+      </code>
+    </pre>
   )
 }

--- a/src/components/panel/workspace-files-view.test.tsx
+++ b/src/components/panel/workspace-files-view.test.tsx
@@ -23,6 +23,9 @@ vi.mock('./files-tree', () => ({
 vi.mock('./file-preview', () => ({
   FilePreview: ({ file }: { file: FileEntry }) => <div data-testid="file-preview">{file.name}</div>,
 }))
+vi.mock('./file-browser', () => ({
+  FileBrowser: () => <div data-testid="file-browser" />,
+}))
 
 import { WorkspaceFilesView } from './workspace-files-view'
 
@@ -43,5 +46,17 @@ describe('WorkspaceFilesView', () => {
     render(<WorkspaceFilesView workspaceId="ws-1" />)
     fireEvent.click(screen.getByLabelText('Refresh files'))
     expect(refresh).toHaveBeenCalled()
+  })
+
+  it('toggles between the Plans tree and the repo Browse tree', () => {
+    render(<WorkspaceFilesView workspaceId="ws-1" />)
+
+    // Plans is the default.
+    expect(screen.getByTestId('pick-plan')).toBeInTheDocument()
+    expect(screen.queryByTestId('file-browser')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('files-mode-browse'))
+    expect(screen.getByTestId('file-browser')).toBeInTheDocument()
+    expect(screen.queryByTestId('pick-plan')).not.toBeInTheDocument()
   })
 })

--- a/src/components/panel/workspace-files-view.tsx
+++ b/src/components/panel/workspace-files-view.tsx
@@ -1,36 +1,62 @@
 /**
- * Workspace Files view — a workspace-level markdown/plan viewer. Master-detail:
- * the file tree (context / tickets / notes) on the left, a rendered preview on
- * the right. Reuses the same `scan_workspace_files` / `read_file_content` IPC
- * and components as the sidebar files browser — just laid out for the wider
- * main area so plans are comfortable to read next to the terminal. Shared by
- * the orchestrator panel and the per-task agent panel (both pass a workspaceId).
+ * Workspace Files view — a workspace-level file/plan viewer. Master-detail:
+ * a tree on the left, a rendered preview on the right. Two tree modes:
+ *   • Plans  — curated markdown (context / tickets / notes) via scan_workspace_files
+ *   • Browse — the full repo tree (any file) via list_workspace_dir, lazily expanded
+ * The preview renders markdown for .md and syntax-highlighted code for the rest.
+ * Shared by the orchestrator panel and the per-task agent panel.
  */
 
 import { useState } from 'react'
 import { FilesTree } from './files-tree'
 import { FilePreview } from './file-preview'
+import { FileBrowser } from './file-browser'
 import { useWorkspaceFiles } from '@/hooks/use-workspace-files'
 import { EmptyState } from '@/components/shared/empty-state'
 import type { FileEntry } from '@/lib/ipc'
 
+type SelectedFile = FileEntry | { path: string; name: string }
+type Mode = 'plans' | 'browse'
+
 export function WorkspaceFilesView({ workspaceId }: { workspaceId: string }) {
   const { groupedFiles, loading, refresh } = useWorkspaceFiles(workspaceId)
-  const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null)
+  const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null)
+  const [mode, setMode] = useState<Mode>('plans')
+  const [browseKey, setBrowseKey] = useState(0)
+
+  const treeSelected = selectedFile && 'category' in selectedFile ? selectedFile : null
 
   return (
     <div
       data-testid="workspace-files-view"
       className="@container/files flex min-h-0 flex-1 overflow-hidden"
     >
-      {/* Left: file tree — narrower in tight panels (agent panel), roomier when
-          the container is wide (orchestrator) so the preview always has space. */}
+      {/* Left: tree (Plans | Browse) — narrower in tight panels, roomier when
+          the container is wide so the preview always has space. */}
       <div className="flex w-44 shrink-0 flex-col border-r border-border-default @lg/files:w-60">
-        <div className="flex items-center justify-between border-b border-border-default px-2 py-1">
-          <span className="text-[11px] font-medium text-text-secondary">Plans &amp; files</span>
+        <div className="flex items-center justify-between gap-1 border-b border-border-default px-2 py-1">
+          <div className="inline-flex items-center gap-0.5 rounded-md bg-surface p-0.5">
+            {(['plans', 'browse'] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => { setMode(m) }}
+                aria-pressed={mode === m}
+                data-testid={`files-mode-${m}`}
+                className={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                  mode === m
+                    ? 'bg-surface-hover text-text-primary'
+                    : 'text-text-secondary hover:text-text-primary'
+                }`}
+                style={{ cursor: 'pointer' }}
+              >
+                {m === 'plans' ? 'Plans' : 'Browse'}
+              </button>
+            ))}
+          </div>
           <button
             type="button"
-            onClick={() => { void refresh() }}
+            onClick={() => { if (mode === 'plans') void refresh(); else setBrowseKey((k) => k + 1) }}
             aria-label="Refresh files"
             title="Rescan workspace files"
             className="rounded p-1 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
@@ -44,13 +70,24 @@ export function WorkspaceFilesView({ workspaceId }: { workspaceId: string }) {
             </svg>
           </button>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto p-2">
-          <FilesTree
-            groupedFiles={groupedFiles}
-            selectedFile={selectedFile}
-            onSelectFile={setSelectedFile}
-            loading={loading}
-          />
+        <div className="min-h-0 flex-1 overflow-y-auto p-1">
+          {mode === 'plans' ? (
+            <div className="p-1">
+              <FilesTree
+                groupedFiles={groupedFiles}
+                selectedFile={treeSelected}
+                onSelectFile={setSelectedFile}
+                loading={loading}
+              />
+            </div>
+          ) : (
+            <FileBrowser
+              key={browseKey}
+              workspaceId={workspaceId}
+              selectedPath={selectedFile?.path ?? null}
+              onSelectFile={setSelectedFile}
+            />
+          )}
         </div>
       </div>
 
@@ -67,7 +104,7 @@ export function WorkspaceFilesView({ workspaceId }: { workspaceId: string }) {
             <EmptyState
               size="md"
               title="No file selected"
-              description="Pick a plan, ticket, or note from the list to read it here — markdown is rendered, alongside your chat and terminal."
+              description="Pick a plan from the list or browse the repo — markdown is rendered, code is syntax-highlighted, alongside your chat and terminal."
               icon={
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-full w-full">
                   <path d="M4 4a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4Z" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/components/review/diff-viewer.tsx
+++ b/src/components/review/diff-viewer.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react'
-import type { BundledLanguage, Highlighter, ThemedToken } from 'shiki'
+import {
+  detectLanguage,
+  tokenizeCode,
+  getCurrentShikiTheme,
+  type ShikiTheme,
+  type ThemedToken,
+} from '@/lib/shiki'
 
 // --- Types ---
 
@@ -29,8 +35,6 @@ type LineSelection = {
   hunkIndex: number
   lineIndex: number
 }
-
-type ShikiTheme = 'github-dark' | 'github-light'
 
 export interface DiffViewerProps {
   /** Raw unified diff string */
@@ -118,63 +122,6 @@ function parseDiff(raw: string): DiffFile[] {
   return files
 }
 
-// --- Shiki Lazy Loader ---
-
-const LANG_MAP: Record<string, BundledLanguage> = {
-  ts: 'typescript',
-  tsx: 'tsx',
-  js: 'javascript',
-  jsx: 'jsx',
-  rs: 'rust',
-  py: 'python',
-  css: 'css',
-  html: 'html',
-  json: 'json',
-  md: 'markdown',
-  toml: 'toml',
-  yaml: 'yaml',
-  yml: 'yaml',
-  sh: 'bash',
-  sql: 'sql',
-  svg: 'xml',
-  xml: 'xml',
-}
-
-function detectLanguage(filePath: string): BundledLanguage | null {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
-  return LANG_MAP[ext] ?? null
-}
-
-let highlighterPromise: Promise<Highlighter> | null = null
-const loadedLangs = new Set<string>()
-
-async function getHighlighter(): Promise<Highlighter> {
-  if (!highlighterPromise) {
-    highlighterPromise = import('shiki').then((mod) =>
-      mod.createHighlighter({ themes: ['github-dark', 'github-light'], langs: [] })
-    )
-  }
-  return highlighterPromise
-}
-
-async function tokenizeCode(
-  code: string,
-  lang: BundledLanguage,
-  theme: ShikiTheme,
-): Promise<ThemedToken[][] | null> {
-  try {
-    const hl = await getHighlighter()
-    if (!loadedLangs.has(lang)) {
-      await hl.loadLanguage(lang)
-      loadedLangs.add(lang)
-    }
-    const result = hl.codeToTokens(code, { lang, theme })
-    return result.tokens
-  } catch {
-    return null
-  }
-}
-
 // --- Helpers ---
 
 const LINE_BG = {
@@ -204,11 +151,6 @@ function formatDiffLine(line: DiffLine) {
 
 function selectionKey(selection: LineSelection) {
   return `${String(selection.fileIndex)}:${String(selection.hunkIndex)}:${String(selection.lineIndex)}`
-}
-
-function getCurrentShikiTheme(): ShikiTheme {
-  if (typeof document === 'undefined') return 'github-dark'
-  return document.documentElement.dataset.theme === 'light' ? 'github-light' : 'github-dark'
 }
 
 function getSelectionRange(files: DiffFile[], start: LineSelection, end: LineSelection) {

--- a/src/lib/ipc/files.ts
+++ b/src/lib/ipc/files.ts
@@ -9,6 +9,13 @@ export type FileEntry = {
   modifiedAt: number
 }
 
+export type DirEntry = {
+  /** Path relative to the workspace root, forward-slashed. */
+  path: string
+  name: string
+  isDir: boolean
+}
+
 export type AttachmentFile = {
   path: string
   name: string
@@ -25,6 +32,15 @@ export async function scanWorkspaceFiles(workspaceId: string): Promise<FileEntry
 
 export async function readFileContent(workspaceId: string, filePath: string): Promise<string> {
   return invoke<string>('read_file_content', { workspaceId, filePath })
+}
+
+/** List the immediate children of a workspace directory (empty/omitted relPath
+ *  = repo root) for the file browser's lazy tree. */
+export async function listWorkspaceDir(
+  workspaceId: string,
+  relPath?: string,
+): Promise<DirEntry[]> {
+  return invoke<DirEntry[]>('list_workspace_dir', { workspaceId, relPath })
 }
 
 export async function createNoteFile(

--- a/src/lib/shiki.ts
+++ b/src/lib/shiki.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared Shiki helpers — one lazily-loaded highlighter instance + tokenizer,
+ * reused by the diff viewer and the file/code viewer. Languages are loaded on
+ * demand and cached; themes follow the app light/dark setting.
+ */
+
+import type { BundledLanguage, Highlighter, ThemedToken } from 'shiki'
+
+export type { ThemedToken }
+export type ShikiTheme = 'github-dark' | 'github-light'
+
+const LANG_MAP: Record<string, BundledLanguage> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  jsx: 'jsx',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  rs: 'rust',
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  java: 'java',
+  c: 'c',
+  h: 'c',
+  cpp: 'cpp',
+  hpp: 'cpp',
+  cs: 'csharp',
+  php: 'php',
+  swift: 'swift',
+  kt: 'kotlin',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  json: 'json',
+  jsonc: 'json',
+  md: 'markdown',
+  markdown: 'markdown',
+  toml: 'toml',
+  yaml: 'yaml',
+  yml: 'yaml',
+  sh: 'bash',
+  bash: 'bash',
+  zsh: 'bash',
+  sql: 'sql',
+  svg: 'xml',
+  xml: 'xml',
+  dockerfile: 'docker',
+  graphql: 'graphql',
+}
+
+export function detectLanguage(filePath: string): BundledLanguage | null {
+  const lower = filePath.toLowerCase()
+  const base = lower.split('/').pop() ?? lower
+  if (base === 'dockerfile') return 'docker'
+  const ext = base.includes('.') ? base.split('.').pop() ?? '' : ''
+  return LANG_MAP[ext] ?? null
+}
+
+let highlighterPromise: Promise<Highlighter> | null = null
+const loadedLangs = new Set<string>()
+
+async function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = import('shiki').then((mod) =>
+      mod.createHighlighter({ themes: ['github-dark', 'github-light'], langs: [] }),
+    )
+  }
+  return highlighterPromise
+}
+
+export async function tokenizeCode(
+  code: string,
+  lang: BundledLanguage,
+  theme: ShikiTheme,
+): Promise<ThemedToken[][] | null> {
+  try {
+    const hl = await getHighlighter()
+    if (!loadedLangs.has(lang)) {
+      await hl.loadLanguage(lang)
+      loadedLangs.add(lang)
+    }
+    return hl.codeToTokens(code, { lang, theme }).tokens
+  } catch {
+    return null
+  }
+}
+
+export function getCurrentShikiTheme(): ShikiTheme {
+  if (typeof document === 'undefined') return 'github-dark'
+  return document.documentElement.dataset.theme === 'light' ? 'github-light' : 'github-dark'
+}


### PR DESCRIPTION
Turns the markdown-only Files view into a real **file/code viewer** (the deferred #14).

## Backend
- `list_workspace_dir(workspaceId, relPath?)` — lazy directory listing within the workspace root (path-traversal guarded; skips `.git`/`node_modules`/`target`/`dist`/…), dirs-first sort. `read_file_content` already reads any file. Unit tests for listing + traversal rejection.

## Frontend
- **DRY**: extracted the diff viewer's inline Shiki logic into a shared `lib/shiki.ts` (one lazily-loaded highlighter, on-demand langs, theme follow) and refactored `diff-viewer` to use it.
- **FilePreview** is now universal: markdown for `.md`, Shiki-highlighted code for everything else (re-tokenizes on theme change), plain-monospace fallback.
- **FileBrowser**: lazy expandable repo tree (each dir fetches children on first open).
- **WorkspaceFilesView** gains a **Plans | Browse** toggle — Plans = curated markdown (context/tickets/notes), Browse = full repo tree — both feeding the shared preview.

## Tests
`list_dir_in_root` (skip/sort + traversal); FileBrowser lazy-expand + select; Plans/Browse toggle. Full vitest **410**; cargo files **7**; tsc + lint clean.