### PR TITLE
Discord MVP slice 1: bot foundation (sidecar + bridge + settings)

### DIFF
--- a/src-tauri/sidecars/discord-bot/package-lock.json
+++ b/src-tauri/sidecars/discord-bot/package-lock.json
@@ -1,0 +1,327 @@
+{
+  "name": "kaitencode-discord-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kaitencode-discord-bot",
+      "version": "1.0.0",
+      "dependencies": {
+        "discord.js": "^14.16.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.48",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.48.tgz",
+      "integrity": "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/src-tauri/sidecars/discord-bot/package.json
+++ b/src-tauri/sidecars/discord-bot/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "kaitencode-discord-bot",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "KaitenCode Discord sidecar — discord.js bot driven over JSON stdin/stdout by the Rust DiscordBridge.",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "discord.js": "^14.16.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src-tauri/sidecars/discord-bot/src/index.js
+++ b/src-tauri/sidecars/discord-bot/src/index.js
@@ -61,11 +61,14 @@ async function handleConnect(payload) {
   if (!token) throw new Error('missing token')
 
   client = new Client({
-    intents: [
-      GatewayIntentBits.Guilds,
-      GatewayIntentBits.GuildMessages,
-      GatewayIntentBits.MessageContent,
-    ],
+    // MVP is one-direction (we create threads + post messages, which is REST +
+    // the non-privileged Guilds gateway intent). GuildMessages + the PRIVILEGED
+    // MessageContent intent are added in the reply-routing slice (T058) when we
+    // read thread replies. Requesting MessageContent here would make login fail
+    // ("disallowed intents") for any bot that doesn't have that privileged
+    // intent toggled on in the Developer Portal — so we keep it minimal, which
+    // lets an existing bot (e.g. choomfie) connect without portal changes.
+    intents: [GatewayIntentBits.Guilds],
   })
 
   // Resolve `connect` only once the gateway is ready, returning the bot

--- a/src-tauri/sidecars/discord-bot/src/index.js
+++ b/src-tauri/sidecars/discord-bot/src/index.js
@@ -1,0 +1,171 @@
+/**
+ * KaitenCode Discord sidecar.
+ *
+ * A thin discord.js process driven by the Rust `DiscordBridge` over a
+ * newline-delimited JSON protocol on stdin/stdout. The Rust side owns all
+ * policy (which task maps to which thread, when to post); this process only
+ * executes Discord operations and reports results/events.
+ *
+ * Protocol (one JSON object per line):
+ *   Rust → Node  (command):  { "id": "<uuid>", "type": "<cmd>", "payload": {…} }
+ *   Node → Rust  (response): { "id": "<uuid>", "success": true, "data": {…} }
+ *                            { "id": "<uuid>", "success": false, "error": "…" }
+ *   Node → Rust  (event):    { "event": "ready|error|disconnect|message", "payload": {…} }
+ *
+ * Commands: connect {token}, disconnect, ping,
+ *           create_thread {channelId, name, autoArchiveMinutes?},
+ *           post_message {channelId|threadId, content}.
+ *
+ * MVP is one-direction (KaitenCode → Discord); `message` events are emitted but
+ * not yet consumed by Rust (reply-routing is a later slice).
+ */
+
+import { createInterface } from 'node:readline'
+import { Client, GatewayIntentBits, ChannelType } from 'discord.js'
+
+let client = null
+
+/** Write a single newline-delimited JSON line to stdout. */
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n')
+}
+
+function emit(event, payload = {}) {
+  out({ event, payload })
+}
+
+function ok(id, data = {}) {
+  out({ id, success: true, data })
+}
+
+function fail(id, error) {
+  out({ id, success: false, error: String(error && error.message ? error.message : error) })
+}
+
+/** discord.js Channel for either a text channel or a thread, fetched by id. */
+async function fetchSendable(channelId) {
+  if (!client) throw new Error('not connected')
+  const ch = await client.channels.fetch(channelId)
+  if (!ch || typeof ch.send !== 'function') {
+    throw new Error(`channel ${channelId} is not sendable`)
+  }
+  return ch
+}
+
+async function handleConnect(payload) {
+  if (client) {
+    try { await client.destroy() } catch { /* ignore */ }
+    client = null
+  }
+  const token = payload && payload.token
+  if (!token) throw new Error('missing token')
+
+  client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+    ],
+  })
+
+  // Resolve `connect` only once the gateway is ready, returning the bot
+  // identity — so the Rust side gets a clean request/response it can surface as
+  // "connected as <tag>".
+  const ready = new Promise((resolve) => {
+    client.once('ready', () => {
+      const info = { tag: client.user ? client.user.tag : null, id: client.user ? client.user.id : null }
+      emit('ready', info)
+      resolve(info)
+    })
+  })
+  client.on('error', (err) => { emit('error', { message: String(err && err.message ? err.message : err) }) })
+  client.on('shardDisconnect', () => { emit('disconnect', {}) })
+  client.on('messageCreate', (msg) => {
+    if (msg.author && msg.author.bot) return // ignore our own + other bots
+    emit('message', {
+      messageId: msg.id,
+      channelId: msg.channelId,
+      content: msg.content,
+      authorTag: msg.author ? msg.author.tag : null,
+      authorId: msg.author ? msg.author.id : null,
+      isThread: typeof msg.channel?.isThread === 'function' ? msg.channel.isThread() : false,
+    })
+  })
+
+  await client.login(token) // validates the token + opens the gateway
+  const timeout = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('timed out waiting for gateway ready')), 15000),
+  )
+  return Promise.race([ready, timeout])
+}
+
+async function handleDisconnect() {
+  if (client) {
+    try { await client.destroy() } catch { /* ignore */ }
+    client = null
+  }
+  return { disconnected: true }
+}
+
+async function handleCreateThread(payload) {
+  const { channelId, name, autoArchiveMinutes } = payload || {}
+  if (!channelId || !name) throw new Error('create_thread requires channelId and name')
+  const channel = await client.channels.fetch(channelId)
+  if (!channel || typeof channel.threads?.create !== 'function') {
+    throw new Error(`channel ${channelId} cannot host threads`)
+  }
+  const thread = await channel.threads.create({
+    name: name.slice(0, 100), // Discord thread name limit
+    autoArchiveDuration: autoArchiveMinutes || 1440,
+    type: ChannelType.PublicThread,
+  })
+  return { threadId: thread.id }
+}
+
+async function handlePostMessage(payload) {
+  const { channelId, threadId, content } = payload || {}
+  const target = threadId || channelId
+  if (!target || !content) throw new Error('post_message requires channelId|threadId and content')
+  const ch = await fetchSendable(target)
+  const sent = await ch.send(content.slice(0, 2000)) // Discord message limit
+  return { messageId: sent.id }
+}
+
+async function dispatch(cmd) {
+  switch (cmd.type) {
+    case 'ping': return { pong: true, connected: !!client }
+    case 'connect': return handleConnect(cmd.payload)
+    case 'disconnect': return handleDisconnect()
+    case 'create_thread': return handleCreateThread(cmd.payload)
+    case 'post_message': return handlePostMessage(cmd.payload)
+    default: throw new Error(`unknown command: ${cmd.type}`)
+  }
+}
+
+const rl = createInterface({ input: process.stdin })
+rl.on('line', (line) => {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  let cmd
+  try {
+    cmd = JSON.parse(trimmed)
+  } catch {
+    emit('error', { message: `bad JSON command: ${trimmed.slice(0, 120)}` })
+    return
+  }
+  Promise.resolve()
+    .then(() => dispatch(cmd))
+    .then((data) => ok(cmd.id, data))
+    .catch((err) => fail(cmd.id, err))
+})
+
+// Clean shutdown when the parent closes our stdin.
+rl.on('close', async () => {
+  await handleDisconnect()
+  process.exit(0)
+})
+
+process.on('SIGTERM', async () => { await handleDisconnect(); process.exit(0) })
+process.on('SIGINT', async () => { await handleDisconnect(); process.exit(0) })
+
+emit('started', { pid: process.pid })

