### PR TITLE
Orchestrator per-tab + (shells) + chef toggle; Discord MVP plan

### DIFF
--- a/.tickets/discord/E001-discord-integration.md
+++ b/.tickets/discord/E001-discord-integration.md
@@ -6,6 +6,22 @@
 
 ---
 
+> ### Update — 2026-06-07
+> Confirmed direction and a smaller first step:
+> - **Thread model = task (board mirror)**: every task → a thread in its
+>   column's channel. KaitenCode is the source; Discord mirrors it. (Confirms the
+>   existing design — no change.)
+> - **Thin MVP first**: build one vertical slice (connect + task→thread + agent
+>   output streaming in, KaitenCode → Discord only) before reply-routing / `#chef`
+>   / bidirectional sync. See [`MVP-PLAN.md`](./MVP-PLAN.md). The MVP maps to
+>   T052 + lite cuts of T053/T054/T056/T057; T058–T060 stay as later slices.
+> - **Architecture has moved since this was written**: the local HTTP API is now
+>   on by default, and interactive completion is advisory (the agent stays alive
+>   at its prompt — relevant to how a thread's agent keeps "talking"). The sidecar
+>   + chef integration points below are still accurate.
+
+---
+
 ## Vision
 
 Transform Discord into a remote cockpit for KaitenCode. Users can monitor agent progress, receive notifications, reply to agents, and manage the board through natural language - all from Discord (including mobile).

--- a/.tickets/discord/MVP-PLAN.md
+++ b/.tickets/discord/MVP-PLAN.md
@@ -1,0 +1,73 @@
+# Discord MVP — thin vertical slice
+
+> **Status**: planned (2026-06-07) · **Parent**: [E001](./E001-discord-integration.md)
+> **Decision**: thread = task (board mirror) · thin MVP first · KaitenCode → Discord (one direction)
+
+The full epic (E001, tickets T052–T060) stays the roadmap. This is "phase 1, lite":
+the smallest end-to-end slice that proves the **hard, reusable** parts — the
+Node.js sidecar, the stdin/stdout IPC protocol, Discord auth, thread creation,
+and batched message posting — before we add reply-routing, `#chef`, and
+bidirectional sync.
+
+## The slice
+
+> Connect the bot → when a task starts running, create a Discord **thread** for
+> it in its column's channel → **stream that agent's output into the thread.**
+
+One direction only (KaitenCode → Discord). No reply routing, no `#chef`, no
+board mutation from Discord yet.
+
+## Why this slice
+
+It exercises every reusable building block exactly once:
+- sidecar process lifecycle + supervision,
+- the JSON IPC protocol (Rust ⇄ Node),
+- Discord auth + a guild/category the bot can write to,
+- thread create + the `MessageSplitter`/`RateLimiter` 2000-char batching
+  (already specced in T056/T057),
+- subscribing to existing app events and forwarding them.
+
+Reply-routing (`--resume`, T058), `#chef` (T059), and bidirectional sync (T060)
+then bolt onto the **same bridge** without re-architecting.
+
+## Components
+
+| Piece | Where (new unless noted) | What it does |
+|------|--------------------------|--------------|
+| Sidecar bot | `src-tauri/sidecars/discord-bot/` | Node.js + `discord.js`. Reads JSON commands on stdin (`createThread`, `postMessage`); connects to Discord; emits events (`ready`, errors) on stdout. (T052) |
+| Rust bridge | `src-tauri/src/discord/mod.rs` | Spawns + supervises the sidecar; sends commands; subscribes to app events (task→running, agent output) and forwards them. |
+| Commands | `src-tauri/src/commands/discord.rs` | `discord_set_token`, `discord_enable`, `discord_test_connection`, `discord_status`. |
+| DB | new migration (after current latest) | Re-add workspace `discord_*` fields + minimal `discord_task_threads` (task_id ↔ thread_id). The old `018` migration was reverted by `026`; revive only the MVP bits. |
+| Settings UI | `src/components/settings/tabs/discord-tab.tsx` | Bot token, enable toggle, guild + category pickers, "Test connection". |
+
+## Event flow (MVP)
+
+1. Task enters a trigger column / agent starts → bridge sends `createThread`
+   `{ taskTitle, columnChannelId }` → sidecar creates the thread, returns
+   `threadId` → bridge persists `discord_task_threads(task_id, thread_id)`.
+2. Agent output events (`pty:<key>:output` / agent transcript) → bridge buffers
+   + splits (≤2000 chars, batched per Discord rate limits) → `postMessage`
+   `{ threadId, content }`.
+3. Agent completes → `postMessage` a short summary; leave the thread (archive
+   lifecycle is a later slice).
+
+No agent-side changes — output already flows as events; the bridge just listens.
+
+## Open practical notes
+
+- **Node.js** becomes a runtime dep for Discord users → add to the preflight
+  check (where `tmux`/`jq` already live), opt-in.
+- The user **invites the bot** to a server and picks a guild/category in
+  settings; the bot needs the **Create Public Threads** + **Send Messages in
+  Threads** perms.
+- **Token at rest**: stored in settings for the MVP; encryption-at-rest is a
+  flagged follow-up, not MVP.
+- **Opt-in**: gated by the per-workspace `discord_enabled` flag; the app runs
+  fully without Discord and without Node.
+
+## Out of scope (later slices, already ticketed)
+
+- Reply in a thread → route to the task's agent (`--resume`) — T058
+- `#chef` channel → natural-language board management — T059
+- Column/workspace rename sync, conflict resolution, offline queue — T060
+- Thread archive/reactivate lifecycle — T054 (full)

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1797,6 +1797,7 @@ pub async fn ensure_pty_session(
 /// (`write_to_pty`/`resize_pty`/`get_pty_scrollback`) and `pty:<key>:*` events
 /// as task terminals — only the spawn/attach entrypoint differs.
 #[tauri::command(rename_all = "camelCase")]
+#[allow(clippy::too_many_arguments)]
 pub async fn ensure_chef_terminal(
     app: AppHandle,
     state: State<'_, AppState>,
@@ -1805,6 +1806,7 @@ pub async fn ensure_chef_terminal(
     cols: u16,
     rows: u16,
     allow_spawn: Option<bool>,
+    shell_index: Option<u32>,
 ) -> Result<AgentInfo, String> {
     let repo_path = {
         let conn = state.db.lock().map_err(|e| e.to_string())?;
@@ -1812,7 +1814,13 @@ pub async fn ensure_chef_terminal(
             .map_err(|_| format!("workspace not found: {}", workspace_id))?
             .repo_path
     };
-    let key = format!("chef_{}", workspace_id);
+    // Shell 1 keeps the bare `chef_<ws>` key (back-compat with the single-shell
+    // session); additional shells are `chef_<ws>_<n>`. The key flows through the
+    // registry, bridge, and `pty:<key>:*` events unchanged.
+    let key = match shell_index {
+        Some(n) if n > 1 => format!("chef_{}_{}", workspace_id, n),
+        _ => format!("chef_{}", workspace_id),
+    };
     let allow_spawn = allow_spawn.unwrap_or(true);
     let mut registry = session_registry.lock().await;
 

--- a/src/components/layout/board.tsx
+++ b/src/components/layout/board.tsx
@@ -27,6 +27,7 @@ import { OrchestratorPanel } from '@/components/panel/orchestrator-panel'
 import { useDnd } from '@/hooks/use-dnd'
 import { useChatPanel } from '@/hooks/use-chat-panel'
 import { useUIStore } from '@/stores/ui-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import { CardPositionContext, useCardPositionProvider } from '@/hooks/use-card-positions'
 import { DepDragContext } from '@/hooks/use-dep-drag-context'
 import { BulkTaskToolbar } from '@/components/kanban/bulk-task-toolbar'
@@ -34,6 +35,7 @@ import { UsageBudgetBanner } from '@/components/usage/usage-budget-banner'
 
 export function Board() {
   const panelDock = useUIStore((s) => s.panelDock)
+  const orchestratorEnabled = useSettingsStore((s) => s.global.agent.orchestratorEnabled)
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
   const columns = useColumnStore((s) => s.columns)
   const loadColumns = useColumnStore((s) => s.load)
@@ -291,13 +293,13 @@ export function Board() {
             </div>
 
             {/* Orchestrator panel - bottom dock */}
-            {activeWorkspaceId && panelDock === 'bottom' && (
+            {orchestratorEnabled && activeWorkspaceId && panelDock === 'bottom' && (
               <OrchestratorPanel workspaceId={activeWorkspaceId} />
             )}
           </div>
 
           {/* Orchestrator panel - right dock */}
-          {activeWorkspaceId && panelDock === 'right' && (
+          {orchestratorEnabled && activeWorkspaceId && panelDock === 'right' && (
             <OrchestratorPanel workspaceId={activeWorkspaceId} />
           )}
 

--- a/src/components/panel/orchestrator-panel.tsx
+++ b/src/components/panel/orchestrator-panel.tsx
@@ -19,6 +19,8 @@ import { buildPromptWithAttachments } from '@/types'
 import { useCliPath } from '@/hooks/use-cli-path'
 import { ChatHistory } from './chat-history'
 import { OrchestratorTerminalView } from './orchestrator-terminal-view'
+import { killTaskSession } from '@/lib/ipc/agent'
+import { chefSessionKey } from '@/lib/ipc/terminal'
 import { WorkspaceFilesView } from './workspace-files-view'
 import { PanelTabs, type PanelTab } from '@/components/shared/panel-tabs'
 import { ChatIcon, TerminalIcon, FilesIcon } from '@/components/shared/tab-icons'
@@ -108,6 +110,9 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
   const [sidebarMode, setSidebarMode] = useState<'history' | 'dashboard' | 'v2-dashboard' | null>(null)
   const [viewMode, setViewMode] = useState<OrchestratorView>('chat')
   const [moreOpen, setMoreOpen] = useState(false)
+  // Chef terminal shells (1-based). `+` adds one while the Terminal view is active.
+  const [shells, setShells] = useState<number[]>([1])
+  const [activeShell, setActiveShell] = useState(1)
   const [localMessages, setLocalMessages] = useState<ChatMessage[]>([])
   const [messagesLoading, setMessagesLoading] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
@@ -252,6 +257,41 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
       console.error('[OrchestratorPanel] Failed to create new chat:', err)
     }
   }, [localMessages.length, activeSession, resetSession, createSession])
+
+  const handleAddShell = useCallback(() => {
+    setShells((prev) => {
+      const next = (prev.length ? Math.max(...prev) : 0) + 1
+      setActiveShell(next)
+      return [...prev, next]
+    })
+  }, [])
+
+  const handleCloseShell = useCallback((shell: number) => {
+    setShells((prev) => {
+      if (prev.length <= 1) return prev // never close the last shell
+      const remaining = prev.filter((s) => s !== shell)
+      setActiveShell((active) =>
+        active === shell ? (remaining[remaining.length - 1] ?? active) : active,
+      )
+      // Kill the underlying tmux session (chef shells are user-driven, no pipeline).
+      void killTaskSession(chefSessionKey(workspaceId, shell)).catch(() => {})
+      return remaining
+    })
+  }, [workspaceId])
+
+  // The `+` button is context-aware: it acts on whichever view is active.
+  const handlePlus = useCallback(() => {
+    if (viewMode === 'terminal') {
+      handleAddShell()
+    } else {
+      void handleNewChat()
+    }
+  }, [viewMode, handleAddShell, handleNewChat])
+
+  // `+` is shown on Chat (new chat) and Terminal (new shell); hidden on Files.
+  const plusVisible = viewMode !== 'files'
+  const plusDisabled = viewMode === 'chat' && localMessages.length === 0
+  const plusTitle = viewMode === 'terminal' ? 'New shell' : 'New chat'
 
   const handleSelectSession = useCallback((session: typeof activeSession) => {
     if (!session) return
@@ -426,19 +466,22 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
         <div className="flex shrink-0 items-center justify-self-end gap-1">
           {!isPanelCollapsed && (
             <>
-              <button
-                type="button"
-                onClick={() => { void handleNewChat() }}
-                disabled={localMessages.length === 0}
-                title="New chat"
-                aria-label="New chat"
-                className="flex h-6 w-6 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-secondary"
-                style={{ cursor: localMessages.length === 0 ? 'not-allowed' : 'pointer' }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
-                  <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
-                </svg>
-              </button>
+              {plusVisible && (
+                <button
+                  type="button"
+                  onClick={handlePlus}
+                  disabled={plusDisabled}
+                  title={plusTitle}
+                  aria-label={plusTitle}
+                  data-testid="orchestrator-plus"
+                  className="flex h-6 w-6 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+                  style={{ cursor: plusDisabled ? 'not-allowed' : 'pointer' }}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+                    <path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z" />
+                  </svg>
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() => { setPanelDock(isRightDock ? 'bottom' : 'right') }}
@@ -528,7 +571,13 @@ export function OrchestratorPanel({ workspaceId }: OrchestratorPanelProps) {
             <ChatErrorBoundary panelName="Orchestrator Chat">
               <div className="flex flex-1 flex-col overflow-hidden">
                 {viewMode === 'terminal' ? (
-                  <OrchestratorTerminalView workspaceId={workspaceId} />
+                  <OrchestratorTerminalView
+                    workspaceId={workspaceId}
+                    shells={shells}
+                    activeShell={activeShell}
+                    onSelectShell={setActiveShell}
+                    onCloseShell={handleCloseShell}
+                  />
                 ) : viewMode === 'files' ? (
                   <WorkspaceFilesView workspaceId={workspaceId} />
                 ) : (

--- a/src/components/panel/orchestrator-terminal-view.test.tsx
+++ b/src/components/panel/orchestrator-terminal-view.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import type { EnsureSessionFn } from '@/lib/ipc/terminal'
 
@@ -22,16 +22,53 @@ vi.mock('@/lib/ipc/terminal', async (importOriginal) => {
 
 import { OrchestratorTerminalView } from './orchestrator-terminal-view'
 
+const noop = () => {}
+
 describe('OrchestratorTerminalView', () => {
   it('points TerminalView at the chef session key and routes ensure to the chef command', async () => {
-    render(<OrchestratorTerminalView workspaceId="ws-1" />)
+    render(
+      <OrchestratorTerminalView
+        workspaceId="ws-1"
+        shells={[1]}
+        activeShell={1}
+        onSelectShell={noop}
+        onCloseShell={noop}
+      />,
+    )
 
     expect(captured.props?.taskId).toBe('chef_ws-1')
+    // Single shell → no tab strip.
+    expect(screen.queryByTestId('chef-shell-tabs')).not.toBeInTheDocument()
 
-    // The ensure strategy ignores the per-task id/cwd and targets the workspace.
     await captured.props?.ensure?.('chef_ws-1', '', 80, 24, true)
     await waitFor(() => {
-      expect(ensureChefTerminal).toHaveBeenCalledWith('ws-1', 80, 24, true)
+      expect(ensureChefTerminal).toHaveBeenCalledWith('ws-1', 80, 24, true, 1)
     })
+  })
+
+  it('shows a shell tab strip with multiple shells and targets the active shell session', () => {
+    const onSelectShell = vi.fn()
+    const onCloseShell = vi.fn()
+    render(
+      <OrchestratorTerminalView
+        workspaceId="ws-1"
+        shells={[1, 2]}
+        activeShell={2}
+        onSelectShell={onSelectShell}
+        onCloseShell={onCloseShell}
+      />,
+    )
+
+    // Tab strip visible; active shell drives the terminal session key.
+    expect(screen.getByTestId('chef-shell-tabs')).toBeInTheDocument()
+    expect(captured.props?.taskId).toBe('chef_ws-1_2')
+
+    // Switch to shell 1.
+    fireEvent.click(screen.getByTestId('chef-shell-tab-1'))
+    expect(onSelectShell).toHaveBeenCalledWith(1)
+
+    // Close shell 2.
+    fireEvent.click(screen.getByTestId('chef-shell-close-2'))
+    expect(onCloseShell).toHaveBeenCalledWith(2)
   })
 })

--- a/src/components/panel/orchestrator-terminal-view.tsx
+++ b/src/components/panel/orchestrator-terminal-view.tsx
@@ -4,22 +4,88 @@ import { ensureChefTerminal, chefSessionKey, type EnsureSessionFn } from '@/lib/
 
 /**
  * Workspace-level terminal for the chef/orchestrator panel. Reuses the per-task
- * `TerminalView` but points it at a `chef_<workspaceId>` session via the
+ * `TerminalView` but points it at a `chef_<workspaceId>[_n]` session via the
  * `ensureChefTerminal` strategy — a shell rooted at the repo the user can drive
  * `claude`/`codex` from without leaving the app.
+ *
+ * Supports multiple shells as a sub-tab strip (the panel header's `+` adds one
+ * when the Terminal view is active). Only the active shell renders; switching
+ * re-attaches its tmux session with restored scrollback, like task terminals.
  */
-export function OrchestratorTerminalView({ workspaceId }: { workspaceId: string }) {
+type OrchestratorTerminalViewProps = {
+  workspaceId: string
+  /** Shell indices currently open (1-based). At least `[1]`. */
+  shells: number[]
+  activeShell: number
+  onSelectShell: (shell: number) => void
+  onCloseShell: (shell: number) => void
+}
+
+export function OrchestratorTerminalView({
+  workspaceId,
+  shells,
+  activeShell,
+  onSelectShell,
+  onCloseShell,
+}: OrchestratorTerminalViewProps) {
   const ensure = useCallback<EnsureSessionFn>(
     (_id, _workingDir, cols, rows, allowSpawn) =>
-      ensureChefTerminal(workspaceId, cols, rows, allowSpawn),
-    [workspaceId],
+      ensureChefTerminal(workspaceId, cols, rows, allowSpawn, activeShell),
+    [workspaceId, activeShell],
   )
 
   return (
-    <TerminalView
-      taskId={chefSessionKey(workspaceId)}
-      workingDir=""
-      ensure={ensure}
-    />
+    <div className="flex h-full min-h-0 flex-col">
+      {shells.length > 1 && (
+        <div
+          data-testid="chef-shell-tabs"
+          className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border-default bg-surface px-2 py-1"
+        >
+          {shells.map((shell) => {
+            const isActive = shell === activeShell
+            return (
+              <div
+                key={shell}
+                className={`group flex items-center gap-1 rounded px-2 py-0.5 text-[11px] ${
+                  isActive
+                    ? 'bg-surface-hover text-text-primary'
+                    : 'text-text-secondary hover:bg-surface-hover/60'
+                }`}
+              >
+                <button
+                  type="button"
+                  data-testid={`chef-shell-tab-${String(shell)}`}
+                  onClick={() => { onSelectShell(shell) }}
+                  className="font-medium"
+                  style={{ cursor: isActive ? 'default' : 'pointer' }}
+                >
+                  Shell {shell}
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Close Shell ${String(shell)}`}
+                  data-testid={`chef-shell-close-${String(shell)}`}
+                  onClick={() => { onCloseShell(shell) }}
+                  className="rounded px-0.5 text-text-secondary/60 opacity-0 transition-opacity hover:text-text-primary group-hover:opacity-100"
+                  style={{ cursor: 'pointer' }}
+                >
+                  ×
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+      <div className="min-h-0 flex-1">
+        {/* Keyed by the session id so switching shells remounts the terminal
+            against the right `chef_<ws>[_n]` session. */}
+        <TerminalView
+          key={chefSessionKey(workspaceId, activeShell)}
+          taskId={chefSessionKey(workspaceId, activeShell)}
+          workingDir=""
+          ensure={ensure}
+        />
+      </div>
+    </div>
   )
 }

--- a/src/components/settings/tabs/agent-tab.tsx
+++ b/src/components/settings/tabs/agent-tab.tsx
@@ -651,6 +651,17 @@ export function AgentTab() {
       >
         <div className="space-y-5">
           <SettingRow
+            label="Show orchestrator panel"
+            description="The in-app chef that manages the board via chat. Turn off if you drive the board from an external agent (MCP / API) and don't need it."
+          >
+            <Toggle
+              checked={agent.orchestratorEnabled}
+              onChange={(checked) => { updateAgent({ orchestratorEnabled: checked }) }}
+              aria-label="Show orchestrator panel"
+            />
+          </SettingRow>
+
+          <SettingRow
             label="Default model"
             description="Used when the orchestrator decides, or when triggers / tasks don't specify a model."
             vertical

--- a/src/lib/ipc/terminal.ts
+++ b/src/lib/ipc/terminal.ts
@@ -50,23 +50,29 @@ export type EnsureSessionFn = (
   allowSpawn: boolean,
 ) => Promise<EnsureSessionInfo>
 
-/** Registry key (and `pty:<key>:*` event prefix) for a workspace chef terminal. */
-export function chefSessionKey(workspaceId: string): string {
-  return `chef_${workspaceId}`
+/**
+ * Registry key (and `pty:<key>:*` event prefix) for a workspace chef terminal.
+ * Shell 1 keeps the bare `chef_<ws>` key (back-compat); additional shells are
+ * `chef_<ws>_<n>`. Must match the key construction in `ensure_chef_terminal`.
+ */
+export function chefSessionKey(workspaceId: string, shellIndex = 1): string {
+  return shellIndex > 1 ? `chef_${workspaceId}_${String(shellIndex)}` : `chef_${workspaceId}`
 }
 
 /**
- * Ensure the workspace-level chef terminal (a shell rooted at the repo) exists.
- * Mirrors `ensurePtySession` but keyed by workspace; the returned `taskId` is
- * the `chef_<workspaceId>` session key the generic PTY IPC + events use.
+ * Ensure a workspace-level chef terminal shell (a shell rooted at the repo)
+ * exists. Mirrors `ensurePtySession` but keyed by workspace + shell index; the
+ * returned `taskId` is the `chef_<workspaceId>[_n]` session key the generic PTY
+ * IPC + events use.
  */
 export async function ensureChefTerminal(
   workspaceId: string,
   cols: number,
   rows: number,
   allowSpawn = true,
+  shellIndex = 1,
 ): Promise<EnsureSessionInfo> {
-  return invoke('ensure_chef_terminal', { workspaceId, cols, rows, allowSpawn })
+  return invoke('ensure_chef_terminal', { workspaceId, cols, rows, allowSpawn, shellIndex })
 }
 
 export type TransportType = 'pipe' | 'pty'

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -17,6 +17,9 @@ export type AgentConfig = {
   modelSelection: string // 'auto' = orchestrator decides, or specific model ID
   /** Default permission mode for new agent chats. 'plan' = read-only safe mode, 'full' = bypassPermissions (dangerous). */
   defaultPermissionMode: 'plan' | 'full'
+  /** Show the built-in orchestrator (chef) panel. Turn off if you drive the
+   *  board from an external agent and don't need the in-app chef. */
+  orchestratorEnabled: boolean
 }
 
 export type AgentMode = {
@@ -167,6 +170,7 @@ export const DEFAULT_SETTINGS: Settings = {
     instructionsFile: '',
     modelSelection: 'auto',
     defaultPermissionMode: 'plan',
+    orchestratorEnabled: true,
   },
   modes: [
     { id: 'code', name: 'Code', icon: 'code', prompt: 'Write clean, maintainable code', tools: ['read', 'write', 'bash'], isBuiltIn: true },


### PR DESCRIPTION
Two commits.

**feat(orchestrator): per-tab `+` + chef toggle**
- The orchestrator `+` is context-aware: Chat → new chat, Terminal → **new shell** (sub-tab strip: Shell 1, Shell 2… with close ×; each its own `chef_<ws>[_n]` tmux session), Files → hidden.
- Settings → Agent → **Show orchestrator panel** toggle (hide the in-app chef if you drive the board externally). Persisted, defaults on.

**docs(discord): MVP plan + epic refresh**
- `.tickets/discord/MVP-PLAN.md`: thin first slice (connect → task→thread → agent output streaming, one direction). Reply-routing/`#chef`/bidirectional stay later slices.
- E001 note confirming thread=task + thin-MVP-first, flagging architecture drift since it was written.

tsc · lint · clippy · cargo check · vitest (+2 terminal tests) green locally.