### PR TITLE
fix(build): dedupe React in Vite (blank-screen fix)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    // Keep a single React instance — a duplicate copy (which the dep optimizer
+    // can introduce when a new dependency is added) causes "Invalid hook call /
+    // Cannot read properties of null (reading 'useState')" and a blank screen.
+    dedupe: ['react', 'react-dom'],
   },
   clearScreen: false,
   server: {


### PR DESCRIPTION
Adding `remark-gfm` made Vite's dep-optimizer introduce a duplicate React copy → 'Invalid hook call / Cannot read useState of null' → blank screen. Pinned a single React/React-DOM via `resolve.dedupe` so a re-optimize can't split it. One-time recovery also needed `rm -rf node_modules/.vite` + restart (done — dev is back up).