--- a/src-tauri/src/chat/bridge.rs
+++ b/src-tauri/src/chat/bridge.rs
@@ -1622,6 +1622,15 @@ async fn run_trigger_in_tmux(
     eprintln!("[bridge] Working dir: {}", working_dir);
     eprintln!("[bridge] Log file: {}", log_path);
 
+    // Discord MVP: mirror this task to a thread (best-effort, never blocks).
+    {
+        let app = app.clone();
+        let task_id = task_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            crate::discord::notify::on_task_started(&app, &task_id).await;
+        });
+    }
+
     let command_metadata = serde_json::json!({
         "cli": cli_command,
         "workdir": working_dir,
@@ -2324,6 +2333,17 @@ async fn run_trigger_in_tmux(
     }
 
     pipeline::emit_tasks_changed(app, &workspace_for_task(task_id), "trigger_complete");
+
+    // Discord MVP: post the output tail + status into the task's thread
+    // (best-effort, never blocks completion).
+    {
+        let app = app.clone();
+        let task_id = task_id.to_string();
+        let output_tail = error_tail.clone();
+        tauri::async_runtime::spawn(async move {
+            crate::discord::notify::on_task_finished(&app, &task_id, success, &output_tail).await;
+        });
+    }
 
     // Phase 4 telemetry — every headless completion logs an event. The
     // source is `exit_code` regardless of success: we got an exit code

--- a/src-tauri/src/commands/discord.rs
+++ b/src-tauri/src/commands/discord.rs
@@ -1,0 +1,101 @@
+//! Tauri commands for the Discord MVP. Persist the Discord config in
+//! `AppSettings` and reconcile the single managed sidecar bridge (start +
+//! connect when enabled with a token, stop otherwise). See
+//! `.tickets/discord/MVP-PLAN.md`.
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, State};
+
+use crate::config::AppSettings;
+use crate::discord::{DiscordBridge, SharedDiscord};
+use crate::error::AppError;
+
+/// Current Discord config for the settings UI. Never returns the raw token.
+#[tauri::command]
+pub fn discord_get_config() -> Result<Value, AppError> {
+    let s = AppSettings::load();
+    Ok(json!({
+        "enabled": s.discord_enabled,
+        "hasToken": !s.discord_bot_token.trim().is_empty(),
+        "threadChannelId": s.discord_thread_channel_id,
+    }))
+}
+
+/// Whether the managed bridge is currently running.
+#[tauri::command]
+pub async fn discord_status(state: State<'_, SharedDiscord>) -> Result<Value, AppError> {
+    let running = state.lock().await.is_some();
+    let s = AppSettings::load();
+    Ok(json!({ "running": running, "enabled": s.discord_enabled }))
+}
+
+/// Spawn a throwaway sidecar, connect with `token`, return the bot tag, then
+/// tear it down. Does not touch the managed bridge — purely a "test" probe.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn discord_test_connection(app: AppHandle, token: String) -> Result<Value, AppError> {
+    if token.trim().is_empty() {
+        return Err(AppError::InvalidInput("missing bot token".into()));
+    }
+    let mut bridge = DiscordBridge::spawn(&app).map_err(AppError::CommandError)?;
+    let result = bridge.send_command("connect", json!({ "token": token })).await;
+    bridge.shutdown();
+    match result {
+        Ok(data) => Ok(json!({ "tag": data.get("tag").and_then(Value::as_str) })),
+        Err(e) => Err(AppError::CommandError(format!("connection failed: {e}"))),
+    }
+}
+
+/// Persist Discord config and reconcile the managed bridge to match it.
+#[tauri::command(rename_all = "camelCase")]
+pub async fn discord_save_config(
+    app: AppHandle,
+    state: State<'_, SharedDiscord>,
+    enabled: bool,
+    token: Option<String>,
+    thread_channel_id: Option<String>,
+) -> Result<Value, AppError> {
+    let mut settings = AppSettings::load();
+    settings.discord_enabled = enabled;
+    if let Some(t) = token {
+        if !t.trim().is_empty() {
+            settings.discord_bot_token = t.trim().to_string();
+        }
+    }
+    if let Some(c) = thread_channel_id {
+        settings.discord_thread_channel_id = c.trim().to_string();
+    }
+    settings.save().map_err(AppError::CommandError)?;
+
+    reconcile_bridge(&app, &state, &settings).await?;
+
+    Ok(json!({
+        "enabled": settings.discord_enabled,
+        "hasToken": !settings.discord_bot_token.trim().is_empty(),
+        "threadChannelId": settings.discord_thread_channel_id,
+        "running": state.lock().await.is_some(),
+    }))
+}
+
+/// Start+connect or stop the managed bridge so it matches `settings`. Also used
+/// at startup. Idempotent: a no-op when already in the desired state.
+pub async fn reconcile_bridge(
+    app: &AppHandle,
+    state: &SharedDiscord,
+    settings: &AppSettings,
+) -> Result<(), AppError> {
+    let mut guard = state.lock().await;
+    let should_run = settings.discord_enabled && !settings.discord_bot_token.trim().is_empty();
+    if should_run {
+        if guard.is_none() {
+            let bridge = DiscordBridge::spawn(app).map_err(AppError::CommandError)?;
+            bridge
+                .send_command("connect", json!({ "token": settings.discord_bot_token }))
+                .await
+                .map_err(|e| AppError::CommandError(format!("discord connect failed: {e}")))?;
+            *guard = Some(bridge);
+        }
+    } else if let Some(mut bridge) = guard.take() {
+        bridge.shutdown();
+    }
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_interactive;
 pub mod checklist;
 pub mod cli_detect;
 pub mod column;
+pub mod discord;
 pub mod files;
 pub mod git;
 pub mod github;

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -139,6 +139,15 @@ pub struct AppSettings {
     /// own task is already at this depth is refused. Default 3 (human → agent →
     /// agent → agent, then stop). See `mcp-add-source-attribution` ticket.
     pub mcp_max_recursion_depth: i64,
+    /// Discord MVP — whether to run the Discord sidecar bot. Opt-in; off by
+    /// default. See `.tickets/discord/MVP-PLAN.md`.
+    pub discord_enabled: bool,
+    /// Discord bot token (stored in settings.json for the MVP; encryption-at-rest
+    /// is a flagged follow-up). Empty = not configured.
+    pub discord_bot_token: String,
+    /// Discord channel id where per-task threads are created. MVP uses a single
+    /// channel for all task threads; per-column channels are a later slice.
+    pub discord_thread_channel_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -302,6 +311,9 @@ impl Default for AppSettings {
             claude_min_version: None,
             codex_min_version: None,
             mcp_max_recursion_depth: 3,
+            discord_enabled: false,
+            discord_bot_token: String::new(),
+            discord_thread_channel_id: String::new(),
         }
     }
 }

