### PR TITLE
Unbreak `npm run dev` (broken by the dependency refresh)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,16 @@ import path from 'path'
 
 const host = process.env.TAURI_DEV_HOST
 
+// Vite's default 'modules' target, with Safari raised 14 -> 15: esbuild >=0.28
+// works around a Safari 14 destructuring bug via a transform it cannot apply to
+// @dnd-kit's code, so a safari14 target fails. Safari 15 shipped for macOS Big
+// Sur, so this does not narrow real support.
+//
+// This MUST be applied to the dep optimizer as well as the build: optimizeDeps
+// has its own esbuild target and does NOT inherit build.target, so setting only
+// the latter leaves `vite dev` failing on @dnd-kit while `vite build` passes.
+const ESBUILD_TARGET = ['es2020', 'edge88', 'firefox78', 'chrome87', 'safari15']
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -17,12 +27,19 @@ export default defineConfig({
     dedupe: ['react', 'react-dom'],
   },
   clearScreen: false,
+  // Dev-mode dependency pre-bundling. Without this, `vite dev` (and therefore
+  // `tauri dev` and the WebDriver E2E harness) dies on @dnd-kit.
+  optimizeDeps: {
+    // Scan ONLY the real entry point. Vite's default dep scan globs every HTML
+    // file in the project root, which here means docs/ mockups, the Playwright
+    // report, site/, and Tauri's codegen assets — any of which can kill the dev
+    // server with an unrelated parse error (a docs page using top-level await
+    // did exactly that). None of them are app entry points.
+    entries: ['index.html'],
+    esbuildOptions: { target: ESBUILD_TARGET },
+  },
   build: {
-    // Vite's default 'modules' target, with Safari raised 14 -> 15: esbuild >=0.28
-    // works around a Safari 14 destructuring bug via a transform it cannot apply to
-    // @dnd-kit's code, so a safari14 target fails the build. Safari 15 shipped for
-    // macOS Big Sur, so this does not narrow real support.
-    target: ['es2020', 'edge88', 'firefox78', 'chrome87', 'safari15'],
+    target: ESBUILD_TARGET,
     rollupOptions: {
       output: {
         // Split heavy vendors out of the single ~1.5 MB app chunk so the webview


### PR DESCRIPTION
Found while setting up the WebDriver E2E harness to test the Roster: `npm run dev` is broken on `main`.

## What broke

#265 raised the esbuild target `safari14 → safari15` to work around an esbuild ≥0.28 issue with `@dnd-kit`, but set it only on `build.target`. **`optimizeDeps` runs its own esbuild pass and does not inherit `build.target`**, so dependency pre-bundling was still targeting safari14:

```
✘ [ERROR] Transforming destructuring to the configured target environment
  ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
  is not supported yet
  node_modules/@dnd-kit/utilities/dist/utilities.esm.js
```

`vite build` passed the whole time, which is why CI never caught it — nothing in CI runs `vite dev`.

Both now share a single `ESBUILD_TARGET` const, so this is harder to half-update next time.

## And a second, older problem it uncovered

With that fixed, dev still died — Vite's dependency scanner globs **every HTML file in the project root**:

```
Failed to scan for dependencies from entries:
  docs/ARCHITECTURE_SHOWCASE.html
  docs/agent-panel-transcript-mockups.html
  playwright-report/index.html
  site/index.html
  target/release/build/.../tauri-codegen-assets/....html
✘ [ERROR] Top-level await is not available in the configured target environment
```

A docs mockup using top-level `await` for mermaid was enough to take the dev server down. None of those are app entry points, so the scan is now scoped to `index.html` — which also means a stray HTML file in the repo can't break dev any more.

## Why it matters

`tauri dev` and the WebDriver E2E harness both start from `vite dev`, so this blocked all interactive development and all real E2E testing.

## Verification

- `npm run dev` → HTTP 200 on :1420, zero esbuild errors (was: dead)
- production build unchanged in shape (691 kB / 181 kB gzip main chunk)
- `tsc --noEmit`, `eslint src/` clean