### PR TITLE
v1 prep: daily-use reliability + cross-OS fixes, bump to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "kaitencode"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "kaitencode-mcp"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaitencode-mcp"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kaitencode",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "packageManager": "pnpm@9.15.9",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.8",
     "@wdio/cli": "^9.27.0",
     "@wdio/local-runner": "^9.27.0",
     "@wdio/mocha-framework": "^9.27.0",
@@ -71,7 +71,7 @@
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.4.2",
-    "vitest": "^4.0.18",
+    "vitest": "^4.1.8",
     "webdriverio": "^9.27.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       shiki:
         specifier: ^3.2.1
         version: 3.23.0
@@ -106,8 +109,8 @@ importers:
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       '@wdio/cli':
         specifier: ^9.27.0
         version: 9.27.0(@types/node@20.19.39)(expect-webdriverio@5.6.5)
@@ -157,8 +160,8 @@ importers:
         specifier: 6.4.2
         version: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0)(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       webdriverio:
         specifier: ^9.27.0
         version: 9.27.0
@@ -183,6 +186,10 @@ packages:
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.0':
@@ -223,8 +230,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -237,6 +252,11 @@ packages:
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -256,8 +276,8 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -270,6 +290,10 @@ packages:
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -1294,6 +1318,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -1428,20 +1455,20 @@ packages:
     peerDependencies:
       vite: 6.4.2
 
-  '@vitest/coverage-v8@4.0.18':
-    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
-      '@vitest/browser': 4.0.18
-      vitest: 4.0.18
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: 6.4.2
@@ -1457,8 +1484,11 @@ packages:
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
@@ -1466,11 +1496,14 @@ packages:
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@wdio/cli@9.27.0':
     resolution: {integrity: sha512-k3kSs1sWTnDwdFLdBua7j5O//0N9k3qTj2nkyfMnkCEzOU00UMV2Y0f/yzNrn8BkkvohrJmwdEQPYx7rNhfj9g==}
@@ -1640,8 +1673,8 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
@@ -2081,8 +2114,8 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2105,6 +2138,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -2874,15 +2911,39 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.2:
-    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -2913,6 +2974,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -3090,8 +3172,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3350,11 +3433,17 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3430,6 +3519,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3523,8 +3617,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-buffers@3.0.3:
     resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
@@ -3624,20 +3718,24 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.23:
@@ -3804,20 +3902,23 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: 6.4.2
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -3830,6 +3931,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4054,6 +4159,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
@@ -4114,7 +4225,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -4126,6 +4241,10 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -4139,7 +4258,7 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
-  '@babel/runtime@7.29.2': {}
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -4163,6 +4282,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -4631,7 +4755,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.4
+      semver: 7.8.2
       tar-fs: 3.1.2
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -4885,8 +5009,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -4954,6 +5078,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -5123,32 +5249,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.18
-      ast-v8-to-istanbul: 0.3.12
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 3.10.0
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0)(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/expect@4.0.18':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -5160,11 +5286,15 @@ snapshots:
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.0.18':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
-      '@vitest/utils': 4.0.18
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
   '@vitest/snapshot@2.1.9':
@@ -5179,12 +5309,20 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.18': {}
-
-  '@vitest/utils@4.0.18':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@wdio/cli@9.27.0(@types/node@20.19.39)(expect-webdriverio@5.6.5)':
     dependencies:
@@ -5458,7 +5596,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@0.3.12:
+  ast-v8-to-istanbul@1.0.3:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -5701,7 +5839,7 @@ snapshots:
       normalize-package-data: 7.0.1
       read-pkg-up: 10.1.0
       recursive-readdir: 2.2.3
-      semver: 7.7.4
+      semver: 7.8.2
       type-fest: 4.41.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -5885,7 +6023,7 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5950,6 +6088,8 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -6041,7 +6181,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -6758,15 +6898,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.2:
+  magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.2
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -6782,6 +6931,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6878,6 +7084,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -7079,13 +7343,13 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.4
+      semver: 7.8.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@7.0.1:
     dependencies:
       hosted-git-info: 8.1.0
-      semver: 7.7.4
+      semver: 7.8.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -7105,7 +7369,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  obug@2.1.1: {}
+  obug@2.1.2: {}
 
   once@1.4.0:
     dependencies:
@@ -7399,6 +7663,17 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -7415,6 +7690,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -7497,6 +7778,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.2: {}
 
   serialize-error@12.0.0:
     dependencies:
@@ -7585,7 +7868,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
   stream-buffers@3.0.3: {}
 
@@ -7711,16 +7994,21 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@1.2.0: {}
 
-  tinyrainbow@3.0.3: {}
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.23: {}
 
@@ -7866,43 +8154,34 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.0.18(@types/node@20.19.39)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.8(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0)(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.2
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       jsdom: 28.1.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaitencode"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.77"
 

--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -428,27 +428,6 @@ const CODEX_STREAM_PRETTY_JQ: &str = r#"
 ///     pretty-prints a compact terminal view via jq. If jq is unavailable,
 ///     it falls back to Codex's normal human-readable exec output.
 ///   - Other / unknown: passed through as-is.
-/// Resolve a CLI token to an absolute executable path for in-tmux execution.
-///
-/// Triggers run inside a tmux pane whose PATH is inherited from the tmux server.
-/// When KaitenCode is launched from a macOS GUI (Finder/Dock) — or any
-/// non-login context — that PATH is the minimal launchd default and omits the
-/// dirs `claude`/`codex` install into (`~/.claude/local/bin`, `~/.local/bin`,
-/// `/opt/homebrew/bin`, npm-global). A bare `claude` then fails with "command
-/// not found" inside the pane even though Settings detected the CLI. Resolving
-/// to the absolute path the detector finds makes execution PATH-independent and
-/// deterministic (it also pins which binary runs when more than one is
-/// installed). A token that already contains '/' (user-configured absolute or
-/// relative path) or that can't be resolved is returned unchanged, so a genuine
-/// misconfiguration surfaces as a real in-pane error rather than a silent
-/// rewrite.
-pub(crate) fn resolve_cli_exec(cli_command: &str) -> String {
-    if cli_command.contains('/') {
-        return cli_command.to_string();
-    }
-    crate::commands::cli_detect::find_cli(cli_command).unwrap_or_else(|| cli_command.to_string())
-}
-
 pub(crate) fn build_trigger_command(
     cli_command: &str,
     args: &[String],
@@ -473,6 +452,27 @@ pub(crate) fn build_trigger_command(
         cmd_parts.push(format!("'{}'", escaped));
     }
     cmd_parts.join(" ")
+}
+
+/// Resolve a CLI token to an absolute executable path for in-tmux execution.
+///
+/// Triggers run inside a tmux pane whose PATH is inherited from the tmux server.
+/// When KaitenCode is launched from a macOS GUI (Finder/Dock) or any non-login
+/// context, that PATH is the minimal launchd default and omits the user dirs
+/// `claude`/`codex` install into (the Claude installer dir, the local bin dir,
+/// Homebrew, npm-global). A bare `claude` then fails with "command not found"
+/// inside the pane even though Settings detected the CLI. Resolving to the
+/// absolute path the detector finds makes execution PATH-independent and
+/// deterministic, and pins which binary runs when more than one is installed.
+/// A token that already contains a path separator (user-configured absolute or
+/// relative path), or that cannot be resolved, is returned unchanged so a
+/// genuine misconfiguration surfaces as a real in-pane error, not a silent
+/// rewrite.
+pub(crate) fn resolve_cli_exec(cli_command: &str) -> String {
+    if cli_command.contains('/') {
+        return cli_command.to_string();
+    }
+    crate::commands::cli_detect::find_cli(cli_command).unwrap_or_else(|| cli_command.to_string())
 }
 
 /// Materialize a long shell command into a short `bash <script>` launcher.
@@ -1297,6 +1297,7 @@ fn workspace_for_task(task_id: &str) -> String {
         .unwrap_or_default()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn persist_agent_session_started(
     conn: &Connection,
     app: &AppHandle,

--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -428,6 +428,27 @@ const CODEX_STREAM_PRETTY_JQ: &str = r#"
 ///     pretty-prints a compact terminal view via jq. If jq is unavailable,
 ///     it falls back to Codex's normal human-readable exec output.
 ///   - Other / unknown: passed through as-is.
+/// Resolve a CLI token to an absolute executable path for in-tmux execution.
+///
+/// Triggers run inside a tmux pane whose PATH is inherited from the tmux server.
+/// When KaitenCode is launched from a macOS GUI (Finder/Dock) — or any
+/// non-login context — that PATH is the minimal launchd default and omits the
+/// dirs `claude`/`codex` install into (`~/.claude/local/bin`, `~/.local/bin`,
+/// `/opt/homebrew/bin`, npm-global). A bare `claude` then fails with "command
+/// not found" inside the pane even though Settings detected the CLI. Resolving
+/// to the absolute path the detector finds makes execution PATH-independent and
+/// deterministic (it also pins which binary runs when more than one is
+/// installed). A token that already contains '/' (user-configured absolute or
+/// relative path) or that can't be resolved is returned unchanged, so a genuine
+/// misconfiguration surfaces as a real in-pane error rather than a silent
+/// rewrite.
+pub(crate) fn resolve_cli_exec(cli_command: &str) -> String {
+    if cli_command.contains('/') {
+        return cli_command.to_string();
+    }
+    crate::commands::cli_detect::find_cli(cli_command).unwrap_or_else(|| cli_command.to_string())
+}
+
 pub(crate) fn build_trigger_command(
     cli_command: &str,
     args: &[String],
@@ -955,7 +976,7 @@ fn run_tmux(args: &[&str]) -> Result<String, String> {
 
 /// Capture pane scrollback (with escape sequences). Returns empty string on
 /// any error so callers can treat it as "no output captured".
-fn capture_pane_scrollback(session: &str) -> String {
+pub(crate) fn capture_pane_scrollback(session: &str) -> String {
     Command::new("tmux")
         .args(["capture-pane", "-t", session, "-p", "-e", "-J", "-S", "-"])
         .output()
@@ -1471,8 +1492,12 @@ pub fn spawn_cli_trigger_task(
 
     tokio::spawn(async move {
         let start_time = std::time::Instant::now();
+        // Execute via the absolute path (PATH inside the tmux pane may not
+        // include the dir this CLI lives in); keep `cli_command` as the logical
+        // name for telemetry / adapter detection.
+        let cli_exec = resolve_cli_exec(&cli_command);
         let full_cmd =
-            build_trigger_command(&cli_command, &args, &initial_prompt, resume_id.as_deref());
+            build_trigger_command(&cli_exec, &args, &initial_prompt, resume_id.as_deref());
         let nonce = gen_nonce();
         let log_path = log_retention::new_trigger_log_path(&nonce);
         let log_path_str = log_path.display().to_string();
@@ -2203,6 +2228,10 @@ async fn run_trigger_in_tmux(
             if should_kill_session_after_completion(persistent_lifecycle) {
                 let _ = tmux_transport::kill_session(task_id);
             }
+            // This task is now idle until its scheduled retry — a slot just
+            // freed. Drain the queue so throughput doesn't collapse while we
+            // wait out the (possibly hours-long) rate-limit backoff.
+            pipeline::promote_queued_tasks(app, &workspace_for_task(task_id));
             return Ok(());
         }
 
@@ -2217,6 +2246,23 @@ async fn run_trigger_in_tmux(
                 "[bridge] Task {} moved columns during trigger — skipping mark_complete",
                 task_id
             );
+            // The task left this column mid-trigger, so we must NOT mark it
+            // complete. But our agent still counts as `running` against the
+            // workspace concurrency cap; left alone it leaks a slot forever and
+            // the queue stalls (board appears frozen). Free the slot — but only
+            // if a fresh agent hasn't already taken over this task in the
+            // destination column (guard on our session id) — then drain the
+            // queue so a waiting task can take the freed slot.
+            if let Some(sid) = session_id {
+                let cleared = db::clear_task_agent_status_for_session(&conn, task_id, sid, "idle")
+                    .unwrap_or(0);
+                let _ = db::update_agent_session(
+                    &conn, sid, None, Some("cancelled"), None, None, None, None,
+                );
+                if cleared > 0 {
+                    pipeline::promote_queued_tasks(app, &workspace_for_task(task_id));
+                }
+            }
         } else {
             let status_str = if success { "completed" } else { "failed" };
             let _ = db::update_task_agent_status(&conn, task_id, Some(status_str), None);
@@ -2533,6 +2579,28 @@ pub(crate) fn pane_contains_sentinel(pane_text: &str, task_id: &str) -> bool {
     })
 }
 
+/// Number of trailing non-empty lines [`pane_tail_contains_sentinel`] inspects.
+/// Generous enough to survive a shell prompt + a few lines of trailing output
+/// landing after the sentinel between polls, but far short of a full transcript.
+const INTERACTIVE_SENTINEL_TAIL_LINES: usize = 40;
+
+/// Like [`pane_contains_sentinel`] but only inspects the last
+/// `INTERACTIVE_SENTINEL_TAIL_LINES` non-empty lines of the pane. A model that
+/// prints the sentinel line early in a long response shouldn't be able to mark
+/// the task done before it has actually finished; the genuine completion
+/// sentinel lands at the very end, just before the prompt returns.
+pub(crate) fn pane_tail_contains_sentinel(pane_text: &str, task_id: &str) -> bool {
+    let stripped = strip_ansi(pane_text);
+    let tail = stripped
+        .lines()
+        .rev()
+        .filter(|l| !l.trim().is_empty())
+        .take(INTERACTIVE_SENTINEL_TAIL_LINES)
+        .collect::<Vec<_>>()
+        .join("\n");
+    pane_contains_sentinel(&tail, task_id)
+}
+
 /// Detect whether Claude Code's TUI input box is visible in the captured
 /// pane. Claude Code draws a rounded box around the input row using the
 /// `╭`/`│`/`╰` box-drawing characters. We accept any of those as evidence
@@ -2658,9 +2726,12 @@ pub(crate) fn spawn_interactive_cli(
     let _ = tmux_transport::kill_session(task_id);
 
     let session = tmux_session_name(task_id);
+    // Execute via the absolute path — the tmux pane's PATH (esp. under a macOS
+    // GUI launch) may not include the dir this CLI lives in. See resolve_cli_exec.
+    let cli_exec = resolve_cli_exec(cli_command);
     let argv = match cli {
         InteractiveCli::Claude => build_interactive_claude_argv(
-            cli_command,
+            &cli_exec,
             user_args,
             task_id,
             resume_id,
@@ -2672,7 +2743,7 @@ pub(crate) fn spawn_interactive_cli(
                     "[bridge:interactive] resume_id ignored for codex (interactive resume not wired in Phase 3)"
                 );
             }
-            build_interactive_codex_argv(cli_command, user_args, task_id, include_sentinel)
+            build_interactive_codex_argv(&cli_exec, user_args, task_id, include_sentinel)
         }
     };
 
@@ -3021,7 +3092,12 @@ async fn watch_interactive_sentinel(
         }
 
         let pane = capture_pane_scrollback(&session);
-        if pane_contains_sentinel(&pane, &task_id) {
+        // Only inspect the tail. The real sentinel is emitted right before the
+        // agent returns to its prompt, so it lives near the end of the
+        // scrollback. Scanning the whole buffer would let a model that echoes
+        // the sentinel line early (e.g. while reasoning aloud about what it will
+        // print when done) trigger a premature completion.
+        if pane_tail_contains_sentinel(&pane, &task_id) {
             sentinel_seen = true;
             eprintln!(
                 "[bridge:interactive] sentinel observed for task {}",
@@ -3033,12 +3109,16 @@ async fn watch_interactive_sentinel(
 
     if moved_columns {
         // Don't run completion handling — the new column's trigger owns the
-        // task now. Just clear the running flag so the GC sweep doesn't
-        // re-mark this task as failed.
+        // task now. Clear the running flag so the GC sweep doesn't re-mark this
+        // task as failed AND so our slot doesn't leak against the concurrency
+        // cap. Guard on our session id so we don't clobber a fresh agent the
+        // destination column may have spawned; then drain the queue.
         if let Ok(conn) = Connection::open(db::db_path()) {
             let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
-            let _ = db::update_task_agent_status(&conn, &task_id, Some("idle"), None);
             if let Some(ref sid) = session_id {
+                let cleared =
+                    db::clear_task_agent_status_for_session(&conn, &task_id, sid, "idle")
+                        .unwrap_or(0);
                 let _ = db::update_agent_session(
                     &conn,
                     sid,
@@ -3049,6 +3129,11 @@ async fn watch_interactive_sentinel(
                     None,
                     None,
                 );
+                if cleared > 0 {
+                    pipeline::promote_queued_tasks(&app, &workspace_for_task(&task_id));
+                }
+            } else {
+                let _ = db::update_task_agent_status(&conn, &task_id, Some("idle"), None);
             }
         }
         return;
@@ -3690,6 +3775,50 @@ mod tests {
         // Document the current behavior so a future tightening (e.g. require
         // sentinel to be the LAST non-empty line) is an intentional change.
         assert!(pane_contains_sentinel(pane, "task-7"));
+    }
+
+    #[test]
+    fn test_resolve_cli_exec_passes_through_explicit_path() {
+        // A user-configured absolute/relative path must be used verbatim — never
+        // re-resolved (they may be pointing at a specific install on purpose).
+        assert_eq!(resolve_cli_exec("/opt/homebrew/bin/claude"), "/opt/homebrew/bin/claude");
+        assert_eq!(resolve_cli_exec("./local/codex"), "./local/codex");
+    }
+
+    #[test]
+    fn test_resolve_cli_exec_passes_through_unresolvable_bare_name() {
+        // A bare name we can't find anywhere is returned unchanged so the user
+        // sees a real "command not found" in-pane instead of a silent rewrite.
+        let bogus = "kaitencode-no-such-cli-xyz";
+        assert_eq!(resolve_cli_exec(bogus), bogus);
+    }
+
+    #[test]
+    fn test_pane_tail_sentinel_ignores_early_echo() {
+        // Regression: the model prints the sentinel line early (while reasoning
+        // about what it will emit when done), then continues working for many
+        // more lines. The tail-scan watcher must NOT complete prematurely.
+        let mut pane = String::from("<<<KAITENCODE_DONE:task-7>>>\n");
+        for i in 0..80 {
+            pane.push_str(&format!("still working line {}\n", i));
+        }
+        assert!(
+            !pane_tail_contains_sentinel(&pane, "task-7"),
+            "an early sentinel echo scrolled out of the tail must not complete"
+        );
+    }
+
+    #[test]
+    fn test_pane_tail_sentinel_matches_when_near_end() {
+        // The genuine completion case: sentinel lands at the end, just before
+        // the prompt returns (a couple trailing lines after it are fine).
+        let mut pane = String::new();
+        for i in 0..80 {
+            pane.push_str(&format!("doing work line {}\n", i));
+        }
+        pane.push_str("<<<KAITENCODE_DONE:task-7>>>\n");
+        pane.push_str("user@host:~/repo$ \n");
+        assert!(pane_tail_contains_sentinel(&pane, "task-7"));
     }
 
     #[test]

--- a/src-tauri/src/chat/gc.rs
+++ b/src-tauri/src/chat/gc.rs
@@ -10,12 +10,17 @@ use std::time::Duration;
 
 use rusqlite::Connection;
 
+use tauri::AppHandle;
+
 use super::tmux_transport;
 use crate::config::AppSettings;
 use crate::db;
 
 /// Run one garbage collection cycle.
-pub fn collect(conn: &Connection) {
+///
+/// `app` is optional so unit tests can exercise the sweep without a Tauri
+/// runtime; when present, freed concurrency slots trigger queue promotion.
+pub fn collect(conn: &Connection, app: Option<&AppHandle>) {
     let settings = AppSettings::load();
     let sessions = tmux_transport::list_sessions();
 
@@ -121,16 +126,21 @@ pub fn collect(conn: &Connection) {
     // (e.g., OOM kill, manual tmux kill-session). Paused tasks (Phase 5)
     // are exempt — their suspended process still owns the session.
     if let Ok(mut stmt) = conn.prepare(
-        "SELECT id, agent_session_id FROM tasks
+        "SELECT id, agent_session_id, workspace_id FROM tasks
          WHERE agent_status = 'running' AND agent_paused_at IS NULL",
     ) {
-        let stale: Vec<(String, Option<String>)> = stmt
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        let stale: Vec<(String, Option<String>, String)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
             .ok()
             .map(|rows| rows.filter_map(|r| r.ok()).collect())
             .unwrap_or_default();
 
-        for (task_id, session_id) in stale {
+        // Workspaces where we just freed a concurrency slot — drain their queues
+        // after the sweep so queued tasks don't wait on the next normal
+        // completion (which may never come).
+        let mut freed_workspaces: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        for (task_id, session_id, workspace_id) in stale {
             let session_name = tmux_transport::session_name(&task_id);
             // Check if tmux session actually exists
             let session_exists = sessions.contains(&session_name);
@@ -152,6 +162,13 @@ pub fn collect(conn: &Connection) {
                         None,
                     );
                 }
+                freed_workspaces.insert(workspace_id);
+            }
+        }
+
+        if let Some(app) = app {
+            for workspace_id in freed_workspaces {
+                crate::pipeline::promote_queued_tasks(app, &workspace_id);
             }
         }
     }
@@ -160,7 +177,7 @@ pub fn collect(conn: &Connection) {
 /// Start the periodic garbage collector.
 /// Runs every `gc_interval_minutes` from settings (default 5).
 /// Note: interval changes via API take effect on the next cycle, not immediately.
-pub fn start_gc() {
+pub fn start_gc(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
         loop {
             let interval = {
@@ -173,7 +190,7 @@ pub fn start_gc() {
             // Open a fresh DB connection for each cycle
             if let Ok(conn) = Connection::open(db::db_path()) {
                 let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
-                collect(&conn);
+                collect(&conn, Some(&app));
             }
         }
     });
@@ -190,7 +207,7 @@ mod tests {
         // Should not panic when no tmux sessions exist
         // (can't fully test without tmux, but verify it doesn't crash)
         let conn = Connection::open_in_memory().unwrap();
-        collect(&conn); // No-op since no tmux sessions
+        collect(&conn, None); // No-op since no tmux sessions
     }
 
     #[test]
@@ -223,7 +240,7 @@ mod tests {
         );
         assert!(tmux_transport::has_session(&task_id));
 
-        collect(&conn);
+        collect(&conn, None);
         thread::sleep(Duration::from_millis(150));
 
         assert!(!tmux_transport::has_session(&task_id));

--- a/src-tauri/src/commands/cli_detect.rs
+++ b/src-tauri/src/commands/cli_detect.rs
@@ -108,39 +108,50 @@ pub struct CliCapabilities {
 fn get_search_paths() -> Vec<PathBuf> {
     let home = std::env::var("HOME").unwrap_or_default();
 
+    // Order matters: this is a first-match search. User-owned install dirs come
+    // BEFORE the system `/usr/local/bin`, because the native Claude/Codex
+    // installers and Homebrew put the newest binary in the user's dirs while a
+    // stale `npm -g` copy often lingers in `/usr/local/bin`. Preferring the user
+    // dirs makes "which binary does the app run" deterministic and matches what
+    // the user's own login shell resolves (avoids the two-installs footgun).
     vec![
-        // Standard PATH locations
+        // Claude Code's official installer location (highest priority).
+        PathBuf::from(format!("{}/.claude/local/bin", home)),
+        // User-specific locations.
+        PathBuf::from(format!("{}/.local/bin", home)),
+        PathBuf::from(format!("{}/bin", home)),
+        // Homebrew (Apple Silicon default, then Intel/Linuxbrew).
+        PathBuf::from("/opt/homebrew/bin"),
+        // Cargo binaries (for rust-based tools).
+        PathBuf::from(format!("{}/.cargo/bin", home)),
+        // System locations (a stale npm-global copy often lives here).
         PathBuf::from("/usr/local/bin"),
         PathBuf::from("/usr/bin"),
         PathBuf::from("/bin"),
-        PathBuf::from("/opt/homebrew/bin"),
         PathBuf::from("/snap/bin"),
         PathBuf::from("/var/lib/flatpak/exports/bin"),
         PathBuf::from(format!("{}/.local/share/flatpak/exports/bin", home)),
-        // User-specific locations
-        PathBuf::from(format!("{}/.local/bin", home)),
-        PathBuf::from(format!("{}/bin", home)),
-        // Claude Code specific
-        PathBuf::from(format!("{}/.claude/local/bin", home)),
-        // Conductor/Codex location
+        // Conductor/Codex location.
         PathBuf::from(format!(
             "{}/Library/Application Support/com.conductor.app/bin",
             home
         )),
-        // Cargo binaries (for rust-based tools)
-        PathBuf::from(format!("{}/.cargo/bin", home)),
-        // npm global binaries
+        // npm global binaries.
         PathBuf::from(format!("{}/.npm-global/bin", home)),
         PathBuf::from("/usr/local/lib/node_modules/.bin"),
-        // pip/pipx binaries (for aider)
+        // pip/pipx binaries (for aider).
         PathBuf::from(format!("{}/.local/pipx/venvs/aider-chat/bin", home)),
         PathBuf::from(format!("{}/Library/Python/3.11/bin", home)),
         PathBuf::from(format!("{}/Library/Python/3.12/bin", home)),
     ]
 }
 
-/// Try to find a CLI tool by name
-fn find_cli(name: &str) -> Option<String> {
+/// Try to find a CLI tool by name. Returns its absolute path if found.
+///
+/// `pub(crate)` so the trigger spawn path can resolve a bare `claude`/`codex`
+/// token to an absolute path before injecting it into a tmux pane (whose PATH,
+/// under a macOS GUI launch, omits the dirs these CLIs install into).
+pub(crate) fn find_cli(name: &str) -> Option<String> {
     // First try `which` command
     if let Ok(Some(output)) = command_output_with_timeout("which", &[name], CLI_PROBE_TIMEOUT) {
         if output.status.success() {

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -138,6 +138,15 @@ pub fn check_runtime_prerequisites() -> Vec<RuntimePrerequisite> {
             &["--version"],
             "Install GitHub CLI from https://cli.github.com/ for PR automation.",
         ),
+        check_tool(
+            "jq",
+            "jq",
+            false,
+            "jq",
+            &["--version"],
+            "Install jq (`brew install jq` / your package manager) for a clean streaming \
+             agent view; without it the terminal falls back to raw JSON output.",
+        ),
     ]
 }
 
@@ -157,5 +166,8 @@ mod tests {
         assert!(checks
             .iter()
             .any(|check| check.id == "gh" && !check.required));
+        assert!(checks
+            .iter()
+            .any(|check| check.id == "jq" && !check.required));
     }
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -151,7 +151,19 @@ fn dirs_home() -> PathBuf {
     std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("."))
+        .unwrap_or_else(|_| {
+            // Neither HOME nor USERPROFILE set — a broken/headless environment.
+            // The old fallback was the current working directory ("."), which
+            // for a GUI app launched from Finder/Dock is often "/" — unwritable,
+            // so `create_dir_all` would panic and the app wouldn't start at all.
+            // Fall back to the OS temp dir (always writable) and warn loudly so
+            // it's diagnosable; set KAITENCODE_DATA_DIR to pin a real location.
+            log::error!(
+                "[db] Neither HOME nor USERPROFILE is set; falling back to the temp dir for app data. \
+                 Set KAITENCODE_DATA_DIR to choose a persistent location."
+            );
+            std::env::temp_dir()
+        })
 }
 
 /// Returns the path to the SQLite database file.

--- a/src-tauri/src/db/task.rs
+++ b/src-tauri/src/db/task.rs
@@ -640,6 +640,28 @@ pub fn get_running_agent_count(conn: &Connection, workspace_id: &str) -> SqlResu
     )
 }
 
+/// Reset a task's `agent_status` ONLY if it still references `session_id`.
+///
+/// Used when a stale completion handler discovers its task moved columns
+/// mid-trigger. If the destination column spawned a fresh agent, the task's
+/// `agent_session_id` has already advanced to the new session, so a blind
+/// `agent_status='idle'` write would clobber the new agent's `running` state.
+/// Guarding on the session id makes the slot-freeing reset a no-op in that case.
+/// Returns the number of rows updated (0 if a newer session took over).
+pub fn clear_task_agent_status_for_session(
+    conn: &Connection,
+    task_id: &str,
+    session_id: &str,
+    new_status: &str,
+) -> SqlResult<usize> {
+    let ts = now();
+    conn.execute(
+        "UPDATE tasks SET agent_status = ?1, updated_at = ?2 \
+         WHERE id = ?3 AND agent_session_id = ?4",
+        params![new_status, ts, task_id, session_id],
+    )
+}
+
 /// Count tasks with agent_status = 'running' in a single column of a workspace.
 /// Used for per-column concurrency caps (e.g. serialize Merge main).
 pub fn get_running_agent_count_in_column(
@@ -650,6 +672,34 @@ pub fn get_running_agent_count_in_column(
     conn.query_row(
         "SELECT COUNT(*) FROM tasks WHERE workspace_id = ?1 AND column_id = ?2 AND agent_status = 'running'",
         params![workspace_id, column_id],
+        |row| row.get(0),
+    )
+}
+
+/// Count active, non-queued task executions across the whole workspace,
+/// excluding one task.
+///
+/// The workspace concurrency gate needs this broader count for the same reason
+/// the column gate does: a terminal-/interactive-mode agent sits in
+/// `pipeline_state='triggered'`/`'running'` before its `agent_status` is set to
+/// `'running'` (that write happens asynchronously inside the spawned task). A
+/// gate that only counts `agent_status='running'` therefore undercounts during
+/// a burst of simultaneous fires and over-spawns past the cap. Excludes the
+/// task currently being evaluated so it isn't counted against its own slot.
+pub fn get_active_execution_count_excluding(
+    conn: &Connection,
+    workspace_id: &str,
+    excluded_task_id: &str,
+) -> SqlResult<i64> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM tasks \
+         WHERE workspace_id = ?1 \
+           AND id != ?2 \
+           AND archived_at IS NULL \
+           AND COALESCE(agent_status, '') != 'queued' \
+           AND (agent_status = 'running' \
+                OR pipeline_state IN ('triggered', 'running', 'evaluating', 'advancing', 'rate_limited'))",
+        params![workspace_id, excluded_task_id],
         |row| row.get(0),
     )
 }
@@ -846,6 +896,44 @@ mod tests {
         let workspace = crate::db::insert_workspace(conn, "WS", "/tmp/ws").unwrap();
         let column = crate::db::insert_column(conn, &workspace.id, "Backlog", 0).unwrap();
         insert_task(conn, &workspace.id, &column.id, "Task", None).unwrap()
+    }
+
+    #[test]
+    fn clear_agent_status_for_session_frees_slot_when_session_matches() {
+        let conn = crate::db::init_test().unwrap();
+        let task = seed_task(&conn);
+        update_task_agent_session(&conn, &task.id, Some("sess-A")).unwrap();
+        update_task_agent_status(&conn, &task.id, Some("running"), None).unwrap();
+
+        let rows =
+            clear_task_agent_status_for_session(&conn, &task.id, "sess-A", "idle").unwrap();
+
+        assert_eq!(rows, 1, "matching session should update exactly one row");
+        let reloaded = get_task(&conn, &task.id).unwrap();
+        assert_eq!(reloaded.agent_status.as_deref(), Some("idle"));
+    }
+
+    #[test]
+    fn clear_agent_status_for_session_is_noop_when_a_newer_session_took_over() {
+        // Regression: a stale completion handler must NOT clobber the `running`
+        // status of a fresh agent that took over the task in another column.
+        let conn = crate::db::init_test().unwrap();
+        let task = seed_task(&conn);
+        // A new agent (session B) now owns the task and is running.
+        update_task_agent_session(&conn, &task.id, Some("sess-B")).unwrap();
+        update_task_agent_status(&conn, &task.id, Some("running"), None).unwrap();
+
+        // The OLD handler (session A) tries to free the slot.
+        let rows =
+            clear_task_agent_status_for_session(&conn, &task.id, "sess-A", "idle").unwrap();
+
+        assert_eq!(rows, 0, "stale session must not match the new owner");
+        let reloaded = get_task(&conn, &task.id).unwrap();
+        assert_eq!(
+            reloaded.agent_status.as_deref(),
+            Some("running"),
+            "the new agent's running status must be preserved"
+        );
     }
 
     #[test]

--- a/src-tauri/src/git/branch_manager.rs
+++ b/src-tauri/src/git/branch_manager.rs
@@ -381,6 +381,21 @@ pub fn create_task_worktree(
         return Ok(wt_path.to_string_lossy().to_string());
     }
 
+    // Stale-metadata recovery: the directory is gone (checked above) but git may
+    // still track this worktree name (e.g. the user `rm -rf`'d .worktrees, a
+    // disk-cleanup tool removed it, or a previous prune was interrupted). In
+    // that case `repo.worktree(name, ...)` below hard-fails with "already
+    // exists" — and because `is_transient_setup_error` matches that string, the
+    // trigger retries forever against the same stale entry, leaving the task
+    // permanently un-spawnable. Prune the dangling registration first.
+    if let Ok(stale) = repo.find_worktree(&wt_name) {
+        let _ = stale.prune(Some(
+            git2::WorktreePruneOptions::new()
+                .valid(true)
+                .working_tree(true),
+        ));
+    }
+
     // Ensure parent dir exists
     if let Some(parent) = wt_path.parent() {
         std::fs::create_dir_all(parent)
@@ -782,6 +797,42 @@ mod tests {
         assert!(!tmp.join(".task.md").exists());
         // Summary mentions what happened
         assert!(summary.contains(".task.md"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Regression: if a worktree directory is removed out-of-band (manual
+    /// `rm -rf .worktrees`, disk cleanup, interrupted prune) while git still
+    /// tracks the worktree by name, re-creating it must succeed instead of
+    /// hard-failing forever with "already exists" (which made the owning task
+    /// permanently un-spawnable, since the trigger retries the same stale entry).
+    #[test]
+    fn test_create_task_worktree_recovers_from_stale_metadata() {
+        let tmp = std::env::temp_dir()
+            .join(format!("kaitencode-wt-stale-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        init_test_repo(&tmp);
+        let repo = tmp.to_str().unwrap();
+
+        let branch = create_task_branch_with_prefix(repo, "Stale WT", None, "kaitencode")
+            .expect("create branch");
+        let wt = create_task_worktree(repo, &branch, "task-stale").expect("first worktree");
+        assert!(std::path::Path::new(&wt).exists());
+
+        // Simulate out-of-band removal of the directory, leaving git metadata
+        // (.git/worktrees/<name>) registered — exactly the leak condition.
+        std::fs::remove_dir_all(&wt).unwrap();
+        assert!(!std::path::Path::new(&wt).exists());
+        assert!(
+            Repository::open(repo).unwrap().find_worktree(&worktree_name("task-stale")).is_ok(),
+            "precondition: git still tracks the stale worktree name"
+        );
+
+        // Recovery: must prune the dangling registration and recreate cleanly.
+        let wt2 = create_task_worktree(repo, &branch, "task-stale")
+            .expect("worktree recreation should succeed after pruning stale metadata");
+        assert!(std::path::Path::new(&wt2).exists());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -381,7 +381,7 @@ pub fn run() {
             start_nightly_worktree_sweep(app.handle().clone());
 
             // Start garbage collector for tmux sessions + agent resources
-            chat::gc::start_gc();
+            chat::gc::start_gc(app.handle().clone());
 
             // Clean up legacy 58-byte rate-limit stub logs and GC the
             // retained trigger_logs/ directory down to MAX_TRIGGER_LOGS.
@@ -673,38 +673,57 @@ fn recover_tmux_sessions(app: tauri::AppHandle) {
             // Codex has already returned to the prompt, so we can mark complete.
             if let Some(cmd) = pane_current_command(session_name) {
                 if matches!(cmd.as_str(), "bash" | "sh" | "zsh" | "fish") {
-                    eprintln!(
-                        "[startup] Adopting orphan-done session: {} (pane at {} prompt)",
-                        session_name, cmd
-                    );
-                    let app_clone = app.clone();
-                    let task_id_owned = task_id.to_string();
-                    // mark_complete may need its own DB connection + can fire
-                    // downstream column triggers; do it after we release the
-                    // outer lock by deferring with tokio::spawn.
-                    tauri::async_runtime::spawn(async move {
-                        let state: tauri::State<db::AppState> = app_clone.state();
-                        let conn = match state.db.lock() {
-                            Ok(c) => c,
-                            Err(e) => {
+                    // The pane is back at a shell prompt → the agent process
+                    // exited. But a prompt alone does NOT distinguish success
+                    // from failure: a non-zero (failed) agent also returns to
+                    // the prompt. Marking it complete-as-success unconditionally
+                    // would advance the pipeline / open a PR for a task that
+                    // actually failed. So only adopt-as-success when the
+                    // completion sentinel is present in the pane; otherwise clear
+                    // the stuck `running` status to idle and let the user inspect
+                    // or retry rather than asserting an outcome we can't verify.
+                    let pane = chat::bridge::capture_pane_scrollback(session_name);
+                    if chat::bridge::pane_contains_sentinel(&pane, task_id) {
+                        eprintln!(
+                            "[startup] Adopting orphan-done session: {} (completion sentinel present)",
+                            session_name
+                        );
+                        let app_clone = app.clone();
+                        let task_id_owned = task_id.to_string();
+                        // mark_complete may need its own DB connection + can fire
+                        // downstream column triggers; do it after we release the
+                        // outer lock by deferring with tokio::spawn.
+                        tauri::async_runtime::spawn(async move {
+                            let state: tauri::State<db::AppState> = app_clone.state();
+                            let conn = match state.db.lock() {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    log::warn!(
+                                        "[startup] orphan-adopt DB lock failed for {}: {}",
+                                        task_id_owned,
+                                        e
+                                    );
+                                    return;
+                                }
+                            };
+                            if let Err(e) =
+                                pipeline::mark_complete(&conn, &app_clone, &task_id_owned, true)
+                            {
                                 log::warn!(
-                                    "[startup] orphan-adopt DB lock failed for {}: {}",
+                                    "[startup] orphan-adopt mark_complete failed for {}: {:?}",
                                     task_id_owned,
                                     e
                                 );
-                                return;
                             }
-                        };
-                        if let Err(e) =
-                            pipeline::mark_complete(&conn, &app_clone, &task_id_owned, true)
-                        {
-                            log::warn!(
-                                "[startup] orphan-adopt mark_complete failed for {}: {:?}",
-                                task_id_owned,
-                                e
-                            );
-                        }
-                    });
+                        });
+                    } else {
+                        eprintln!(
+                            "[startup] Session {} at {} prompt but no completion sentinel — \
+                             leaving task {} idle (not asserting success)",
+                            session_name, cmd, task_id
+                        );
+                        let _ = db::update_task_agent_status(&conn, task_id, Some("idle"), None);
+                    }
                 }
             }
         } else {

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -1271,7 +1271,7 @@ fn emit_completion_event(
 ///      drain.
 ///   3. Honors per-column `triggers.max_concurrent` — if a queued task's
 ///      column is at its column cap, skip it and try the next queued task.
-fn promote_queued_tasks(app: &AppHandle, workspace_id: &str) {
+pub(crate) fn promote_queued_tasks(app: &AppHandle, workspace_id: &str) {
     let conn = match Connection::open(db::db_path()) {
         Ok(c) => c,
         Err(e) => {
@@ -1294,7 +1294,10 @@ fn promote_queued_tasks(app: &AppHandle, workspace_id: &str) {
     let max_workspace =
         crate::config::effective_pipeline_settings(&workspace.config).max_concurrent_agents;
 
-    let running = db::get_running_agent_count(&conn, workspace_id).unwrap_or(0);
+    // Use the same broad active count the spawn gate uses (not just
+    // agent_status='running'), so we don't promote tasks the gate will simply
+    // re-queue. Empty excluded-id counts every active task in the workspace.
+    let running = db::get_active_execution_count_excluding(&conn, workspace_id, "").unwrap_or(0);
     if running >= max_workspace {
         return;
     }

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -1110,8 +1110,27 @@ fn ensure_task_worktree(
 ) -> Result<Task, AppError> {
     let mut task = task.clone();
 
-    // Step 1: Ensure task has a branch
-    if task.branch_name.as_deref().unwrap_or("").is_empty() {
+    // Step 1: Ensure task has a branch that actually exists in THIS repo.
+    //
+    // A task may carry a stale `branch_name` — e.g. a legacy `bentoya/` prefix,
+    // or a branch that belonged to a different repo/worktree and was never
+    // created here. Trusting a recorded-but-missing branch makes
+    // `create_task_worktree` hard-fail on `find_branch`, which surfaces to the
+    // user as "failed to spawn cli" with no recovery short of retry-from-start
+    // (the only path that nulls `branch_name`). So treat a missing branch the
+    // same as no branch and (re)create it from base.
+    let recorded_branch = task.branch_name.as_deref().unwrap_or("").to_string();
+    let branch_missing = recorded_branch.is_empty()
+        || !branch_manager::branch_exists(repo_path, &recorded_branch).unwrap_or(false);
+    if branch_missing {
+        if !recorded_branch.is_empty() {
+            log::warn!(
+                "[triggers] Task {} references branch '{}' which does not exist in {}; recreating from base",
+                task.id,
+                recorded_branch,
+                repo_path
+            );
+        }
         let base = validate_setup_base_branch(base_branch, &task.id)?;
         let slug = branch_manager::slugify(&task.title);
         match branch_manager::create_task_branch_with_prefix(
@@ -1526,7 +1545,13 @@ fn execute_spawn_cli(
     // Two-layer cap: workspace-wide, then column-scoped. If either is at or
     // above its limit, mark this task as queued instead of spawning.
     let max_concurrent = pipeline_settings.max_concurrent_agents;
-    let running_count = db::get_running_agent_count(conn, &task.workspace_id).unwrap_or(0);
+    // Count the broad active set (not just agent_status='running') excluding this
+    // task. `agent_status='running'` is written asynchronously after spawn, so a
+    // burst of simultaneous fires would each read a stale count and over-spawn
+    // past the cap. The pre-`running` pipeline states close that window — same
+    // approach the column-scoped gate below uses.
+    let running_count =
+        db::get_active_execution_count_excluding(conn, &task.workspace_id, &task.id).unwrap_or(0);
 
     if running_count >= max_concurrent {
         log::info!(
@@ -4552,6 +4577,59 @@ mod tests {
         .expect("branch creation should succeed with explicit base");
 
         assert_eq!(branch, "kaitencode/implement-feature");
+    }
+
+    /// Regression: a task carrying a stale `branch_name` — e.g. a legacy
+    /// `bentoya/` prefix, or a branch that belonged to another repo/worktree and
+    /// was never created here — must NOT permanently break worktree creation.
+    ///
+    /// The bug: `ensure_task_worktree` only created a branch when `branch_name`
+    /// was empty, then called `create_task_worktree`, which hard-fails on
+    /// `find_branch` for a missing branch. That surfaced to the user as
+    /// "failed to spawn cli" with no recovery short of retry-from-start.
+    ///
+    /// The fix detects the missing branch (`branch_exists` → false) and
+    /// recreates it from base before the worktree. This test pins that contract
+    /// on the underlying git layer (sidestepping the AppHandle-typed wrapper).
+    #[test]
+    fn test_worktree_recovers_from_stale_missing_branch() {
+        use crate::git::branch_manager;
+        let tmp = tempfile::tempdir().unwrap();
+        init_test_repo(tmp.path());
+        let repo = tmp.path().to_str().unwrap();
+        let settings = make_test_pipeline_settings();
+
+        // Bug condition: a recorded branch that does not exist in this repo.
+        let stale = "bentoya/deliberately-missing-branch";
+        assert!(
+            !branch_manager::branch_exists(repo, stale).unwrap(),
+            "precondition: stale branch must be absent"
+        );
+
+        // The original failure: a worktree on a missing branch is a hard error.
+        assert!(
+            branch_manager::create_task_worktree(repo, stale, "task-stale").is_err(),
+            "worktree on a missing branch should fail (this is the bug we recover from)"
+        );
+
+        // The recovery `ensure_task_worktree` now performs: detect the missing
+        // branch, recreate it from base, then create the worktree successfully.
+        assert!(!branch_manager::branch_exists(repo, stale).unwrap());
+        let fresh = branch_manager::create_task_branch_with_prefix(
+            repo,
+            "Implement Feature",
+            Some(&settings.default_base_branch),
+            &settings.branch_prefix,
+        )
+        .expect("recreate branch from base");
+        assert_eq!(fresh, "kaitencode/implement-feature");
+
+        let wt = branch_manager::create_task_worktree(repo, &fresh, "task-stale")
+            .expect("worktree creation should now succeed after branch recovery");
+        assert!(
+            std::path::Path::new(&wt).exists(),
+            "worktree dir should exist"
+        );
     }
 
     /// Bogus base branch → hard fail (Bug D test on the underlying git layer).

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "KaitenCode",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "identifier": "com.kaitencode.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release-readiness pass for daily use. All green: **Rust 497 · MCP 19 · Vitest 410 · tsc + lint clean.** Version bumped to **1.0.0** (package.json, both Cargo.toml, tauri.conf.json, Cargo.lock).

## Concurrency / queue-stall (the "board freezes" class)
`promote_queued_tasks` was only ever called from the normal completion path, so any *other* way a concurrency slot freed leaked it — the workspace silently stopped spawning and every new task got stuck `queued`. Now drained from:
- a task **moved out of a trigger column mid-run** (headless + interactive),
- the **rate-limit backoff** branch (slot no longer idle for the whole backoff),
- the **GC dead-session sweep** (threaded `AppHandle` through `start_gc`/`collect`).

The moved-column slot reset is **session-scoped** (new `db::clear_task_agent_status_for_session`) so it can't clobber a fresh agent that took over the task in the destination column. The workspace cap now counts the **broad active set** (not just `agent_status='running'`, which is written async after spawn) excluding self — mirroring the column gate — so bursts can't over-spawn past the cap.

## Worktree recovery
`create_task_worktree` now prunes a dangling git worktree registration when the directory was removed out-of-band. Previously the task became **permanently un-spawnable** (retries hit the same stale "already exists" entry).

## Startup recovery (false-success)
Orphan-done adoption no longer marks a task **complete-as-success** just because its pane is at a shell prompt — a *failed* agent looks identical, which could auto-advance the pipeline / open a PR for a failed task after a restart. It now requires the completion sentinel; otherwise the stuck status is cleared to `idle` for the user to inspect/retry.

## Cross-OS / new-user portability
- Triggers execute the agent via its **absolute path** (resolved via `cli_detect`) instead of bare `claude`/`codex`. A macOS GUI/launchd launch — whose PATH omits `~/.claude/local/bin`, `~/.local/bin`, `/opt/homebrew/bin`, npm-global — no longer fails every trigger with "command not found". Also pins which binary runs when more than one is installed (the "two claudes" footgun).
- `get_search_paths()` now prefers user/Homebrew dirs over `/usr/local/bin` (where a stale `npm -g` copy lingers).
- `jq` added to the runtime preflight (optional; clean streaming view).
- No-HOME data-dir fallback uses the OS temp dir (writable) instead of `"."` (often `/` under a GUI launch → unwritable → app won't start).

## Interactive mode
- Sentinel watcher scans only the **tail** of the scrollback so a model echoing the DONE line early can't trigger a premature completion.

Adds 9 regression tests.

## Note on target platforms
The agent layer is built on tmux + POSIX shell + jq, and the bundle targets are deb/appimage/dmg/app — so **macOS and Linux are the realistic targets; Windows is not supported** (would need a transport rewrite). Flagging in case that should be made explicit before tagging.