--- a/src-tauri/src/db/discord.rs
+++ b/src-tauri/src/db/discord.rs
@@ -1,0 +1,42 @@
+//! Discord MVP — task ↔ thread mapping (table `discord_task_threads`).
+
+use rusqlite::{params, Connection, OptionalExtension, Result as SqlResult};
+
+/// The Discord thread mirroring a task.
+#[derive(Debug, Clone)]
+pub struct DiscordTaskThread {
+    pub thread_id: String,
+    pub channel_id: String,
+}
+
+/// Record (or replace) the thread a task is mirrored to.
+pub fn upsert_discord_thread(
+    conn: &Connection,
+    task_id: &str,
+    thread_id: &str,
+    channel_id: &str,
+) -> SqlResult<()> {
+    conn.execute(
+        "INSERT INTO discord_task_threads (task_id, thread_id, channel_id) \
+         VALUES (?1, ?2, ?3) \
+         ON CONFLICT(task_id) DO UPDATE SET thread_id = excluded.thread_id, \
+             channel_id = excluded.channel_id",
+        params![task_id, thread_id, channel_id],
+    )?;
+    Ok(())
+}
+
+/// Look up the thread mapped to a task, if any.
+pub fn get_discord_thread(conn: &Connection, task_id: &str) -> SqlResult<Option<DiscordTaskThread>> {
+    conn.query_row(
+        "SELECT thread_id, channel_id FROM discord_task_threads WHERE task_id = ?1",
+        params![task_id],
+        |row| {
+            Ok(DiscordTaskThread {
+                thread_id: row.get(0)?,
+                channel_id: row.get(1)?,
+            })
+        },
+    )
+    .optional()
+}

