### PR TITLE
Roster: title into the tab bar, flip the split, rebuild the config view

### DIFF
--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -24,6 +24,7 @@ import { useChecklistStore } from '@/stores/checklist-store'
 import { useTaskStore } from '@/stores/task-store'
 import { Tooltip } from '@/components/shared/tooltip'
 import { SectionSwitcher } from './section-switcher'
+import { useUIStore } from '@/stores/ui-store'
 import type { Workspace } from '@/types'
 import { CostBadge, MetricsDashboard } from '@/components/usage'
 import { AddWorkspaceDialog } from './add-workspace-dialog'
@@ -91,7 +92,9 @@ function SortableTab({
         style={{ cursor: 'pointer' }}
       >
         <span className="flex items-center">
-          <span className="max-w-[64px] truncate text-center sm:max-w-[120px]">{workspace.name}</span>
+          <span className="max-w-[64px] truncate text-center sm:max-w-[120px]">
+            {workspace.name}
+          </span>
           {activeTaskCount > 0 && (
             <span className="ml-1 hidden rounded-full bg-primary/20 px-1.5 text-xs text-primary sm:inline">
               {activeTaskCount}
@@ -199,7 +202,9 @@ function ShowArchivedButton() {
   return (
     <Tooltip content={showArchived ? 'Hide archived' : 'Show archived'} side="bottom">
       <motion.button
-        onClick={() => { setShowArchived(!showArchived) }}
+        onClick={() => {
+          setShowArchived(!showArchived)
+        }}
         aria-label={showArchived ? 'Hide archived workspaces' : 'Show archived workspaces'}
         aria-pressed={showArchived}
         whileHover={{ scale: 1.05 }}
@@ -212,7 +217,11 @@ function ShowArchivedButton() {
       >
         <svg viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
           <path d="M2 3a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1H2Z" />
-          <path fillRule="evenodd" d="M2 7.5h16l-.811 7.71a2 2 0 0 1-1.99 1.79H4.802a2 2 0 0 1-1.99-1.79L2 7.5Zm5.22 1.72a.75.75 0 0 1 1.06 0L10 10.94l1.72-1.72a.75.75 0 1 1 1.06 1.06l-2.25 2.25a.75.75 0 0 1-1.06 0l-2.25-2.25a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M2 7.5h16l-.811 7.71a2 2 0 0 1-1.99 1.79H4.802a2 2 0 0 1-1.99-1.79L2 7.5Zm5.22 1.72a.75.75 0 0 1 1.06 0L10 10.94l1.72-1.72a.75.75 0 1 1 1.06 1.06l-2.25 2.25a.75.75 0 0 1-1.06 0l-2.25-2.25a.75.75 0 0 1 0-1.06Z"
+            clipRule="evenodd"
+          />
         </svg>
       </motion.button>
     </Tooltip>
@@ -233,7 +242,11 @@ function ChecklistButton() {
     <Tooltip content="Checklist" side="bottom">
       <motion.button
         onClick={openChecklist}
-        aria-label={hasItems ? `Checklist (${String(total - progress)} of ${String(total)} remaining)` : 'Checklist'}
+        aria-label={
+          hasItems
+            ? `Checklist (${String(total - progress)} of ${String(total)} remaining)`
+            : 'Checklist'
+        }
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
         className="relative flex h-8 w-8 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
@@ -273,6 +286,7 @@ export function TabBar() {
   const setActive = useWorkspaceStore((s) => s.setActive)
   const reorder = useWorkspaceStore((s) => s.reorder)
   const remove = useWorkspaceStore((s) => s.remove)
+  const activeSection = useUIStore((s) => s.activeSection)
 
   const getUnviewedCount = useAttentionStore((s) => s.getUnviewedCount)
 
@@ -294,7 +308,9 @@ export function TabBar() {
     activeWorkspaceId,
     setActive,
     remove,
-    openAddDialog: () => { setShowAddDialog(true) },
+    openAddDialog: () => {
+      setShowAddDialog(true)
+    },
   })
 
   // ─── Drag Handlers ──────────────────────────────────────────────────────────
@@ -333,35 +349,42 @@ export function TabBar() {
             right-hand cluster so the header reads as one row of controls. */}
         <SectionSwitcher />
 
-        {/* Center: tabs - absolutely positioned for true centering */}
+        {/* Center: workspace tabs on the board, the section name everywhere
+            else. Agents are global, so a workspace selector in the Roster is
+            chrome that does nothing — showing the section name instead gives
+            the view the title its own header used to carry. */}
         <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-1">
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext items={workspaceIds} strategy={horizontalListSortingStrategy}>
-              <AnimatePresence mode="popLayout">
-                {sortedWorkspaces.map((workspace) => (
-                  <SortableTab
-                    key={workspace.id}
-                    workspace={workspace}
-                    isActive={workspace.id === activeWorkspaceId}
-                    activeTaskCount={workspace.activeTaskCount}
-                    notificationCount={getUnviewedCount(workspace.id)}
-                    onSelect={() => {
-                      setActive(workspace.id)
-                    }}
-                  />
-                ))}
-              </AnimatePresence>
-            </SortableContext>
+          {activeSection !== 'board' ? (
+            <span className="text-sm font-medium text-text-primary">Roster</span>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={workspaceIds} strategy={horizontalListSortingStrategy}>
+                <AnimatePresence mode="popLayout">
+                  {sortedWorkspaces.map((workspace) => (
+                    <SortableTab
+                      key={workspace.id}
+                      workspace={workspace}
+                      isActive={workspace.id === activeWorkspaceId}
+                      activeTaskCount={workspace.activeTaskCount}
+                      notificationCount={getUnviewedCount(workspace.id)}
+                      onSelect={() => {
+                        setActive(workspace.id)
+                      }}
+                    />
+                  ))}
+                </AnimatePresence>
+              </SortableContext>
 
-            <DragOverlay>
-              {draggingWorkspace && <TabOverlay workspace={draggingWorkspace} />}
-            </DragOverlay>
-          </DndContext>
+              <DragOverlay>
+                {draggingWorkspace && <TabOverlay workspace={draggingWorkspace} />}
+              </DragOverlay>
+            </DndContext>
+          )}
         </div>
 
         {/* Right: add workspace + checklist + cost + settings.
@@ -382,7 +405,9 @@ export function TabBar() {
           {activeWorkspaceId && (
             <CostBadge
               workspaceId={activeWorkspaceId}
-              onOpenDashboard={() => { setShowDashboard(true) }}
+              onOpenDashboard={() => {
+                setShowDashboard(true)
+              }}
             />
           )}
           <SettingsButton />
@@ -400,7 +425,9 @@ export function TabBar() {
       {showDashboard && activeWorkspaceId && (
         <MetricsDashboard
           workspaceId={activeWorkspaceId}
-          onClose={() => { setShowDashboard(false) }}
+          onClose={() => {
+            setShowDashboard(false)
+          }}
         />
       )}
     </>

--- a/src/components/roster/agent-dossier.tsx
+++ b/src/components/roster/agent-dossier.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import type { Agent, LlmConfig, ScriptRuntimeConfig } from '@/types'
 import { parseAgentAvatar, parseAgentConfig } from '@/types'
 import { useRosterStore } from '@/stores/roster-store'
@@ -6,146 +6,256 @@ import { useRosterStore } from '@/stores/roster-store'
 /**
  * The runtime-typed dossier — the load-bearing idea of the roster.
  *
- * Universal fields up top, then a block whose *shape* is chosen by the agent's
- * runtime: a script agent shows command/args/env; an LLM agent swaps those for
- * system prompt / model / MCP set / skills.
+ * Universal identity across the top, then configuration grouped into cards
+ * whose *set* is chosen by the agent's runtime: a script agent gets
+ * command/arguments/environment; an LLM agent gets instructions/model/tools/
+ * skills. Grouping beats one flat key-value list because these fields are not
+ * peers — a system prompt is prose, a model is a token, an MCP path is a
+ * filesystem path you'll want to copy elsewhere.
  *
- * Slots that aren't wired yet render visibly disabled with a `v2` tag rather
- * than being hidden, so the dossier stays honest about what the app can
- * actually do today.
+ * Cards that can't do anything yet are shown disabled with a `v2` tag rather
+ * than hidden, so the dossier stays honest about what the app can do today.
  */
 
-function Row({
-  label,
-  children,
+function Section({
+  title,
+  count,
+  wide = false,
   v2 = false,
+  children,
 }: {
-  label: string
-  children: ReactNode
+  title: string
+  count?: number
+  /** Span both columns — for prose, which reads badly in a narrow column. */
+  wide?: boolean
   v2?: boolean
+  children: ReactNode
 }) {
   return (
-    <div
-      className={`flex items-start gap-3 border-b border-border-default py-2 ${v2 ? 'opacity-50' : ''}`}
+    <section
+      className={`rounded-lg border border-border-default bg-surface ${wide ? 'xl:col-span-2' : ''} ${
+        v2 ? 'opacity-60' : ''
+      }`}
     >
-      <span className="w-16 shrink-0 pt-0.5 font-mono text-[11px] text-text-secondary">
-        {label}
-      </span>
-      <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 text-sm text-text-primary">
-        {children}
-      </span>
-      {v2 && (
-        <span className="mt-0.5 shrink-0 rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">
-          v2
-        </span>
-      )}
-    </div>
+      <header className="flex items-center gap-2 border-b border-border-default px-4 py-2.5">
+        <h4 className="text-xs font-semibold text-text-primary">{title}</h4>
+        {count !== undefined && count > 0 && (
+          <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+            {count}
+          </span>
+        )}
+        {v2 && (
+          <span className="ml-auto rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+            v2
+          </span>
+        )}
+      </header>
+      <div className="px-4 py-3">{children}</div>
+    </section>
   )
 }
 
-function Token({ children }: { children: ReactNode }) {
+/**
+ * A monospace value. Paths, commands and tool ids get click-to-copy, because
+ * those are things people paste somewhere else.
+ */
+function CodeValue({ value, copyable = false }: { value: string; copyable?: boolean }) {
+  const [copied, setCopied] = useState(false)
+
+  if (!copyable) {
+    return (
+      <span className="rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] text-text-primary">
+        {value}
+      </span>
+    )
+  }
+
   return (
-    <span className="rounded border border-border-default bg-surface px-1.5 py-0.5 font-mono text-[11px] text-text-primary">
-      {children}
-    </span>
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard
+          .writeText(value)
+          .then(() => {
+            setCopied(true)
+            window.setTimeout(() => {
+              setCopied(false)
+            }, 1200)
+          })
+          .catch(() => {
+            // Clipboard access can be denied; the value stays readable on screen.
+          })
+      }}
+      title="Copy"
+      style={{ cursor: 'pointer' }}
+      className="group inline-flex max-w-full items-center gap-1.5 rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] text-text-primary transition-colors hover:border-text-secondary"
+    >
+      <span className="truncate">{value}</span>
+      <span className="shrink-0">
+        {copied ? (
+          <svg viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 text-success">
+            <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-6.5 6.5a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 1 1 1.06-1.06L6.75 10.19l5.97-5.97a.75.75 0 0 1 1.06 0Z" />
+          </svg>
+        ) : (
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="h-3 w-3 text-text-secondary opacity-0 transition-opacity group-hover:opacity-100"
+          >
+            <path d="M3.5 2A1.5 1.5 0 0 0 2 3.5v7A1.5 1.5 0 0 0 3.5 12H5v1.5A1.5 1.5 0 0 0 6.5 15h6a1.5 1.5 0 0 0 1.5-1.5v-7A1.5 1.5 0 0 0 12.5 5H11V3.5A1.5 1.5 0 0 0 9.5 2h-6Zm7.5 4V3.5a.5.5 0 0 0-.5-.5h-6a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .5.5H5V6.5A1.5 1.5 0 0 1 6.5 5H11Z" />
+          </svg>
+        )}
+      </span>
+    </button>
   )
 }
 
 function Empty({ children }: { children: ReactNode }) {
-  return <span className="text-sm text-text-secondary">{children}</span>
+  return <p className="text-sm text-text-secondary">{children}</p>
 }
 
-function SectionLabel({ children }: { children: ReactNode }) {
+/** Label/value pair inside a card, for fields that genuinely are peers. */
+function Field({
+  label,
+  wideLabel = false,
+  children,
+}: {
+  label: string
+  /** For env var names and other long keys that shouldn't truncate. */
+  wideLabel?: boolean
+  children: ReactNode
+}) {
   return (
-    <div className="mb-1 mt-5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary/70">
-      {children}
+    <div className="flex items-baseline gap-3 py-1">
+      <span
+        className={`${wideLabel ? 'w-40' : 'w-28'} shrink-0 truncate font-mono text-[11px] text-text-secondary`}
+        title={label}
+      >
+        {label}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">{children}</span>
     </div>
   )
 }
 
-function LlmBlock({ config }: { config: LlmConfig }) {
+function LlmSections({ config }: { config: LlmConfig }) {
   const resolveSkills = useRosterStore((s) => s.resolveSkills)
   const skills = resolveSkills(config.skillIds)
 
   return (
     <>
-      <SectionLabel>Configuration</SectionLabel>
-      <Row label="prompt">
+      <Section title="Instructions" wide>
         {config.systemPrompt ? (
-          <span className="whitespace-pre-wrap break-words">{config.systemPrompt}</span>
+          // Prose gets a measure cap: the pane is wide enough to run ~150
+          // characters per line, which is well past comfortable reading.
+          <p className="max-w-prose whitespace-pre-wrap break-words text-sm leading-relaxed text-text-primary">
+            {config.systemPrompt}
+          </p>
         ) : (
-          <Empty>No system prompt — the CLI default applies.</Empty>
+          <Empty>No system prompt. The CLI&apos;s own default applies.</Empty>
         )}
-      </Row>
-      <Row label="model">
-        {config.model ? <Token>{config.model}</Token> : <Empty>CLI default</Empty>}
-      </Row>
-      <Row label="mcp">
-        {config.mcpConfigPath ? <Token>{config.mcpConfigPath}</Token> : <Empty>Not set</Empty>}
-      </Row>
-      <Row label="tools">
-        {config.allowedTools.length > 0 ? (
-          config.allowedTools.map((t) => <Token key={t}>{t}</Token>)
-        ) : (
-          <Empty>All tools allowed</Empty>
-        )}
-      </Row>
-      <Row label="skills">
+      </Section>
+
+      <Section title="Model">
+        <Field label="Model">
+          {config.model ? (
+            <CodeValue value={config.model} />
+          ) : (
+            <span className="text-sm text-text-secondary">CLI default</span>
+          )}
+        </Field>
+        <Field label="Runtime">
+          <CodeValue value={config.runtime} />
+        </Field>
+      </Section>
+
+      <Section title="Tools" count={config.allowedTools.length}>
+        <Field label="MCP config">
+          {config.mcpConfigPath ? (
+            <CodeValue value={config.mcpConfigPath} copyable />
+          ) : (
+            <span className="text-sm text-text-secondary">Not set</span>
+          )}
+        </Field>
+        <Field label="Allowed">
+          {config.allowedTools.length > 0 ? (
+            config.allowedTools.map((t) => <CodeValue key={t} value={t} copyable />)
+          ) : (
+            <span className="text-sm text-text-secondary">
+              {config.mcpConfigPath ? 'All tools' : 'All tools (no MCP configured)'}
+            </span>
+          )}
+        </Field>
+      </Section>
+
+      <Section title="Skills" count={skills.length}>
         {skills.length > 0 ? (
-          skills.map((skill, i) =>
-            skill ? (
-              <Token key={skill.id}>{skill.name}</Token>
-            ) : (
-              // A skill can be deleted while agents still reference it. Say so
-              // rather than silently dropping it from the list.
-              <span
-                key={`missing-${String(i)}`}
-                className="rounded bg-error/10 px-1.5 py-0.5 text-[10px] font-medium text-error"
-              >
-                Missing skill
-              </span>
-            ),
-          )
+          <div className="flex flex-wrap gap-1.5">
+            {skills.map((skill, i) =>
+              skill ? (
+                <span
+                  key={skill.id}
+                  className="rounded bg-surface-hover px-2 py-0.5 text-xs text-text-primary"
+                  title={skill.description || undefined}
+                >
+                  {skill.name}
+                </span>
+              ) : (
+                // A skill can be deleted while agents still reference it. Say
+                // so rather than silently dropping it from the list.
+                <span
+                  key={`missing-${String(i)}`}
+                  className="rounded bg-error/10 px-2 py-0.5 text-xs font-medium text-error"
+                  title="This skill no longer exists. Edit the agent to detach it."
+                >
+                  Missing skill
+                </span>
+              ),
+            )}
+          </div>
         ) : (
-          <Empty>None attached</Empty>
+          <Empty>None attached.</Empty>
         )}
-      </Row>
-      <Row label="rag" v2>
-        <Empty>Retrieval lands in a later phase.</Empty>
-      </Row>
+      </Section>
+
+      <Section title="Retrieval" v2>
+        <Empty>Giving an agent its own document set lands in a later phase.</Empty>
+      </Section>
     </>
   )
 }
 
-function ScriptBlock({ config }: { config: ScriptRuntimeConfig }) {
+function ScriptSections({ config }: { config: ScriptRuntimeConfig }) {
   const envEntries = Object.entries(config.env)
   return (
     <>
-      <SectionLabel>Configuration</SectionLabel>
-      <Row label="command">
-        {config.command ? <Token>{config.command}</Token> : <Empty>Not set</Empty>}
-      </Row>
-      <Row label="args">
-        {config.args.length > 0 ? (
-          config.args.map((a, i) => <Token key={`${a}-${String(i)}`}>{a}</Token>)
+      <Section title="Command" count={config.args.length} wide>
+        {config.command ? (
+          // One line, exactly what gets run, copyable. Listing each argument
+          // separately as well said the same thing twice.
+          <CodeValue value={[config.command, ...config.args].join(' ')} copyable />
         ) : (
-          <Empty>None</Empty>
+          <Empty>No command set. This agent can&apos;t run until one is.</Empty>
         )}
-      </Row>
-      <Row label="env">
+      </Section>
+
+      <Section title="Environment" count={envEntries.length}>
         {envEntries.length > 0 ? (
-          envEntries.map(([k, v]) => (
-            <Token key={k}>
-              {k}={v}
-            </Token>
-          ))
+          <div className="flex flex-col gap-1">
+            {envEntries.map(([k, v]) => (
+              <Field key={k} label={k} wideLabel>
+                <CodeValue value={v} />
+              </Field>
+            ))}
+          </div>
         ) : (
-          <Empty>None</Empty>
+          <Empty>No overrides. The agent inherits the app&apos;s environment.</Empty>
         )}
-      </Row>
-      <Row label="outputs" v2>
-        <Empty>Typed artifacts land in a later phase.</Empty>
-      </Row>
+      </Section>
+
+      <Section title="Outputs" v2>
+        <Empty>Typed artifacts a downstream agent can consume land in a later phase.</Empty>
+      </Section>
     </>
   )
 }
@@ -165,52 +275,71 @@ export function AgentDossier({
   const config = parseAgentConfig(agent.config, agent.runtime)
 
   return (
-    <div className="flex flex-col p-6 lg:h-full" data-testid="agent-dossier">
-      <div
-        className="flex h-24 w-full max-w-[380px] shrink-0 items-center justify-center rounded-lg"
-        style={{
-          background: `linear-gradient(140deg, ${avatar.gradientFrom}, ${avatar.gradientTo})`,
-        }}
-      >
-        <span className="font-mono text-4xl font-bold text-white">{avatar.initials}</span>
+    <div className="flex h-full flex-col overflow-y-auto" data-testid="agent-dossier">
+      {/* Identity band — portrait beside the name rather than above it, so the
+          wider pane doesn't carry a stretched banner across the top. */}
+      <div className="flex items-center gap-4 border-b border-border-default px-6 py-4">
+        <div
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg"
+          style={{
+            background: `linear-gradient(140deg, ${avatar.gradientFrom}, ${avatar.gradientTo})`,
+          }}
+        >
+          <span className="font-mono text-lg font-bold text-white">{avatar.initials}</span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-base font-semibold text-text-primary">{agent.name}</h3>
+          <p className="mt-0.5 truncate text-xs text-text-secondary">
+            {agent.role || 'No description yet.'}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={onEdit}
+            data-testid="agent-edit"
+            style={{ cursor: 'pointer' }}
+            className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-bg transition-opacity hover:opacity-90"
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={onDuplicate}
+            data-testid="agent-duplicate"
+            style={{ cursor: 'pointer' }}
+            className="rounded-lg border border-border-default px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary"
+          >
+            Duplicate
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label="Delete agent"
+            title="Delete agent"
+            data-testid="agent-delete"
+            style={{ cursor: 'pointer' }}
+            className="rounded-lg border border-border-default p-2 text-text-secondary transition-colors hover:border-error/40 hover:text-error"
+          >
+            <svg viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4" aria-hidden="true">
+              <path
+                fillRule="evenodd"
+                d="M8.75 1a.75.75 0 0 0-.75.75V3h-3.5a.75.75 0 0 0 0 1.5h11a.75.75 0 0 0 0-1.5H12V1.75a.75.75 0 0 0-.75-.75h-2.5ZM5.06 6l.66 9.26A2 2 0 0 0 7.71 17h4.58a2 2 0 0 0 1.99-1.74L14.94 6H5.06Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
 
-      <h3 className="mt-4 text-base font-semibold text-text-primary">{agent.name}</h3>
-      <p className="mt-0.5 text-xs text-text-secondary">{agent.role || 'No description yet.'}</p>
-      <span className="mt-3 self-start rounded bg-surface-hover px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-text-secondary">
-        {agent.runtime}
-      </span>
-
-      {config.runtime === 'script' ? <ScriptBlock config={config} /> : <LlmBlock config={config} />}
-
-      <div className="mt-6 flex flex-wrap gap-2">
-        <button
-          type="button"
-          onClick={onEdit}
-          data-testid="agent-edit"
-          style={{ cursor: 'pointer' }}
-          className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-bg transition-opacity hover:opacity-90"
-        >
-          Edit
-        </button>
-        <button
-          type="button"
-          onClick={onDuplicate}
-          data-testid="agent-duplicate"
-          style={{ cursor: 'pointer' }}
-          className="rounded-lg border border-border-default px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary"
-        >
-          Duplicate
-        </button>
-        <button
-          type="button"
-          onClick={onDelete}
-          data-testid="agent-delete"
-          style={{ cursor: 'pointer' }}
-          className="rounded-lg border border-border-default px-4 py-2 text-sm text-error transition-colors hover:bg-error/10"
-        >
-          Delete
-        </button>
+      <div className="flex-1 px-6 py-5">
+        <div className="grid items-start gap-3 xl:grid-cols-2">
+          {config.runtime === 'script' ? (
+            <ScriptSections config={config} />
+          ) : (
+            <LlmSections config={config} />
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/roster/roster-view.test.tsx
+++ b/src/components/roster/roster-view.test.tsx
@@ -74,16 +74,18 @@ describe('RosterView', () => {
     render(<RosterView />)
 
     fireEvent.click(screen.getByTestId('agent-tile-a1'))
-    // LLM agent: prompt/model/skills, no command.
-    expect(screen.getByText('prompt')).toBeInTheDocument()
-    expect(screen.getByText('model')).toBeInTheDocument()
-    expect(screen.queryByText('command')).not.toBeInTheDocument()
+    // LLM agent: instructions / model / tools / skills, and no command.
+    expect(screen.getByText('Instructions')).toBeInTheDocument()
+    expect(screen.getByText('Skills')).toBeInTheDocument()
+    expect(screen.queryByText('Command')).not.toBeInTheDocument()
+    expect(screen.queryByText('Environment')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('agent-tile-a2'))
-    // Script agent: command/args/env, no prompt.
-    expect(screen.getByText('command')).toBeInTheDocument()
-    expect(screen.getByText('env')).toBeInTheDocument()
-    expect(screen.queryByText('prompt')).not.toBeInTheDocument()
+    // Script agent: command / arguments / environment, and no prompt or skills.
+    expect(screen.getByText('Command')).toBeInTheDocument()
+    expect(screen.getByText('Environment')).toBeInTheDocument()
+    expect(screen.queryByText('Instructions')).not.toBeInTheDocument()
+    expect(screen.queryByText('Skills')).not.toBeInTheDocument()
   })
 
   it('shows an empty dossier prompt until an agent is picked', () => {

--- a/src/components/roster/roster-view.tsx
+++ b/src/components/roster/roster-view.tsx
@@ -71,22 +71,12 @@ export function RosterView() {
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="roster-view">
-      {/* One title bar across both columns — a header that stopped at the grid
-          left the dossier's content floating with nothing to align to. */}
-      <header className="shrink-0 border-b border-border-default bg-bg/80 px-6 py-3 backdrop-blur">
-        <h3 className="text-base font-semibold text-text-primary">Roster</h3>
-        <p className="mt-0.5 text-xs text-text-secondary">
-          Agents you build once and reuse. Assigning them to board columns comes later.
-        </p>
-      </header>
-
-      {/* Below lg the dossier stacks under the grid rather than disappearing —
-          hiding it outright meant selecting an agent on a narrow window did
-          nothing visible at all. */}
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
         {/* Grid */}
-        <div className="flex min-w-0 flex-none flex-col lg:flex-1 lg:overflow-hidden">
-          <div className="flex shrink-0 flex-wrap items-center gap-2 px-6 py-3">
+        {/* Browsing rail — deliberately narrow. Scanning happens here; the
+            reading happens in the dossier. */}
+        <div className="flex min-w-0 flex-none flex-col border-border-default lg:w-[340px] lg:shrink-0 lg:overflow-hidden lg:border-r">
+          <div className="flex shrink-0 flex-wrap items-center gap-1.5 border-b border-border-default px-4 py-2.5">
             {FILTERS.map((f) => (
               <button
                 key={f.value}
@@ -112,16 +102,16 @@ export function RosterView() {
           </div>
 
           {error && (
-            <p className="mx-6 mb-3 rounded-lg border border-error/40 bg-error/10 px-3 py-2 text-xs text-error">
+            <p className="mx-4 mb-3 rounded-lg border border-error/40 bg-error/10 px-3 py-2 text-xs text-error">
               {error}
             </p>
           )}
 
-          <div className="min-h-0 px-6 pb-6 lg:flex-1 lg:overflow-y-auto">
+          <div className="min-h-0 p-4 lg:flex-1 lg:overflow-y-auto">
             {!loaded ? (
               <p className="text-sm text-text-secondary">Loading agents…</p>
             ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-3">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-2.5">
                 {visible.map((agent) => (
                   <AgentTile
                     key={agent.id}
@@ -144,7 +134,7 @@ export function RosterView() {
 
         {/* Dossier */}
         <aside
-          className={`shrink-0 overflow-y-auto border-border-default lg:w-[380px] lg:border-l ${
+          className={`min-w-0 overflow-y-auto border-border-default lg:flex-1 ${
             selected ? 'border-t lg:border-t-0' : 'hidden lg:block'
           }`}
         >
@@ -164,9 +154,13 @@ export function RosterView() {
             />
           ) : (
             <div className="flex h-full items-center justify-center p-6">
-              <p className="text-center text-sm text-text-secondary">
-                Pick an agent to see how it's set up.
-              </p>
+              <div className="max-w-sm text-center">
+                <p className="text-sm text-text-primary">Pick an agent to see how it's set up.</p>
+                <p className="mt-1 text-xs text-text-secondary">
+                  Agents are shared across every workspace. Assigning them to board columns comes
+                  later.
+                </p>
+              </div>
             </div>
           )}
         </aside>


### PR DESCRIPTION
## Section title moves into the tab bar

The Roster's own header block (title + caption) is gone. The workspace tab strip now shows the **section name** instead of workspace tabs when you're not on the board.

That's a correctness fix as much as tidying: **agents are global**, so a workspace selector in the Roster was chrome that changed nothing. Now the tab strip only offers a choice where the choice does something.

## Split flipped

The list was taking ~65% and the dossier a fixed 380px — backwards, since the list is for *scanning* and the dossier is where the *reading* happens.

| | before | after |
|---|---|---|
| list | `flex-1` (~65%) | **340px fixed** |
| dossier | 380px fixed | **`flex-1`** |

340px fits two tiles per row, which is enough to scan a roster, and hands the rest to the pane that actually has content in it.

## Configuration view rebuilt

It was a flat key-value list with a hairline under every row — a shape that treats a system prompt, a model name and a filesystem path as if they were peers. They aren't. Now grouped into **cards**, the pattern GitHub / Vercel / Stripe settings all use:

```
LLM      Instructions (spans, prose) │ Model │ Tools │ Skills │ Retrieval (v2)
Script   Command (spans)             │ Environment │ Outputs (v2)
```

- Card headers carry a **count** where one is meaningful (tools, skills, args)
- Paths, commands and tool ids are **click-to-copy** with a check-mark confirmation — those are values you paste elsewhere
- The system prompt gets `max-w-prose`; the wider pane happily ran it to ~150 characters per line
- **Delete demoted** from a full-width button to an icon — it sits beside two non-destructive actions and shouldn't carry equal weight
- Portrait moved beside the name rather than above it, so the wider pane doesn't carry a stretched banner

### Two duplications cut, both found by looking at the rendered result

1. A separate **Arguments** card listed the exact values the Command card already showed.
2. Inside Command, a chip row *and* a full command line said the same thing twice.

What's left is the one line that actually gets run, copyable.

Also fixed: env keys like `RENDER_THREADS` were truncating in a 112px label column.

## Verification

- `tsc`, `eslint`, IPC check (209), `vitest run` → **429**, production build clean
- Walked all three runtimes in Chrome, plus the MCP-with-allow-list case and the missing-skill case, at 1500px