### PR TITLE
feat(agent-panel): icon-only tabs on the top row

### DIFF
--- a/src/components/panel/agent-panel.test.tsx
+++ b/src/components/panel/agent-panel.test.tsx
@@ -285,12 +285,13 @@ describe('AgentPanel session controls', () => {
   it('shows Activity, Terminal, and Changes tabs in headless mode without tab badges', () => {
     renderPanel()
 
+    // Icon-only tabs in the header; their accessible name comes from aria-label.
     const tabs = [
       screen.getByRole('button', { name: 'Activity' }),
       screen.getByRole('button', { name: 'Terminal' }),
       screen.getByRole('button', { name: 'Changes' }),
     ]
-    expect(tabs.map((tab) => tab.textContent)).toEqual(['Activity', 'Terminal', 'Changes'])
+    expect(tabs.map((tab) => tab.getAttribute('aria-label'))).toEqual(['Activity', 'Terminal', 'Changes'])
     expect(screen.queryByRole('button', { name: 'Context' })).not.toBeInTheDocument()
     expect(screen.queryByText('live')).not.toBeInTheDocument()
     expect(screen.queryByText(/\+\d+/)).not.toBeInTheDocument()

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -234,6 +234,7 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
         viewSlot={
           <PanelTabs
             className="shrink-0"
+            iconOnly
             aria-label="Agent panel views"
             value={activeView}
             onChange={setActiveView}
@@ -589,16 +590,15 @@ function PanelHeader({
             </button>
           )}
 
+          {/* Icon-only view tabs sit on the top row next to the close icon. */}
+          {viewSlot}
+
           <div className="min-w-0 flex-1" />
 
           <div className="inline-flex shrink-0 items-center gap-1 text-xs">
             {rightSlot}
           </div>
       </div>
-
-      {/* View tabs on their own full-width row so they never clip the runtime
-          controls (the agent panel is narrow). Mirrors the orchestrator. */}
-      {viewSlot && <div className="px-2 pb-1">{viewSlot}</div>}
 
       {errorSlot && <div className="px-3 pb-2">{errorSlot}</div>}
     </div>

--- a/src/components/shared/panel-tabs.tsx
+++ b/src/components/shared/panel-tabs.tsx
@@ -20,6 +20,8 @@ type PanelTabsProps<T extends string> = {
   onChange: (value: T) => void
   /** Extra classes for the row container (e.g. border-b, padding). */
   className?: string
+  /** Icon-only (label as tooltip) — for tight headers like the agent panel. */
+  iconOnly?: boolean
   'aria-label'?: string
 }
 
@@ -28,6 +30,7 @@ export function PanelTabs<T extends string>({
   value,
   onChange,
   className = '',
+  iconOnly = false,
   'aria-label': ariaLabel,
 }: PanelTabsProps<T>) {
   return (
@@ -43,17 +46,19 @@ export function PanelTabs<T extends string>({
             key={tab.value}
             type="button"
             aria-pressed={active}
+            aria-label={iconOnly ? tab.label : undefined}
+            title={iconOnly ? tab.label : undefined}
             data-testid={tab.testId}
             onClick={() => { onChange(tab.value) }}
-            className={`relative inline-flex min-w-0 items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium transition-colors ${
-              active ? 'text-text-primary' : 'text-text-secondary hover:text-text-primary'
-            }`}
+            className={`relative inline-flex min-w-0 items-center gap-1.5 py-1.5 text-[11px] font-medium transition-colors ${
+              iconOnly ? 'px-1.5' : 'px-2'
+            } ${active ? 'text-text-primary' : 'text-text-secondary hover:text-text-primary'}`}
             style={{ cursor: 'pointer' }}
           >
             {tab.icon}
-            <span className="truncate">{tab.label}</span>
+            {!iconOnly && <span className="truncate">{tab.label}</span>}
             {active && (
-              <span className="absolute inset-x-2 bottom-0 h-px rounded-full bg-accent" aria-hidden="true" />
+              <span className="absolute inset-x-1 bottom-0 h-px rounded-full bg-accent" aria-hidden="true" />
             )}
           </button>
         )


### PR DESCRIPTION
Moved the Activity/Terminal/Changes/Files tabs from the second row up to the top row next to the collapse icon. Added an `iconOnly` mode to `PanelTabs` (label → tooltip/aria-label) so all four tabs + the runtime controls fit on one narrow row. Verified via Playwright. tsc + lint clean; tests pass.