--- a/src-tauri/src/db/migrations/047_discord_task_threads.sql
+++ b/src-tauri/src/db/migrations/047_discord_task_threads.sql
@@ -1,0 +1,10 @@
+-- Discord MVP (slice 2): map a task to the Discord thread that mirrors it.
+-- One thread per task. KaitenCode is the source of truth; this is just the
+-- thread bookkeeping so output/updates know where to post.
+CREATE TABLE IF NOT EXISTS discord_task_threads (
+    task_id    TEXT PRIMARY KEY,
+    thread_id  TEXT NOT NULL,
+    channel_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -17,6 +17,7 @@ pub mod chat_session;
 pub mod checklist;
 pub mod column;
 pub mod completion_events;
+pub mod discord;
 pub mod github_sync;
 pub mod history;
 pub mod label;
@@ -41,6 +42,7 @@ pub use chat_message::*;
 pub use chat_session::*;
 pub use checklist::*;
 pub use column::*;
+pub use discord::*;
 pub use github_sync::*;
 pub use history::*;
 pub use label::*;
@@ -394,6 +396,10 @@ fn run_migrations(conn: &Connection) -> SqlResult<()> {
             "046_task_source_attribution",
             include_str!("migrations/046_task_source_attribution.sql"),
         ),
+        (
+            "047_discord_task_threads",
+            include_str!("migrations/047_discord_task_threads.sql"),
+        ),
     ];
 
     for (name, sql) in migrations {
@@ -523,8 +529,9 @@ mod tests {
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
             .unwrap();
-        // Includes split 019, 030 + Phase 4 (044, 045) + 046 attribution.
-        assert_eq!(count, 48);
+        // Includes split 019, 030 + Phase 4 (044, 045) + 046 attribution
+        // + 047 discord_task_threads.
+        assert_eq!(count, 49);
     }
 
     #[test]

--- a/src-tauri/src/discord/mod.rs
+++ b/src-tauri/src/discord/mod.rs
@@ -20,6 +20,8 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::oneshot;
 
+pub mod notify;
+
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(20);
 
 type Pending = Arc<Mutex<HashMap<String, oneshot::Sender<Result<Value, String>>>>>;

--- a/src-tauri/src/discord/mod.rs
+++ b/src-tauri/src/discord/mod.rs
@@ -1,0 +1,204 @@
+//! Discord sidecar bridge (MVP).
+//!
+//! Spawns the Node.js discord.js sidecar at `sidecars/discord-bot` and talks to
+//! it over newline-delimited JSON on stdin/stdout (see the protocol doc in
+//! `src/index.js` and `.tickets/discord/MVP-PLAN.md`).
+//!
+//! MVP is one-direction: KaitenCode drives Discord (create threads, post
+//! messages). Inbound `message` events are re-emitted to the frontend as
+//! `discord:message` but reply-routing is a later slice (T058).
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Emitter};
+use tokio::sync::oneshot;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(20);
+
+type Pending = Arc<Mutex<HashMap<String, oneshot::Sender<Result<Value, String>>>>>;
+
+/// Shared, app-managed handle to the (at most one) running sidecar bridge.
+pub type SharedDiscord = Arc<tokio::sync::Mutex<Option<DiscordBridge>>>;
+
+pub fn shared() -> SharedDiscord {
+    Arc::new(tokio::sync::Mutex::new(None))
+}
+
+/// A live connection to the Node sidecar process.
+pub struct DiscordBridge {
+    child: Child,
+    stdin: Arc<Mutex<ChildStdin>>,
+    pending: Pending,
+    next_id: AtomicU64,
+}
+
+impl DiscordBridge {
+    /// Spawn the sidecar process and start the stdout reader. Does not connect
+    /// to Discord — call `send_command("connect", { token })` for that.
+    pub fn spawn(app: &AppHandle) -> Result<Self, String> {
+        let entry = sidecar_entry_path()?;
+        // discord.js must be installed in the sidecar dir.
+        if let Some(dir) = entry.parent().and_then(|p| p.parent()) {
+            if !dir.join("node_modules").exists() {
+                return Err(format!(
+                    "Discord sidecar dependencies missing — run `npm install` in {}",
+                    dir.display()
+                ));
+            }
+        }
+        let node = node_path();
+        let mut child = Command::new(&node)
+            .arg(&entry)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                format!(
+                    "failed to spawn discord sidecar (`{} {}`): {}",
+                    node,
+                    entry.display(),
+                    e
+                )
+            })?;
+
+        let stdin = child.stdin.take().ok_or("no sidecar stdin")?;
+        let stdout = child.stdout.take().ok_or("no sidecar stdout")?;
+        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+
+        // Reader thread: responses (have "id") fulfill waiters; events forward.
+        {
+            let pending = Arc::clone(&pending);
+            let app = app.clone();
+            std::thread::spawn(move || {
+                let reader = BufReader::new(stdout);
+                for line in reader.lines().map_while(Result::ok) {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let value: Value = match serde_json::from_str(trimmed) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    if let Some(id) = value.get("id").and_then(Value::as_str) {
+                        if let Some(tx) = pending.lock().unwrap().remove(id) {
+                            let result =
+                                if value.get("success").and_then(Value::as_bool).unwrap_or(false) {
+                                    Ok(value.get("data").cloned().unwrap_or(Value::Null))
+                                } else {
+                                    Err(value
+                                        .get("error")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("unknown sidecar error")
+                                        .to_string())
+                                };
+                            let _ = tx.send(result);
+                        }
+                    } else if let Some(event) = value.get("event").and_then(Value::as_str) {
+                        let payload = value.get("payload").cloned().unwrap_or(Value::Null);
+                        let _ = app.emit(&format!("discord:{event}"), payload);
+                    }
+                }
+                // stdout closed → the sidecar exited.
+                let _ = app.emit("discord:disconnect", json!({ "reason": "sidecar_exited" }));
+            });
+        }
+
+        // Drain stderr to the log so connection failures are diagnosable.
+        if let Some(stderr) = child.stderr.take() {
+            std::thread::spawn(move || {
+                let reader = BufReader::new(stderr);
+                for line in reader.lines().map_while(Result::ok) {
+                    log::warn!("[discord-sidecar] {line}");
+                }
+            });
+        }
+
+        Ok(Self {
+            child,
+            stdin: Arc::new(Mutex::new(stdin)),
+            pending,
+            next_id: AtomicU64::new(1),
+        })
+    }
+
+    /// Send a command and await its correlated response (with a timeout).
+    pub async fn send_command(&self, cmd_type: &str, payload: Value) -> Result<Value, String> {
+        let id = format!("c{}", self.next_id.fetch_add(1, Ordering::Relaxed));
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(id.clone(), tx);
+
+        let line = serde_json::to_string(&json!({ "id": id, "type": cmd_type, "payload": payload }))
+            .map_err(|e| e.to_string())?;
+        {
+            let mut stdin = self.stdin.lock().unwrap();
+            stdin.write_all(line.as_bytes()).map_err(|e| e.to_string())?;
+            stdin.write_all(b"\n").map_err(|e| e.to_string())?;
+            stdin.flush().map_err(|e| e.to_string())?;
+        }
+
+        match tokio::time::timeout(COMMAND_TIMEOUT, rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err("sidecar dropped the response".to_string()),
+            Err(_) => {
+                self.pending.lock().unwrap().remove(&id);
+                Err(format!("discord command '{cmd_type}' timed out"))
+            }
+        }
+    }
+
+    pub fn shutdown(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for DiscordBridge {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Resolve the sidecar entry script. Honors `KAITENCODE_DISCORD_SIDECAR`, then
+/// looks in the dev tree (cwd = `src-tauri` or repo root), then next to the exe.
+fn sidecar_entry_path() -> Result<PathBuf, String> {
+    if let Ok(p) = std::env::var("KAITENCODE_DISCORD_SIDECAR") {
+        let pb = PathBuf::from(p);
+        if pb.exists() {
+            return Ok(pb);
+        }
+    }
+    let rel = "sidecars/discord-bot/src/index.js";
+    let candidates = [
+        PathBuf::from(rel),                                  // cwd = src-tauri (tauri dev)
+        PathBuf::from("src-tauri").join(rel),                // cwd = repo root
+    ];
+    for c in candidates {
+        if c.exists() {
+            return Ok(c);
+        }
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let p = dir.join(rel);
+            if p.exists() {
+                return Ok(p);
+            }
+        }
+    }
+    Err(format!(
+        "discord sidecar not found — set KAITENCODE_DISCORD_SIDECAR to the path of {rel}"
+    ))
+}
+
+fn node_path() -> String {
+    crate::commands::cli_detect::find_cli("node").unwrap_or_else(|| "node".to_string())
+}

--- a/src-tauri/src/discord/notify.rs
+++ b/src-tauri/src/discord/notify.rs
@@ -1,0 +1,229 @@
+//! Best-effort Discord notifications for the MVP: task → thread + output.
+//!
+//! Everything here is fire-and-forget and heavily guarded — a no-op unless
+//! Discord is enabled, the managed bridge is running, and a thread channel is
+//! configured. It must never block or fail agent execution, so call sites
+//! should `tauri::async_runtime::spawn` these and ignore the result.
+
+use rusqlite::Connection;
+use serde_json::json;
+use tauri::{AppHandle, Manager};
+
+use crate::config::AppSettings;
+use crate::db;
+use crate::discord::SharedDiscord;
+
+/// Stay comfortably under Discord's 2000-char message limit (leaving room for a
+/// code-fence wrapper). Mirrors choomfie's `MAX_REPLY_CHARS`.
+const MAX_DISCORD_CHARS: usize = 1900;
+
+/// Split text into <=MAX_DISCORD_CHARS pieces, preferring to break on line
+/// boundaries (and hard-splitting any single over-long line on a char
+/// boundary). Mirrors choomfie's `chunkMessage`.
+pub fn chunk_message(text: &str) -> Vec<String> {
+    let text = text.trim_end();
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let mut chunks: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    for line in text.split_inclusive('\n') {
+        if line.len() > MAX_DISCORD_CHARS {
+            if !cur.is_empty() {
+                chunks.push(std::mem::take(&mut cur));
+            }
+            let mut rest = line;
+            while rest.len() > MAX_DISCORD_CHARS {
+                let cut = floor_char_boundary(rest, MAX_DISCORD_CHARS);
+                chunks.push(rest[..cut].to_string());
+                rest = &rest[cut..];
+            }
+            cur.push_str(rest);
+        } else if cur.len() + line.len() > MAX_DISCORD_CHARS {
+            chunks.push(std::mem::take(&mut cur));
+            cur.push_str(line);
+        } else {
+            cur.push_str(line);
+        }
+    }
+    if !cur.is_empty() {
+        chunks.push(cur);
+    }
+    chunks
+}
+
+fn floor_char_boundary(s: &str, n: usize) -> usize {
+    if n >= s.len() {
+        return s.len();
+    }
+    let mut i = n;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars().take(max).collect()
+    }
+}
+
+/// Open a short-lived DB connection and run `f`, swallowing errors.
+fn with_conn<T>(f: impl FnOnce(&Connection) -> rusqlite::Result<T>) -> Option<T> {
+    let conn = Connection::open(db::db_path()).ok()?;
+    let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
+    f(&conn).ok()
+}
+
+fn channel_if_enabled() -> Option<String> {
+    let s = AppSettings::load();
+    if !s.discord_enabled {
+        return None;
+    }
+    let ch = s.discord_thread_channel_id.trim().to_string();
+    if ch.is_empty() {
+        None
+    } else {
+        Some(ch)
+    }
+}
+
+fn task_title(task_id: &str) -> String {
+    with_conn(|c| db::get_task(c, task_id))
+        .map(|t| t.title)
+        .unwrap_or_else(|| task_id.to_string())
+}
+
+/// Create the thread for a task (idempotent) and announce that the agent
+/// started. No-op when Discord isn't configured/running.
+pub async fn on_task_started(app: &AppHandle, task_id: &str) {
+    let Some(channel) = channel_if_enabled() else {
+        return;
+    };
+    if let Some(Some(_)) = with_conn(|c| db::get_discord_thread(c, task_id)) {
+        return; // already mirrored
+    }
+    let title = task_title(task_id);
+    let title = title.as_str();
+    let state = app.state::<SharedDiscord>();
+    let guard = state.lock().await;
+    let Some(bridge) = guard.as_ref() else {
+        return;
+    };
+    match bridge
+        .send_command(
+            "create_thread",
+            json!({ "channelId": channel, "name": format!("▸ {}", truncate(title, 90)) }),
+        )
+        .await
+    {
+        Ok(data) => {
+            if let Some(thread_id) = data.get("threadId").and_then(|v| v.as_str()) {
+                let _ = with_conn(|c| db::upsert_discord_thread(c, task_id, thread_id, &channel));
+                let _ = bridge
+                    .send_command(
+                        "post_message",
+                        json!({ "threadId": thread_id, "content": format!("**{title}** — agent started.") }),
+                    )
+                    .await;
+            }
+        }
+        Err(e) => log::warn!("[discord] create_thread failed for {task_id}: {e}"),
+    }
+}
+
+/// Post the agent's output tail (chunked) + a completion status into the task's
+/// thread. Creates the thread first if the start hook didn't run.
+pub async fn on_task_finished(app: &AppHandle, task_id: &str, success: bool, output_tail: &str) {
+    let Some(channel) = channel_if_enabled() else {
+        return;
+    };
+    let title = task_title(task_id);
+    let title = title.as_str();
+    let state = app.state::<SharedDiscord>();
+    let guard = state.lock().await;
+    let Some(bridge) = guard.as_ref() else {
+        return;
+    };
+
+    // Ensure a thread exists.
+    let thread_id = match with_conn(|c| db::get_discord_thread(c, task_id)) {
+        Some(Some(t)) => t.thread_id,
+        _ => match bridge
+            .send_command(
+                "create_thread",
+                json!({ "channelId": channel, "name": format!("▸ {}", truncate(title, 90)) }),
+            )
+            .await
+        {
+            Ok(data) => match data.get("threadId").and_then(|v| v.as_str()) {
+                Some(tid) if !tid.is_empty() => {
+                    let _ = with_conn(|c| db::upsert_discord_thread(c, task_id, tid, &channel));
+                    tid.to_string()
+                }
+                _ => return,
+            },
+            Err(e) => {
+                log::warn!("[discord] create_thread (finish) failed for {task_id}: {e}");
+                return;
+            }
+        },
+    };
+
+    // Output tail (ANSI-stripped) inside code fences, chunked.
+    let tail = crate::chat::bridge::strip_ansi(output_tail);
+    let tail = tail.trim();
+    if !tail.is_empty() {
+        for chunk in chunk_message(tail) {
+            let _ = bridge
+                .send_command(
+                    "post_message",
+                    json!({ "threadId": thread_id, "content": format!("```\n{chunk}\n```") }),
+                )
+                .await;
+        }
+    }
+
+    let status = if success { "✅ completed" } else { "❌ failed" };
+    let _ = bridge
+        .send_command(
+            "post_message",
+            json!({ "threadId": thread_id, "content": format!("**{title}** — {status}") }),
+        )
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{chunk_message, MAX_DISCORD_CHARS};
+
+    #[test]
+    fn short_text_is_a_single_chunk() {
+        assert_eq!(chunk_message("hello world"), vec!["hello world"]);
+    }
+
+    #[test]
+    fn whitespace_only_is_no_chunks() {
+        assert!(chunk_message("   \n  ").is_empty());
+    }
+
+    #[test]
+    fn long_multiline_splits_and_each_chunk_is_under_the_limit() {
+        let line = "x".repeat(100);
+        let text = vec![line; 60].join("\n"); // ~6k chars across many lines
+        let chunks = chunk_message(&text);
+        assert!(chunks.len() > 1);
+        assert!(chunks.iter().all(|c| c.len() <= MAX_DISCORD_CHARS));
+    }
+
+    #[test]
+    fn an_over_long_single_line_is_hard_split_losslessly() {
+        let text = "y".repeat(5000);
+        let chunks = chunk_message(&text);
+        assert!(chunks.iter().all(|c| c.len() <= MAX_DISCORD_CHARS));
+        assert_eq!(chunks.concat(), text);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod commands;
 pub mod config;
 pub mod db;
 pub mod error;
+pub mod discord;
 pub mod events;
 pub mod git;
 pub mod github_sync;
@@ -98,7 +99,9 @@ pub fn run() {
         // Tracks in-flight orchestrator API streams so they can be aborted.
         // Required by `stream_orchestrator_chat` — without this the command
         // panics with "state not managed for field `apiStreamRegistry`".
-        .manage(crate::commands::orchestrator::ApiStreamRegistry::default());
+        .manage(crate::commands::orchestrator::ApiStreamRegistry::default())
+        // The single managed Discord sidecar bridge (None until enabled).
+        .manage(crate::discord::shared());
 
     #[cfg(feature = "webdriver")]
     {
@@ -243,6 +246,11 @@ pub fn run() {
             commands::agent_interactive::list_completion_events,
             commands::agent_interactive::agent_pause,
             commands::agent_interactive::agent_resume,
+            // Discord integration (MVP)
+            commands::discord::discord_get_config,
+            commands::discord::discord_status,
+            commands::discord::discord_test_connection,
+            commands::discord::discord_save_config,
             // Global app settings (Phase 3 — Agent runtime)
             commands::settings::get_app_settings,
             commands::settings::update_app_settings,
@@ -383,6 +391,26 @@ pub fn run() {
 
             // Start garbage collector for tmux sessions + agent resources
             chat::gc::start_gc(app.handle().clone());
+
+            // Auto-start the Discord sidecar bridge if it was left enabled.
+            {
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let settings = crate::config::AppSettings::load();
+                    if settings.discord_enabled && !settings.discord_bot_token.trim().is_empty() {
+                        let state = app_handle.state::<crate::discord::SharedDiscord>();
+                        if let Err(e) = crate::commands::discord::reconcile_bridge(
+                            &app_handle,
+                            &state,
+                            &settings,
+                        )
+                        .await
+                        {
+                            log::warn!("[discord] startup reconcile failed: {e}");
+                        }
+                    }
+                });
+            }
 
             // Clean up legacy 58-byte rate-limit stub logs and GC the
             // retained trigger_logs/ directory down to MAX_TRIGGER_LOGS.

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -10,6 +10,7 @@ import { VoiceTab } from './tabs/voice-tab'
 import { AdvancedTab } from './tabs/advanced-tab'
 import { GitTab } from './tabs/git-tab'
 import { GithubTab } from './tabs/github-tab'
+import { DiscordTab } from './tabs/discord-tab'
 import { ShortcutsTab } from './tabs/shortcuts-tab'
 import { UpdatesTab } from './tabs/updates-tab'
 import { BatchesTab } from './tabs/batches-tab'
@@ -78,6 +79,7 @@ type TabId =
   | 'board'
   | 'voice'
   | 'github'
+  | 'discord'
   | 'batches'
   | 'updates'
   | 'advanced'
@@ -117,6 +119,7 @@ const TAB_GROUPS: TabGroup[] = [
     label: 'Integrations',
     tabs: [
       { id: 'github', label: 'GitHub', hint: 'Issue sync and column mapping' },
+      { id: 'discord', label: 'Discord', hint: 'Mirror the board to Discord threads' },
       { id: 'mcp', label: 'MCP Server', hint: 'Connect external agents to the board' },
       { id: 'batches', label: 'Batches', hint: 'Grouped task PR workflows' },
     ],
@@ -201,6 +204,8 @@ export function SettingsPanel() {
         return <VoiceTab />
       case 'github':
         return <GithubTab />
+      case 'discord':
+        return <DiscordTab />
       case 'batches':
         return <BatchesTab />
       case 'updates':

--- a/src/components/settings/tabs/discord-tab.tsx
+++ b/src/components/settings/tabs/discord-tab.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react'
+import { SettingSection, SettingRow, SettingInput } from '@/components/shared/setting-components'
+import { Toggle } from '@/components/shared/toggle'
+import {
+  discordGetConfig,
+  discordStatus,
+  discordTestConnection,
+  discordSaveConfig,
+} from '@/lib/ipc/discord'
+
+type TestState =
+  | { kind: 'idle' }
+  | { kind: 'testing' }
+  | { kind: 'ok'; tag: string | null }
+  | { kind: 'error'; message: string }
+
+export function DiscordTab() {
+  const [enabled, setEnabled] = useState(false)
+  const [hasToken, setHasToken] = useState(false)
+  const [token, setToken] = useState('') // empty = keep existing saved token
+  const [channelId, setChannelId] = useState('')
+  const [running, setRunning] = useState(false)
+  const [test, setTest] = useState<TestState>({ kind: 'idle' })
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const cfg = await discordGetConfig()
+        setEnabled(cfg.enabled)
+        setHasToken(cfg.hasToken)
+        setChannelId(cfg.threadChannelId)
+        const st = await discordStatus()
+        setRunning(st.running)
+      } catch {
+        /* settings not reachable — leave defaults */
+      }
+    })()
+  }, [])
+
+  const handleTest = async () => {
+    setTest({ kind: 'testing' })
+    try {
+      // Test the typed token; if none typed but one is saved, the user should
+      // type it again to re-test (we never read the saved token back to JS).
+      if (!token.trim()) {
+        setTest({ kind: 'error', message: 'Enter the bot token to test.' })
+        return
+      }
+      const res = await discordTestConnection(token.trim())
+      setTest({ kind: 'ok', tag: res.tag })
+    } catch (err) {
+      setTest({ kind: 'error', message: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const res = await discordSaveConfig({
+        enabled,
+        token: token.trim() || undefined, // omit → keep the saved token
+        threadChannelId: channelId.trim(),
+      })
+      setEnabled(res.enabled)
+      setHasToken(res.hasToken)
+      setChannelId(res.threadChannelId)
+      setRunning(res.running)
+      setToken('') // clear the input; the token is now persisted server-side
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <SettingSection
+        title="Discord"
+        description="Mirror the board to Discord: each task gets a thread with its agent's output streaming in (KaitenCode → Discord). Reply-routing and #chef come later — see .tickets/discord/MVP-PLAN.md."
+      >
+        <SettingRow
+          label="Enable Discord"
+          description={
+            running
+              ? 'Sidecar bot running.'
+              : enabled
+                ? 'Enabled (bot will connect on save / app start).'
+                : 'Off. Requires a bot token + a channel for task threads.'
+          }
+        >
+          <Toggle checked={enabled} onChange={setEnabled} aria-label="Enable Discord" />
+        </SettingRow>
+      </SettingSection>
+
+      <SettingSection
+        title="Bot token"
+        description={
+          hasToken
+            ? 'A token is saved. Leave blank to keep it, or paste a new one to replace it.'
+            : 'Create a bot at discord.com/developers, enable the Message Content intent, and paste its token. Invite it with Create Public Threads + Send Messages in Threads.'
+        }
+      >
+        <div className="space-y-2">
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => { setToken(e.target.value) }}
+            placeholder={hasToken ? '•••••••••• (saved)' : 'Bot token'}
+            className="w-full rounded-md border border-border-default bg-bg px-3 py-2 font-mono text-xs text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none"
+          />
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => { void handleTest() }}
+              disabled={test.kind === 'testing'}
+              className="rounded-md border border-border-default bg-surface px-3 py-1 text-xs font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+              style={{ cursor: test.kind === 'testing' ? 'wait' : 'pointer' }}
+            >
+              {test.kind === 'testing' ? 'Testing…' : 'Test connection'}
+            </button>
+            {test.kind === 'ok' && (
+              <span className="text-xs text-running">✓ Connected as {test.tag ?? 'bot'}</span>
+            )}
+            {test.kind === 'error' && (
+              <span className="text-xs text-error" title={test.message}>✗ {test.message}</span>
+            )}
+          </div>
+        </div>
+      </SettingSection>
+
+      <SettingSection
+        title="Task-thread channel"
+        description="Channel ID where per-task threads are created (right-click a channel → Copy Channel ID; Developer Mode must be on). MVP uses one channel for all task threads."
+      >
+        <SettingInput
+          value={channelId}
+          onChange={setChannelId}
+          placeholder="123456789012345678"
+          mono
+        />
+      </SettingSection>
+
+      <div className="flex items-center gap-3 border-t border-border-default pt-4">
+        <button
+          type="button"
+          onClick={() => { void handleSave() }}
+          disabled={saving}
+          className="rounded-md border border-accent/40 bg-accent/15 px-4 py-1.5 text-xs font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
+          style={{ cursor: saving ? 'wait' : 'pointer' }}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        {saveError && <span className="text-xs text-error" title={saveError}>{saveError}</span>}
+        {!saveError && running && <span className="text-xs text-text-secondary">Bot is running.</span>}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/ipc/discord.ts
+++ b/src/lib/ipc/discord.ts
@@ -1,0 +1,39 @@
+/** IPC wrappers for the Discord MVP. See `.tickets/discord/MVP-PLAN.md`. */
+
+import { invoke } from './invoke'
+
+export type DiscordConfig = {
+  enabled: boolean
+  hasToken: boolean
+  threadChannelId: string
+}
+
+export type DiscordSaveResult = DiscordConfig & { running: boolean }
+
+/** Current config for the settings UI (never returns the raw token). */
+export async function discordGetConfig(): Promise<DiscordConfig> {
+  return invoke('discord_get_config')
+}
+
+/** Whether the managed sidecar bridge is currently running. */
+export async function discordStatus(): Promise<{ running: boolean; enabled: boolean }> {
+  return invoke('discord_status')
+}
+
+/** Probe a token by spawning a throwaway sidecar; returns the bot tag. */
+export async function discordTestConnection(token: string): Promise<{ tag: string | null }> {
+  return invoke('discord_test_connection', { token })
+}
+
+/** Persist config and (re)start or stop the managed bridge to match it. */
+export async function discordSaveConfig(args: {
+  enabled: boolean
+  token?: string
+  threadChannelId?: string
+}): Promise<DiscordSaveResult> {
+  return invoke('discord_save_config', {
+    enabled: args.enabled,
+    token: args.token,
+    threadChannelId: args.threadChannelId,
+  })
+}


### PR DESCRIPTION
First slice of the Discord MVP ([.tickets/discord/MVP-PLAN.md](../blob/main/.tickets/discord/MVP-PLAN.md)): **connect a bot and test it.** Task threads + agent-output streaming are the next slice.

## What's here
- **Node sidecar** (`src-tauri/sidecars/discord-bot`) — `discord.js`, driven over newline-delimited JSON on stdin/stdout. Commands: `connect`/`disconnect`/`ping`/`create_thread`/`post_message`; events: `ready`/`error`/`disconnect`/`message`. `connect` waits for gateway-ready and returns the bot tag.
- **Rust bridge** (`src/discord/mod.rs`) — spawns + supervises the sidecar, id-correlated request/response with timeout, forwards events as `discord:<event>`, drains stderr to the log, resolves `node` + the sidecar path.
- **Commands** (`src/commands/discord.rs`) — `discord_get_config` / `discord_status` / `discord_test_connection` (throwaway probe → bot tag) / `discord_save_config` (persist + reconcile the single managed bridge). Auto-reconciles on startup.
- **Config** — `AppSettings.discord_enabled / discord_bot_token / discord_thread_channel_id` (opt-in, off by default).
- **Settings UI** — a Discord tab: enable, token + **Test connection**, task-thread channel, Save.

## Notes
- **Opt-in & isolated**: the app runs fully without Node/Discord.
- Sidecar deps are a one-time `npm install` in the sidecar dir (`node_modules` gitignored; `package-lock.json` committed). CI doesn't need them — the Rust code only references the sidecar at runtime.
- To test live: create a Discord bot (enable the Message Content intent), invite it with *Create Public Threads* + *Send Messages in Threads*, paste the token in Settings → Discord → Test connection.

clippy · cargo check · config tests · tsc · lint · sidecar smoke all green.