### PR TITLE
fix(settings): wire the three Appearance settings that never reached the UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: IPC registration check
         run: pnpm run test:ipc
+      - name: Type scale check
+        run: pnpm run test:type-scale
 
       - name: Frontend tests
         run: pnpm exec vitest run
@@ -98,7 +100,7 @@ jobs:
               '',
               'Checks run:',
               '- Rust: `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`',
-              '- Frontend: `pnpm run type-check`, `pnpm run lint`, `pnpm run test:ipc`, `pnpm audit --audit-level moderate`, `pnpm exec vitest run`',
+              '- Frontend: `pnpm run type-check`, `pnpm run lint`, `pnpm run test:ipc`, `pnpm run test:type-scale`, `pnpm audit --audit-level moderate`, `pnpm exec vitest run`',
               '',
               'Please inspect the failed workflow run and fix main.'
             ].join('\n');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: IPC registration check
         run: pnpm run test:ipc
+      - name: Type scale check
+        run: pnpm run test:type-scale
 
       - name: Dependency audit
         run: pnpm audit --audit-level moderate

--- a/.tickets/_docs/ROADMAP.md
+++ b/.tickets/_docs/ROADMAP.md
@@ -35,6 +35,18 @@ replaces the terminal.
   with a 60s budget and **never** hard-kills — exhausting it injects anyway and
   leaves the pane inspectable. `CLI_HEALTH_SPECS` now probes the interactive
   codex path so the same drift can't ship silently again.
+- Settings wiring pass (Appearance): all five settings now reach the UI. Font Size
+  was worse than unwired — 247 arbitrary `text-[Npx]` values across 63 files were
+  absolute, so at "small" the root dropped to 12px while a caption pinned at 11px
+  stayed put and rendered *larger* than the `text-sm` body above it. The scale is
+  now four rem steps (`text-2xs` added to `@theme`, since Tailwind stops at `xs`),
+  all 247 converted, and `scripts/check-type-scale.js` fails CI on the next
+  absolute size. Card Density and Animation Speed were fully inert: the chain died
+  at `.card-padding`/`.card-gap`/`.transition-appearance`, three helper classes
+  zero components used. Density now drives the task card's padding and the
+  column's inter-card gap directly; Animation Speed rides Tailwind's own
+  `--default-transition-duration`, so every `transition-*` utility honours it
+  without opting in. The three dead classes are gone.
 - Interactive done-advisory persisted (migration 048, `tasks.agent_done_signaled_at`):
   the signal used to be a Tauri event only, so it existed just while the agent
   panel was mounted. Now the board shows a "Ready to advance" badge that
@@ -50,37 +62,11 @@ replaces the terminal.
 
 ## 🟡 Important (rough edges, not blockers)
 
-2. **Settings wiring pass — three of five Appearance settings don't reach the UI.**
-   Measured 2026-08-21 in a real browser, not inferred. The store→DOM plumbing is
-   fine (`lib/appearance.ts`, called from `main.tsx` and `settings-store.ts`);
-   what's missing is anything *consuming* the result.
-
-   | Setting | State |
-   |---|---|
-   | Theme | works |
-   | Accent colour | works (sets `--accent`) |
-   | **Font size** | **partial, and actively wrong at "small"** |
-   | **Card density** | **inert** |
-   | **Animation speed** | **inert** |
-
-   - **Font size.** `--base-font-size` lands on `html`, so rem-based utilities do
-     scale — `text-sm` measures 10.5 / 12.25 / 14px across small/medium/large.
-     But **247 arbitrary `text-[Npx]` values across 63 files** (144× `text-[10px]`,
-     96× `text-[11px]`) are absolute and never move. At "small" that *inverts the
-     hierarchy*: `text-sm` drops to 10.5px while a caption pinned at `text-[11px]`
-     stays larger than the body text it's meant to sit under.
-     Fix: add rem-based steps to the `@theme` block in `index.css` (the scale
-     wants a `text-micro`/`text-tiny` below `text-xs`) and convert the 247 uses.
-   - **Card density / animation speed.** The chain is
-     store → `data-card-density` / `data-animation-speed` → `--card-padding` /
-     `--card-gap` / `--transition-duration` → `.card-padding` / `.card-gap` /
-     `.transition-appearance`. That last hop is where it dies: those three helper
-     classes are used by **zero** components. Either apply them on the card/panel
-     primitives or drop the settings.
-
-   While in there, re-check the other known-inert surfaces listed under
-   "Inert / deferred" below — custom keyboard shortcuts render but do nothing,
-   and the OpenRouter / Google / Ollama provider cards are "Coming soon".
+2. **Other inert settings surfaces.** Flagged while wiring Appearance, not fixed:
+   custom keyboard shortcuts render but do nothing (`shortcuts-tab.tsx:54`), and
+   the OpenRouter / Google / Ollama provider cards are "Coming soon". Framer
+   Motion animations also ignore Animation Speed — they read no CSS variable, so
+   "none" doesn't fully mean none.
 
 3. **`effort_level` not wired into the trigger path.** It's a real DB field + has a
    `thinking-selector.tsx` and works in the interactive chat panel, but no
@@ -123,5 +109,5 @@ replaces the terminal.
 
 ## Suggested order
 
-`#1 rm stale claude` (free) → `#2 settings wiring pass` → `#3 effort wiring` →
-`#4 checklist/roadmap MCP` → `#5 MCP gaps`.
+`#1 rm stale claude` (free) → `#3 effort wiring` → `#4 checklist/roadmap MCP` →
+`#5 MCP gaps`. `#2` is cosmetic cleanup; do it opportunistically.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint src/",
     "test:ipc": "node scripts/check-ipc-registration.js",
+    "test:type-scale": "node scripts/check-type-scale.js",
     "format": "prettier --write 'src/**/*.{ts,tsx,css}'",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/check-type-scale.js
+++ b/scripts/check-type-scale.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * Guards Settings → Appearance → Font Size.
+ *
+ * That setting works by putting `--base-font-size` on <html>, so only
+ * rem-based type scales with it. An arbitrary pixel size is absolute: it
+ * ignores the setting entirely. Once enough of them accumulate the hierarchy
+ * doesn't just stop scaling, it inverts — at "small" the root drops to 12px so
+ * `text-sm` renders 10.5px, and a caption pinned at a fixed 11px comes out *larger*
+ * than the body text it sits under.
+ *
+ * 247 of these had built up before this check existed. Use the scale instead:
+ * text-2xs / text-xs / text-sm / text-base / text-lg …
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const sourceExtensions = new Set(['.ts', '.tsx', '.css'])
+const ARBITRARY_FONT_SIZE = /text-\[\d+(?:\.\d+)?(px|pt)\]/g
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walk(fullPath, files)
+    } else if (sourceExtensions.has(path.extname(entry.name))) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+const offenders = []
+let scanned = 0
+for (const file of walk(path.join(root, 'src'))) {
+  scanned += 1
+  const lines = fs.readFileSync(file, 'utf8').split('\n')
+  lines.forEach((line, i) => {
+    for (const match of line.matchAll(ARBITRARY_FONT_SIZE)) {
+      offenders.push(`${path.relative(root, file)}:${i + 1}  ${match[0]}`)
+    }
+  })
+}
+
+if (offenders.length > 0) {
+  console.error('Absolute font sizes found — these ignore the Font Size setting:')
+  for (const offender of offenders) {
+    console.error(`  - ${offender}`)
+  }
+  console.error('\nUse a rem step from the scale instead: text-2xs, text-xs, text-sm, text-base, text-lg.')
+  console.error('If a genuinely fixed size is required, add a rem token to the @theme block in src/index.css.')
+  process.exit(1)
+}
+
+console.log(`Type scale check passed (${scanned} file(s), no absolute font sizes).`)

--- a/src/components/checklist/checklist-item.tsx
+++ b/src/components/checklist/checklist-item.tsx
@@ -77,7 +77,7 @@ export function ChecklistItemRow({ item, categoryId, onFixThis }: Props) {
             {/* Auto-detect badge */}
             {item.detectType && item.detectType !== 'none' && (
               <span
-                className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${
                   item.autoDetected
                     ? 'bg-success/20 text-success'
                     : 'bg-bg-secondary text-text-secondary'
@@ -91,7 +91,7 @@ export function ChecklistItemRow({ item, categoryId, onFixThis }: Props) {
             {/* Linked task badge */}
             {item.linkedTaskId && (
               <span
-                className="inline-flex items-center gap-1 rounded bg-accent/20 px-1.5 py-0.5 text-[10px] font-medium text-accent"
+                className="inline-flex items-center gap-1 rounded bg-accent/20 px-1.5 py-0.5 text-xs font-medium text-accent"
                 title="Linked to task"
               >
                 Linked Task

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -294,7 +294,7 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
             autoFocus
             className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-secondary focus:outline-none"
           />
-          <kbd className="rounded bg-bg px-1.5 py-0.5 font-mono text-[10px] text-text-secondary" aria-label="Escape to close">
+          <kbd className="rounded bg-bg px-1.5 py-0.5 font-mono text-xs text-text-secondary" aria-label="Escape to close">
             Esc
           </kbd>
         </div>
@@ -345,11 +345,11 @@ export function CommandPalette({ onClose, onShowShortcuts }: Props) {
                         <div className="flex items-center gap-0.5" aria-hidden="true">
                           {cmd.shortcut.map((key, j) => (
                             <span key={j}>
-                              <kbd className="rounded bg-bg px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
+                              <kbd className="rounded bg-bg px-1.5 py-0.5 font-mono text-xs text-text-secondary">
                                 {key}
                               </kbd>
                               {j < (cmd.shortcut?.length ?? 0) - 1 && (
-                                <span className="mx-0.5 text-[10px] text-text-secondary">+</span>
+                                <span className="mx-0.5 text-xs text-text-secondary">+</span>
                               )}
                             </span>
                           ))}

--- a/src/components/kanban/column-automation-sentence.tsx
+++ b/src/components/kanban/column-automation-sentence.tsx
@@ -116,7 +116,7 @@ export function AutomationSentence({ onEntry, setOnEntry, exitCriteria, setExitC
         <span>.</span>
       </div>
 
-      <p className="text-[11px] text-text-secondary/60">
+      <p className="text-xs text-text-secondary/60">
         The prompt, runtime, retries and more live under Advanced. Most columns never need them.
       </p>
     </div>

--- a/src/components/kanban/column-config-dialog.tsx
+++ b/src/components/kanban/column-config-dialog.tsx
@@ -406,7 +406,7 @@ function CapacityFields({
                   aria-pressed={selected}
                 >
                   <span className="block text-sm font-medium leading-4">{option.label}</span>
-                  <span className="mt-1 block text-[11px] leading-3 text-text-secondary/70">{option.hint}</span>
+                  <span className="mt-1 block text-xs leading-3 text-text-secondary/70">{option.hint}</span>
                 </button>
               )
             })}

--- a/src/components/kanban/column-header.tsx
+++ b/src/components/kanban/column-header.tsx
@@ -207,7 +207,7 @@ export const ColumnHeader = memo(function ColumnHeader({
         >
           {getIcon(icon)}
         </span>
-        <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary tabular-nums">
+        <span className="rounded bg-surface-hover px-1.5 py-0.5 text-xs font-medium text-text-secondary tabular-nums">
           {taskCount}
         </span>
         {isRenaming ? (
@@ -240,7 +240,7 @@ export const ColumnHeader = memo(function ColumnHeader({
               <button
                 type="button"
                 onClick={() => { setMetricsExpanded(false) }}
-                className="flex items-center gap-1 rounded text-[10px] text-text-secondary/60 tabular-nums whitespace-nowrap hover:text-text-secondary"
+                className="flex items-center gap-1 rounded text-xs text-text-secondary/60 tabular-nums whitespace-nowrap hover:text-text-secondary"
               >
                 <span>⏱{formatDuration(metrics.avgDurationSeconds)}</span>
                 <span className="text-text-secondary/30">·</span>
@@ -267,7 +267,7 @@ export const ColumnHeader = memo(function ColumnHeader({
 
         {scriptTrigger && (
           <span
-            className="truncate rounded bg-purple-500/10 px-1.5 py-0.5 text-[10px] font-medium text-purple-400"
+            className="truncate rounded bg-purple-500/10 px-1.5 py-0.5 text-xs font-medium text-purple-400"
             title={`Script: ${scriptTrigger.scriptName} (${scriptTrigger.event === 'both' ? 'entry + exit' : `on ${scriptTrigger.event}`})`}
           >
             {scriptTrigger.scriptName}
@@ -276,7 +276,7 @@ export const ColumnHeader = memo(function ColumnHeader({
 
         {/* Batch queue progress badge */}
         {batchQueue && (
-          <span className="rounded bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+          <span className="rounded bg-accent/15 px-1.5 py-0.5 text-xs font-medium text-accent">
             Queued: {batchQueue.completed}/{batchQueue.total}
           </span>
         )}
@@ -292,7 +292,7 @@ export const ColumnHeader = memo(function ColumnHeader({
             wrap
           >
             <span
-              className={`rounded px-1.5 py-0.5 text-[10px] font-medium tabular-nums ${
+              className={`rounded px-1.5 py-0.5 text-xs font-medium tabular-nums ${
                 agentConcurrency.running >= agentConcurrency.max
                   ? 'bg-warning/10 text-warning'
                   : agentConcurrency.running > 0

--- a/src/components/kanban/column-trigger-action-editors.tsx
+++ b/src/components/kanban/column-trigger-action-editors.tsx
@@ -69,7 +69,7 @@ export function ActionEditor({
                   <span className="text-amber-400" title="Irreversible action">⚠</span>
                 )}
               </div>
-              <div className="mt-0.5 text-[10px] opacity-60 leading-tight">{t.description}</div>
+              <div className="mt-0.5 text-xs opacity-60 leading-tight">{t.description}</div>
             </button>
           )
         })}

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -274,7 +274,7 @@ export const Column = memo(function Column({
         <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
           <div
             ref={setDroppableRef}
-            className={`flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pt-1 pb-2 transition-colors ${
+            className={`flex min-h-0 flex-1 flex-col gap-[var(--card-gap)] overflow-y-auto px-2 pt-1 pb-2 transition-colors ${
               isOver ? 'bg-accent/5' : ''
             }`}
           >

--- a/src/components/kanban/drag-overlay.tsx
+++ b/src/components/kanban/drag-overlay.tsx
@@ -60,7 +60,7 @@ export function DragOverlayContent({ item }: DragOverlayContentProps) {
 
           {/* Metadata row */}
           {hasMetadata && (
-            <div className="flex items-center gap-x-3 text-[11px] text-text-secondary">
+            <div className="flex items-center gap-x-3 text-xs text-text-secondary">
               {cardSettings.showPrBadge && task.prNumber && (
                 <span className="inline-flex items-center gap-1">
                   <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
@@ -84,14 +84,14 @@ export function DragOverlayContent({ item }: DragOverlayContentProps) {
               {taskLabels.slice(0, 3).map((label) => (
                 <span
                   key={label.id}
-                  className="inline-flex items-center gap-1 rounded-full bg-surface-hover px-2 py-0.5 text-[10px] text-text-secondary"
+                  className="inline-flex items-center gap-1 rounded-full bg-surface-hover px-2 py-0.5 text-xs text-text-secondary"
                 >
                   <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: label.color }} />
                   {label.name}
                 </span>
               ))}
               {taskLabels.length > 3 && (
-                <span className="text-[10px] text-text-secondary/70">+{taskLabels.length - 3}</span>
+                <span className="text-xs text-text-secondary/70">+{taskLabels.length - 3}</span>
               )}
             </div>
           )}

--- a/src/components/kanban/spawn-cli-action-editor.tsx
+++ b/src/components/kanban/spawn-cli-action-editor.tsx
@@ -118,7 +118,7 @@ export function SpawnCliActionEditor({
                   }`}
                 >
                   <span className="block text-xs font-medium">{opt.label}</span>
-                  <span className="block text-[10px] opacity-60">{opt.description}</span>
+                  <span className="block text-xs opacity-60">{opt.description}</span>
                 </button>
               )
             })}
@@ -147,13 +147,13 @@ export function SpawnCliActionEditor({
                   }`}
                 >
                   <span className="block text-xs font-medium">{mode.label}</span>
-                  <span className="block text-[10px] opacity-60">{mode.caption}</span>
+                  <span className="block text-xs opacity-60">{mode.caption}</span>
                 </button>
               )
             })}
           </div>
           {isManagedMode && (
-            <p className="mt-1 text-[10px] text-amber-400">
+            <p className="mt-1 text-xs text-amber-400">
               Managed mode streams structured events; Terminal is more reliable for long-running agents.
             </p>
           )}
@@ -182,8 +182,8 @@ export function SpawnCliActionEditor({
           <div className="mt-1.5 grid grid-cols-2 gap-x-4 gap-y-0.5 rounded-lg border border-border-default bg-bg/60 p-2">
             {TEMPLATE_VARIABLES.map((v) => (
               <div key={v.name} className="flex items-baseline gap-1.5">
-                <code className="shrink-0 text-[10px] font-mono text-accent">{v.name}</code>
-                <span className="truncate text-[10px] text-text-secondary">{v.desc}</span>
+                <code className="shrink-0 text-xs font-mono text-accent">{v.name}</code>
+                <span className="truncate text-xs text-text-secondary">{v.desc}</span>
               </div>
             ))}
           </div>
@@ -199,7 +199,7 @@ export function SpawnCliActionEditor({
           className="h-4 w-4 rounded border-border-default accent-accent"
         />
         Use agent queue
-        <span className="ml-0.5 rounded bg-bg-elevated px-1.5 py-0.5 text-[10px] text-text-secondary">
+        <span className="ml-0.5 rounded bg-bg-elevated px-1.5 py-0.5 text-xs text-text-secondary">
           max 3 concurrent
         </span>
       </label>

--- a/src/components/kanban/task-card-activity.tsx
+++ b/src/components/kanban/task-card-activity.tsx
@@ -22,7 +22,7 @@ export function AgentActivityPreview({
 
     return (
       <div className="space-y-1">
-        <div className="flex items-center gap-1.5 text-[11px] text-running">
+        <div className="flex items-center gap-1.5 text-xs text-running">
           <span className="relative flex h-1.5 w-1.5 shrink-0">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-running opacity-75" />
             <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-running" />
@@ -35,7 +35,7 @@ export function AgentActivityPreview({
           <span className="text-text-secondary/50 ml-auto shrink-0 tabular-nums">{elapsedStr}</span>
         </div>
         {agentStream.toolCount > 0 && (
-          <div className="flex items-center gap-1 text-[10px] text-text-secondary/60 pl-3">
+          <div className="flex items-center gap-1 text-xs text-text-secondary/60 pl-3">
             <svg className="h-2.5 w-2.5" viewBox="0 0 16 16" fill="currentColor">
               <path d="M5.433 2.304A4.492 4.492 0 0 0 3.5 6c0 1.598.832 3.002 2.09 3.802.518.328.929.923.902 1.64v.008l-.164 3.337a.75.75 0 1 1-1.498-.073l.163-3.34c.007-.14-.1-.313-.37-.484A5.988 5.988 0 0 1 2 6a5.992 5.992 0 0 1 2.567-4.92 1.477 1.477 0 0 1 .433-.224ZM6.5 14h3a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5Zm4.157-11.696a.75.75 0 0 1 1.343.392 5.992 5.992 0 0 1-2.567 4.92 1.477 1.477 0 0 1-.433.224.75.75 0 0 1-.71-1.321A4.492 4.492 0 0 0 12.5 6c0-1.598-.832-3.002-2.09-3.802-.518-.328-.929-.923-.902-1.64V.55l.164-3.337a.75.75 0 0 1 1.498.073L11.006 .623c-.007.14.1.313.37.484Z" />
             </svg>
@@ -59,7 +59,7 @@ export function AgentActivityPreview({
   }
 
   return (
-    <div className={`flex items-center gap-1.5 text-[11px] ${colorClasses[activity.type]}`}>
+    <div className={`flex items-center gap-1.5 text-xs ${colorClasses[activity.type]}`}>
       {activity.type === 'active' && (
         <span className="relative flex h-1.5 w-1.5">
           <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-running opacity-75" />

--- a/src/components/kanban/task-card-badges.tsx
+++ b/src/components/kanban/task-card-badges.tsx
@@ -70,7 +70,7 @@ export function PrStatusIndicator({ task, settings }: { task: Task; settings: ty
       <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="currentColor">
         <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z" />
       </svg>
-      <span className="text-[11px]">#{task.prNumber}</span>
+      <span className="text-xs">#{task.prNumber}</span>
       {statusIcon}
     </span>
   )
@@ -90,7 +90,7 @@ export function AgentDoneBadge({ task }: { task: Task }) {
   if (task.agentDoneSignaledAt === null) return null
   return (
     <span
-      className="inline-flex items-center gap-1 rounded bg-running/10 px-1.5 py-0.5 text-[10px] font-medium text-running"
+      className="inline-flex items-center gap-1 rounded bg-running/10 px-1.5 py-0.5 text-xs font-medium text-running"
       title="The agent signaled it finished. Its session is still live — open the task to review, then advance the column."
     >
       <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -116,7 +116,7 @@ export function SiegeBadge({ task }: { task: Task }) {
         <path d="M2.8 10A4.7 4.7 0 0 0 11.6 11.2L13 9.2" />
         <path d="M13 12V9.2h-2.8" />
       </svg>
-      <span className="text-[11px] font-medium">
+      <span className="text-xs font-medium">
         {task.siegeIteration}/{task.siegeMaxIterations}
       </span>
     </span>

--- a/src/components/kanban/task-card-expanded.tsx
+++ b/src/components/kanban/task-card-expanded.tsx
@@ -42,7 +42,7 @@ function DescriptionMarkdown({ description }: { description: string }) {
             )
           },
           pre: ({ children }) => (
-            <pre className="my-2 overflow-x-auto rounded border border-border-default bg-surface p-2 text-[11px]">
+            <pre className="my-2 overflow-x-auto rounded border border-border-default bg-surface p-2 text-xs">
               {children}
             </pre>
           ),
@@ -177,7 +177,7 @@ export function TaskCardExpanded({ task }: { task: Task }) {
               }}
               className="max-h-56 w-full resize-y rounded-md border border-accent bg-surface px-2 py-1.5 text-xs leading-relaxed text-text-primary outline-none focus:ring-2 focus:ring-accent/20 disabled:opacity-60"
             />
-            <div className="px-1 text-[10px] text-text-secondary">
+            <div className="px-1 text-xs text-text-secondary">
               {saveShortcutLabel} to save, Escape to cancel
             </div>
           </div>
@@ -224,12 +224,12 @@ export function TaskCardExpanded({ task }: { task: Task }) {
                 <circle cx="8" cy="9" r="1.5" />
                 <path d="M4 4.5V7.5C4 8.5 5 9 8 9M8 7.5V3" />
               </svg>
-              <span className="truncate font-mono text-[11px] text-accent max-w-[180px]">
+              <span className="truncate font-mono text-xs text-accent max-w-[180px]">
                 {task.branch}
               </span>
               {task.worktreePath && (
                 <span
-                  className="rounded bg-purple-500/10 px-1 py-0.5 text-[10px] font-medium text-purple-400"
+                  className="rounded bg-purple-500/10 px-1 py-0.5 text-xs font-medium text-purple-400"
                   title={task.worktreePath}
                 >
                   worktree
@@ -238,7 +238,7 @@ export function TaskCardExpanded({ task }: { task: Task }) {
             </div>
           )}
           {task.model && (
-            <span className="rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+            <span className="rounded bg-accent/10 px-1.5 py-0.5 text-xs font-medium text-accent">
               {task.model}
             </span>
           )}
@@ -247,7 +247,7 @@ export function TaskCardExpanded({ task }: { task: Task }) {
         {/* Siege Loop Status (only when active) */}
         {(task.siegeActive || task.siegeIteration > 0) && (
           <div>
-            <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+            <h4 className="text-xs font-medium uppercase tracking-wider text-text-secondary mb-1">
               Siege Loop
             </h4>
             <SiegeStatus task={task} onUpdate={updateTask} />
@@ -256,7 +256,7 @@ export function TaskCardExpanded({ task }: { task: Task }) {
 
         {/* Touched files only; full diffs live in the agent panel. */}
         <div>
-          <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+          <h4 className="text-xs font-medium uppercase tracking-wider text-text-secondary mb-1">
             Touched Files
           </h4>
           <TouchedFilesSummary
@@ -267,7 +267,7 @@ export function TaskCardExpanded({ task }: { task: Task }) {
         </div>
 
         <div>
-          <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary mb-1">
+          <h4 className="text-xs font-medium uppercase tracking-wider text-text-secondary mb-1">
             Commits
           </h4>
           <div className="rounded-md border border-border-default bg-surface">
@@ -338,7 +338,7 @@ function TouchedFilesSummary({
           <button
             type="button"
             onClick={() => { setExpanded((current) => !current) }}
-            className="mt-1 flex w-full items-center justify-center rounded px-2 py-1 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            className="mt-1 flex w-full items-center justify-center rounded px-2 py-1 text-xs text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
             style={{ cursor: 'pointer' }}
           >
             {expanded ? 'Show less' : `Show ${String(hiddenCount)} more`}
@@ -353,11 +353,11 @@ function TouchedFileRow({ file }: { file: FileChange }) {
   return (
     <div className="flex min-w-0 items-center gap-2 rounded px-2 py-1 text-xs">
       <StatusBadge status={file.status} />
-      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-secondary" title={file.path}>
+      <span className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary" title={file.path}>
         {file.path}
       </span>
-      <span className="shrink-0 text-[11px] text-success">+{file.additions}</span>
-      <span className="shrink-0 text-[11px] text-error">-{file.deletions}</span>
+      <span className="shrink-0 text-xs text-success">+{file.additions}</span>
+      <span className="shrink-0 text-xs text-error">-{file.deletions}</span>
     </div>
   )
 }
@@ -374,7 +374,7 @@ function StatusBadge({ status }: { status: string }) {
   const letter = status[0]?.toUpperCase() ?? '?'
 
   return (
-    <span className={`w-3 shrink-0 text-center font-mono text-[10px] font-bold ${color}`}>
+    <span className={`w-3 shrink-0 text-center font-mono text-xs font-bold ${color}`}>
       {letter}
     </span>
   )

--- a/src/components/kanban/task-card-status.tsx
+++ b/src/components/kanban/task-card-status.tsx
@@ -42,7 +42,7 @@ export function QueuedBanner({
 
   return (
     <Tooltip content={tooltipText} side="top" wrap delay={200}>
-      <div role="status" style={{ cursor: 'default' }} className="flex items-center gap-1.5 rounded bg-warning/10 px-2 py-1 text-[11px] text-warning">
+      <div role="status" style={{ cursor: 'default' }} className="flex items-center gap-1.5 rounded bg-warning/10 px-2 py-1 text-xs text-warning">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 shrink-0" aria-hidden="true">
           <path fillRule="evenodd" d="M1 8a7 7 0 1 1 14 0A7 7 0 0 1 1 8Zm7.75-4.25a.75.75 0 0 0-1.5 0V8c0 .414.336.75.75.75h3.25a.75.75 0 0 0 0-1.5h-2.5V3.75Z" clipRule="evenodd" />
         </svg>
@@ -57,7 +57,7 @@ export function QueuedBanner({
 /** Blocked by dependencies banner */
 export function BlockedBanner({ blockerInfo }: { blockerInfo: string | null }) {
   return (
-    <div role="status" className="flex items-center gap-1.5 rounded bg-amber-500/10 px-2 py-1 text-[11px] text-amber-400">
+    <div role="status" className="flex items-center gap-1.5 rounded bg-amber-500/10 px-2 py-1 text-xs text-amber-400">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 shrink-0" aria-hidden="true">
         <path fillRule="evenodd" d="M8 1a3.5 3.5 0 0 0-3.5 3.5V7A1.5 1.5 0 0 0 3 8.5v5A1.5 1.5 0 0 0 4.5 15h7a1.5 1.5 0 0 0 1.5-1.5v-5A1.5 1.5 0 0 0 11.5 7V4.5A3.5 3.5 0 0 0 8 1Zm2 6V4.5a2 2 0 1 0-4 0V7h4Z" clipRule="evenodd" />
       </svg>
@@ -134,7 +134,7 @@ export function PipelineErrorBanner({
           }}
           aria-expanded={expanded}
           aria-label={expanded ? 'Hide error details' : 'Show error details'}
-          className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium text-error/70 hover:text-error hover:bg-error/20 transition-colors"
+          className="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium text-error/70 hover:text-error hover:bg-error/20 transition-colors"
         >
           Why?
         </button>
@@ -144,7 +144,7 @@ export function PipelineErrorBanner({
             onRetry()
           }}
           aria-label="Retry pipeline"
-          className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium bg-error/20 hover:bg-error/30 transition-colors"
+          className="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium bg-error/20 hover:bg-error/30 transition-colors"
         >
           Retry
         </button>
@@ -170,7 +170,7 @@ export function PipelineErrorBanner({
               >
                 Raw error
               </summary>
-              <p className="mt-1 break-all text-error/50 font-mono text-[10px] leading-relaxed">
+              <p className="mt-1 break-all text-error/50 font-mono text-xs leading-relaxed">
                 {rawError}
               </p>
             </details>

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -520,7 +520,7 @@ export const TaskCard = memo(function TaskCard({
       <div
         {...attributes}
         {...listeners}
-        className="space-y-2.5 p-3"
+        className="space-y-2.5 p-[var(--card-padding)]"
         style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
       >
         {/* Title — click-to-edit when card is expanded */}
@@ -562,7 +562,7 @@ export const TaskCard = memo(function TaskCard({
                   setEditingTitle(true)
                 }
               }}
-              className={`min-w-0 flex-1 pr-7 text-[13px] font-medium leading-snug text-text-primary line-clamp-2 ${isExpanded ? 'hover:text-accent' : ''}`}
+              className={`min-w-0 flex-1 pr-7 text-sm font-medium leading-snug text-text-primary line-clamp-2 ${isExpanded ? 'hover:text-accent' : ''}`}
               style={isExpanded ? { cursor: 'text' } : undefined}
               title={isExpanded ? 'Click to edit title' : undefined}
             >
@@ -574,7 +574,7 @@ export const TaskCard = memo(function TaskCard({
               type="button"
               onClick={(e) => { e.stopPropagation(); actions.handleUnarchiveTask(); }}
               title="Restore — move back to the active board"
-              className="shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-surface-hover text-text-secondary/80 border border-border-default hover:border-accent hover:text-accent transition-colors"
+              className="shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium bg-surface-hover text-text-secondary/80 border border-border-default hover:border-accent hover:text-accent transition-colors"
             >
               <svg viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3">
                 <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H4.598a.75.75 0 0 0-.75.75v3.634a.75.75 0 0 0 1.5 0v-2.033l.312.311a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39l-.611.21ZM4.688 8.576a5.5 5.5 0 0 1 9.201-2.466l.312.311h-2.433a.75.75 0 0 0 0 1.5h3.634a.75.75 0 0 0 .75-.75V3.537a.75.75 0 0 0-1.5 0v2.033l-.312-.311A7 7 0 0 0 3.628 8.397a.75.75 0 0 0 1.449.39l-.389-.211Z" clipRule="evenodd" />
@@ -602,7 +602,7 @@ export const TaskCard = memo(function TaskCard({
 
         {/* Compact metadata row — hidden when expanded (expanded view has its own) */}
         {!isExpanded && hasMetadata && (
-          <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[11px] text-text-secondary">
+          <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-text-secondary">
             {isPipelineActive && !hasPipelineError && task.pipelineState !== 'running' && (
               <span className="inline-flex items-center gap-1 text-running">
                 <span className="relative flex h-1.5 w-1.5">
@@ -615,13 +615,13 @@ export const TaskCard = memo(function TaskCard({
             <SiegeBadge task={task} />
             <AgentDoneBadge task={task} />
             {task.heldByUser && (
-              <span className="inline-flex items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-warning">
+              <span className="inline-flex items-center gap-1 rounded bg-warning/10 px-1.5 py-0.5 text-xs font-medium text-warning">
                 Held
               </span>
             )}
             {spawnedByLabel && (
               <span
-                className="inline-flex max-w-[160px] items-center gap-1 truncate rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent"
+                className="inline-flex max-w-[160px] items-center gap-1 truncate rounded bg-accent/10 px-1.5 py-0.5 text-xs font-medium text-accent"
                 title={`Spawned by an agent on "${spawnedByLabel}" (chain depth ${String(task.recursionDepth)})`}
               >
                 <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -632,7 +632,7 @@ export const TaskCard = memo(function TaskCard({
               </span>
             )}
             {titleWorkspaceName && (
-              <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+              <span className="rounded bg-surface-hover px-1.5 py-0.5 text-xs font-medium text-text-secondary">
                 {titleWorkspaceName}
               </span>
             )}
@@ -653,12 +653,12 @@ export const TaskCard = memo(function TaskCard({
               <span className="text-text-secondary/70">{task.agentType}</span>
             )}
             {task.model && (
-              <span className="rounded bg-accent/10 px-1 py-0.5 text-[10px] font-medium text-accent">
+              <span className="rounded bg-accent/10 px-1 py-0.5 text-xs font-medium text-accent">
                 {task.model}
               </span>
             )}
             {cardSettings.showBranch && task.branch && (
-              <span className="flex max-w-[130px] items-center gap-1 truncate font-mono text-[11px]" title={task.worktreePath ? `Worktree: ${task.worktreePath}` : task.branch}>
+              <span className="flex max-w-[130px] items-center gap-1 truncate font-mono text-xs" title={task.worktreePath ? `Worktree: ${task.worktreePath}` : task.branch}>
                 {task.worktreePath && (
                   <span className="inline-block w-1.5 h-1.5 rounded-full bg-purple-400 shrink-0" />
                 )}
@@ -670,12 +670,12 @@ export const TaskCard = memo(function TaskCard({
                 <svg className="h-3 w-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                   <path d="M6 3L10 3M10 3L10 7M10 3L3 10" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
-                <span className="text-[10px]">{depCount}</span>
+                <span className="text-xs">{depCount}</span>
               </span>
             )}
             <span className="flex-1" />
             {cardSettings.showTimestamp && !isPipelineActive && (
-              <span className="text-[10px] text-text-secondary/40 tabular-nums">
+              <span className="text-xs text-text-secondary/40 tabular-nums">
                 {formatRelativeTime(task.updatedAt)}
               </span>
             )}
@@ -688,14 +688,14 @@ export const TaskCard = memo(function TaskCard({
             {taskLabels.slice(0, 3).map((label) => (
               <span
                 key={label.id}
-                className="inline-flex items-center gap-1 rounded-full bg-surface-hover px-2 py-0.5 text-[10px] text-text-secondary"
+                className="inline-flex items-center gap-1 rounded-full bg-surface-hover px-2 py-0.5 text-xs text-text-secondary"
               >
                 <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: label.color }} />
                 {label.name}
               </span>
             ))}
             {taskLabels.length > 3 && (
-              <span className="text-[10px] text-text-secondary/70">+{taskLabels.length - 3}</span>
+              <span className="text-xs text-text-secondary/70">+{taskLabels.length - 3}</span>
             )}
           </div>
         )}

--- a/src/components/kanban/task-context-menu.tsx
+++ b/src/components/kanban/task-context-menu.tsx
@@ -136,7 +136,7 @@ function MenuItemComponent({ item, onClose }: { item: MenuItem; onClose: () => v
       {item.icon && <span className="text-text-secondary">{item.icon}</span>}
       <span className="flex-1">{item.label}</span>
       {item.shortcut && (
-        <span className="text-[11px] text-text-secondary/70">{item.shortcut}</span>
+        <span className="text-xs text-text-secondary/70">{item.shortcut}</span>
       )}
     </button>
   )

--- a/src/components/kanban/task-label-picker.tsx
+++ b/src/components/kanban/task-label-picker.tsx
@@ -65,7 +65,7 @@ export function TaskLabelPicker({ task }: TaskLabelPickerProps) {
 
       {open && (
         <div className="absolute left-0 top-6 z-40 w-52 rounded border border-border-default bg-surface p-2 shadow-xl">
-          <div className="mb-1 px-1 text-[10px] font-medium uppercase text-text-secondary/70">Labels</div>
+          <div className="mb-1 px-1 text-xs font-medium uppercase text-text-secondary/70">Labels</div>
           {labels.length === 0 ? (
             <div className="px-1 py-2 text-xs text-text-secondary">Create labels in the board header.</div>
           ) : (

--- a/src/components/kanban/task-quick-actions.tsx
+++ b/src/components/kanban/task-quick-actions.tsx
@@ -19,7 +19,7 @@ export const TaskQuickActions = memo(function TaskQuickActions({
       {confirmDeletePending && (
         <button
           onClick={(e) => { e.stopPropagation(); onDelete(); }}
-          className="h-6 rounded bg-error/20 px-2 text-[10px] font-medium text-error transition-colors hover:bg-error/30"
+          className="h-6 rounded bg-error/20 px-2 text-xs font-medium text-error transition-colors hover:bg-error/30"
           style={{ cursor: 'pointer' }}
           title="Click again to confirm"
           aria-label="Confirm delete"

--- a/src/components/kanban/task-settings-modal.tsx
+++ b/src/components/kanban/task-settings-modal.tsx
@@ -116,7 +116,7 @@ export function TaskSettingsModal({ task, onClose, initialTab }: TaskSettingsMod
             >
               {t === 'triggers' ? 'Triggers' : 'Dependencies'}
               {t === 'dependencies' && deps.length > 0 && (
-                <span className="ml-1.5 rounded bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent">
+                <span className="ml-1.5 rounded bg-accent/10 px-1.5 py-0.5 text-xs text-accent">
                   {deps.length}
                 </span>
               )}
@@ -257,7 +257,7 @@ function TriggersTab({
         runtimeFooter={
           <p
             data-testid="task-runtime-effective"
-            className="mt-1.5 text-[11px] text-text-secondary"
+            className="mt-1.5 text-xs text-text-secondary"
           >
             Effective: <span className="font-medium text-text-primary">{effectiveLabel}</span>
             {resolved.interactiveDevFlagRequired && (

--- a/src/components/kanban/task-template-picker-dialog.tsx
+++ b/src/components/kanban/task-template-picker-dialog.tsx
@@ -266,7 +266,7 @@ export function TaskTemplatePickerDialog({
                       {template.description && (
                         <p className="text-xs text-text-secondary">{template.description}</p>
                       )}
-                      <p className="mt-1 text-[11px] text-text-secondary/80">
+                      <p className="mt-1 text-xs text-text-secondary/80">
                         labels: {template.labels}
                       </p>
                     </div>

--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -104,7 +104,7 @@ function SortableTab({
 
         {/* Notification badge */}
         {notificationCount > 0 && (
-          <span className="ml-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-attention px-1 text-[10px] font-bold text-bg">
+          <span className="ml-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-attention px-1 text-xs font-bold text-bg">
             {notificationCount > 9 ? '9+' : notificationCount}
           </span>
         )}
@@ -264,12 +264,12 @@ function ChecklistButton() {
           />
         </svg>
         {hasItems && !allComplete && (
-          <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-accent text-[8px] font-bold text-bg">
+          <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-accent text-2xs font-bold text-bg">
             {total - progress}
           </span>
         )}
         {allComplete && (
-          <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-success text-[8px] text-white">
+          <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-success text-2xs text-white">
             ✓
           </span>
         )}

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -201,7 +201,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                   onClick={() => { void refreshPrerequisites() }}
                   disabled={checkingPrereqs}
                   style={{ cursor: checkingPrereqs ? 'not-allowed' : 'pointer' }}
-                  className="rounded border border-border-default px-2 py-0.5 text-[11px] text-text-secondary hover:bg-surface-hover disabled:opacity-50"
+                  className="rounded border border-border-default px-2 py-0.5 text-xs text-text-secondary hover:bg-surface-hover disabled:opacity-50"
                 >
                   {checkingPrereqs ? 'Checking...' : 'Recheck'}
                 </button>
@@ -307,11 +307,11 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
                     style={{ cursor: 'pointer' }}
                   >
                     <div className="text-sm font-medium text-text-primary">{opt.name}</div>
-                    <div className="mt-0.5 text-[11px] text-text-secondary">{opt.blurb}</div>
+                    <div className="mt-0.5 text-xs text-text-secondary">{opt.blurb}</div>
                   </button>
                 ))}
               </div>
-              <p className="mt-1 text-[11px] text-text-secondary">
+              <p className="mt-1 text-xs text-text-secondary">
                 Headless is the recommended default. You can change this anytime in Settings → Agent.
               </p>
             </div>

--- a/src/components/panel/agent-panel.tsx
+++ b/src/components/panel/agent-panel.tsx
@@ -236,7 +236,7 @@ function HeadlessPanel({ task, onClose }: AgentPanelProps) {
             <button
               type="button"
               onClick={session.clearDisplayedError}
-              className="truncate text-[11px] text-error hover:text-error/80"
+              className="truncate text-xs text-error hover:text-error/80"
               title={session.error}
             >
               {session.error}
@@ -475,7 +475,7 @@ function InteractivePanel({ task, onClose }: AgentPanelProps) {
         </div>
         <div
           data-testid="interactive-input-hint"
-          className="border-t border-border-default bg-surface px-3 py-1.5 text-[11px] text-text-secondary/70"
+          className="border-t border-border-default bg-surface px-3 py-1.5 text-xs text-text-secondary/70"
         >
           Type directly in the terminal — <span className="text-text-secondary">/commands</span>,{' '}
           <span className="text-text-secondary">@files</span>, Tab-complete and paste all work like a real terminal.
@@ -624,7 +624,7 @@ function RuntimeModeToggle({
         type="button"
         disabled={disabled}
         onClick={() => { void handleSelect(choice.value) }}
-        className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-[11px] transition-colors disabled:opacity-40 ${
+        className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs transition-colors disabled:opacity-40 ${
           current === choice.value
             ? 'text-text-primary'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
@@ -634,7 +634,7 @@ function RuntimeModeToggle({
       >
         <span className="truncate">{choice.label}</span>
         {current === choice.value && <span className="ml-2 text-accent">✓</span>}
-        {disabled && <span className="ml-2 text-[10px] text-text-secondary/60">off</span>}
+        {disabled && <span className="ml-2 text-xs text-text-secondary/60">off</span>}
       </button>
     )
   })
@@ -643,7 +643,7 @@ function RuntimeModeToggle({
   if (variant === 'menu') {
     return (
       <div>
-        <div className="px-2 pb-0.5 pt-1 text-[10px] font-medium uppercase tracking-wide text-text-secondary/60">
+        <div className="px-2 pb-0.5 pt-1 text-xs font-medium uppercase tracking-wide text-text-secondary/60">
           Runtime
         </div>
         {choiceButtons}
@@ -662,7 +662,7 @@ function RuntimeModeToggle({
         aria-label="Runtime mode"
         title={`Runtime: ${label} — click to switch`}
         data-testid="agent-panel-runtime-toggle"
-        className={`inline-flex h-7 items-center gap-1 rounded-md border border-border-default bg-surface text-[11px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 ${
+        className={`inline-flex h-7 items-center gap-1 rounded-md border border-border-default bg-surface text-xs font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 ${
           iconOnly ? 'w-7 justify-center px-0' : 'px-2'
         }`}
         style={{ cursor: busy ? 'wait' : 'pointer' }}
@@ -721,7 +721,7 @@ function AgentHeaderControls({
       onClick={() => { close(); onKill() }}
       disabled={killBusy}
       data-testid="agent-panel-kill-button"
-      className="flex w-full items-center rounded px-2 py-1.5 text-left text-[11px] font-medium text-error hover:bg-error/10 disabled:opacity-50"
+      className="flex w-full items-center rounded px-2 py-1.5 text-left text-xs font-medium text-error hover:bg-error/10 disabled:opacity-50"
       style={{ cursor: killBusy ? 'wait' : 'pointer' }}
     >
       Kill session
@@ -785,7 +785,7 @@ function HoldButton({
         onClick={onToggle}
         disabled={busy}
         data-testid="agent-panel-hold-button"
-        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[11px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
         style={{ cursor: busy ? 'wait' : 'pointer' }}
       >
         <HoldIcon />
@@ -801,7 +801,7 @@ function HoldButton({
       disabled={busy}
       data-testid="agent-panel-hold-button"
       title={title}
-      className={`inline-flex h-7 items-center gap-1.5 rounded-md border text-[11px] font-medium transition-colors disabled:opacity-50 ${
+      className={`inline-flex h-7 items-center gap-1.5 rounded-md border text-xs font-medium transition-colors disabled:opacity-50 ${
         compact ? 'w-7 justify-center px-0' : 'px-2'
       } ${
         held

--- a/src/components/panel/agent-transcript.tsx
+++ b/src/components/panel/agent-transcript.tsx
@@ -82,7 +82,7 @@ export function AgentTranscript({
       {isEmpty ? (
         <div className="flex h-full items-center justify-center">
           <div className="max-w-sm text-center">
-            <div className="mb-3 text-[10px] uppercase tracking-[0.18em] text-text-secondary">
+            <div className="mb-3 text-xs uppercase tracking-[0.18em] text-text-secondary">
               No semantic transcript yet
             </div>
             <p className="text-sm leading-relaxed text-text-secondary">
@@ -374,7 +374,7 @@ function RunGroup({ group, isLatest }: { group: Extract<TranscriptGroup, { kind:
           {group.header.detail ? ` · ${group.header.detail}` : ''}
         </span>
         <RunStatusBadge status={status} detail={runStatusDetail(group.items)} />
-        <time className="shrink-0 text-[10px] text-text-secondary/50">
+        <time className="shrink-0 text-xs text-text-secondary/50">
           {new Date(group.header.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
         </time>
       </button>
@@ -477,7 +477,7 @@ function RunStatusBadge({ status, detail }: { status: RunStatus; detail?: string
   }[status]
 
   return (
-    <span className={`shrink-0 rounded border px-2 py-0.5 text-[10px] font-semibold ${className}`}>
+    <span className={`shrink-0 rounded border px-2 py-0.5 text-xs font-semibold ${className}`}>
       {label}{detail ? ` · ${detail}` : ''}
     </span>
   )
@@ -600,7 +600,7 @@ function CollapsibleBlock({ label, content, storageKey }: { label: string; conte
       <button
         type="button"
         onClick={() => { setOpen(!open) }}
-        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[11px] text-text-secondary hover:text-text-primary"
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs text-text-secondary hover:text-text-primary"
         style={{ cursor: 'pointer' }}
       >
         <span className={`transition-transform ${open ? 'rotate-90' : ''}`}>›</span>
@@ -697,16 +697,16 @@ function ActionDisclosure({
         <span className={`text-xs text-running/65 transition-transform ${open ? 'rotate-90' : ''}`}>▶</span>
         <span className="font-semibold text-running/70">{title}</span>
         {status && (
-          <span className="text-[10px] text-text-secondary/60">
+          <span className="text-xs text-text-secondary/60">
             {status}
           </span>
         )}
         {timestamp && (
-          <time className="text-[10px] text-text-secondary/45">
+          <time className="text-xs text-text-secondary/45">
             {new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
           </time>
         )}
-        {hasDetail && <span className="ml-auto text-[10px] text-text-secondary">details</span>}
+        {hasDetail && <span className="ml-auto text-xs text-text-secondary">details</span>}
       </button>
       <AnimatePresence>
         {open && hasDetail && (
@@ -809,7 +809,7 @@ function PendingSemanticRunEntry({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded border border-border-default px-2 py-0.5 text-[10px] text-text-secondary hover:border-error/40 hover:text-error"
+            className="rounded border border-border-default px-2 py-0.5 text-xs text-text-secondary hover:border-error/40 hover:text-error"
             style={{ cursor: 'pointer' }}
           >
             Cancel

--- a/src/components/panel/chat-flat.tsx
+++ b/src/components/panel/chat-flat.tsx
@@ -72,7 +72,7 @@ export function ChatEntry({
       className={`border-l pl-3 ${TONE_BORDER[tone]}`}
     >
       {hasHeader && (
-        <div className="mb-1 flex flex-wrap items-center gap-2 text-[11px]">
+        <div className="mb-1 flex flex-wrap items-center gap-2 text-xs">
           {label && <span className={`font-semibold ${TONE_LABEL[tone]}`}>{label}</span>}
           {detail && <span className="min-w-0 break-words text-text-secondary/70">{detail}</span>}
           {time && <time className="text-text-secondary/50">{time}</time>}
@@ -93,7 +93,7 @@ export function ChatDivider({ children, isLatest = false }: { children: ReactNod
       className="flex items-center gap-3 py-0.5"
     >
       <div className="h-px flex-1 bg-border-default" />
-      <span className="max-w-full truncate text-[10px] text-text-secondary">{children}</span>
+      <span className="max-w-full truncate text-xs text-text-secondary">{children}</span>
       <div className="h-px flex-1 bg-border-default" />
     </motion.div>
   )

--- a/src/components/panel/chat-history.tsx
+++ b/src/components/panel/chat-history.tsx
@@ -303,7 +303,7 @@ function TypingDots() {
 function QueuedEntry({ content }: { content: string }) {
   return (
     <div className="ml-3 rounded-md border border-dashed border-border-default bg-surface/30 px-3 py-2 opacity-70">
-      <div className="mb-1 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-text-secondary/70">
+      <div className="mb-1 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-text-secondary/70">
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" className="h-3 w-3" aria-hidden="true">
           <circle cx="8" cy="8" r="6" />
           <path d="M8 5v3l2 1.5" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/components/panel/file-browser.tsx
+++ b/src/components/panel/file-browser.tsx
@@ -32,13 +32,13 @@ export function FileBrowser({ workspaceId, selectedPath, onSelectFile }: FileBro
   }, [workspaceId])
 
   if (error) {
-    return <p className="px-2 py-3 text-[11px] text-red-400">{error}</p>
+    return <p className="px-2 py-3 text-xs text-red-400">{error}</p>
   }
   if (root === null) {
-    return <p className="px-2 py-3 text-[11px] text-text-secondary/60">Loading…</p>
+    return <p className="px-2 py-3 text-xs text-text-secondary/60">Loading…</p>
   }
   if (root.length === 0) {
-    return <p className="px-2 py-3 text-[11px] text-text-secondary/60">Empty repository</p>
+    return <p className="px-2 py-3 text-xs text-text-secondary/60">Empty repository</p>
   }
 
   return (
@@ -83,7 +83,7 @@ function Row({
       type="button"
       onClick={onClick}
       style={{ paddingLeft: 8 + depth * 12, cursor: 'pointer' }}
-      className={`flex w-full items-center gap-1.5 py-0.5 pr-2 text-left text-[11px] transition-colors ${
+      className={`flex w-full items-center gap-1.5 py-0.5 pr-2 text-left text-xs transition-colors ${
         active
           ? 'bg-surface-hover text-text-primary'
           : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
@@ -146,7 +146,7 @@ function DirNode({
       {open && (
         <div>
           {loading && children === null && (
-            <p className="py-0.5 text-[11px] text-text-secondary/50" style={{ paddingLeft: 8 + (depth + 1) * 12 }}>
+            <p className="py-0.5 text-xs text-text-secondary/50" style={{ paddingLeft: 8 + (depth + 1) * 12 }}>
               …
             </p>
           )}

--- a/src/components/panel/file-preview.tsx
+++ b/src/components/panel/file-preview.tsx
@@ -63,7 +63,7 @@ export function FilePreview({ workspaceId, file, onClose }: FilePreviewProps) {
           <button
             type="button"
             onClick={() => { void openInEditor(workspaceId, file.path).catch(() => {}) }}
-            className="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            className="flex items-center gap-1 rounded px-1.5 py-1 text-xs text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
             title="Open in editor (VS Code)"
             aria-label="Open in editor"
             style={{ cursor: 'pointer' }}

--- a/src/components/panel/files-tree.tsx
+++ b/src/components/panel/files-tree.tsx
@@ -141,7 +141,7 @@ export function FilesTree({ groupedFiles, selectedFile, onSelectFile, loading }:
                           <path fillRule="evenodd" d="M4 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.414A2 2 0 0 0 13.414 6L10 2.586A2 2 0 0 0 8.586 2H4Zm5 2a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h1a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H9Z" clipRule="evenodd" />
                         </svg>
                         <span className="truncate flex-1">{file.name}</span>
-                        <span className="text-text-secondary/40 text-[10px]">{formatDate(file.modifiedAt)}</span>
+                        <span className="text-text-secondary/40 text-xs">{formatDate(file.modifiedAt)}</span>
                       </button>
                     </li>
                   )

--- a/src/components/panel/interactive-agent-view.tsx
+++ b/src/components/panel/interactive-agent-view.tsx
@@ -250,7 +250,7 @@ export function InteractiveAgentView({
       />
       {error && (
         <div
-          className="border-b border-error/30 bg-error/10 px-3 py-1.5 text-[11px] text-error"
+          className="border-b border-error/30 bg-error/10 px-3 py-1.5 text-xs text-error"
           data-testid="interactive-agent-view-error"
         >
           {error}
@@ -261,7 +261,7 @@ export function InteractiveAgentView({
           data-testid="interactive-agent-done-banner"
           className="flex items-center justify-between gap-3 border-b border-running/30 bg-running/10 px-3 py-1.5"
         >
-          <span className="text-[11px] text-running">
+          <span className="text-xs text-running">
             ✓ Agent signaled it's done. The session is still live — keep chatting, or advance the column when you're satisfied.
           </span>
           <div className="flex items-center gap-2">
@@ -269,7 +269,7 @@ export function InteractiveAgentView({
               type="button"
               onClick={() => { setDoneSignaled(false) }}
               data-testid="interactive-agent-done-dismiss"
-              className="rounded px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary"
+              className="rounded px-2 py-0.5 text-xs text-text-secondary hover:text-text-primary"
               style={{ cursor: 'pointer' }}
             >
               Dismiss
@@ -280,7 +280,7 @@ export function InteractiveAgentView({
               disabled={advancing}
               data-testid="interactive-agent-advance"
               title="Mark complete and run the column's exit/advance"
-              className="rounded border border-running/40 bg-running/15 px-2 py-0.5 text-[11px] font-medium text-running hover:bg-running/25 disabled:opacity-50"
+              className="rounded border border-running/40 bg-running/15 px-2 py-0.5 text-xs font-medium text-running hover:bg-running/25 disabled:opacity-50"
               style={{ cursor: advancing ? 'wait' : 'pointer' }}
             >
               {advancing ? 'Advancing…' : 'Advance column →'}
@@ -345,7 +345,7 @@ function ControlBar({
       <div className="flex items-center gap-2">
         <span
           data-testid="interactive-agent-status"
-          className={`inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-[11px] font-medium ${statusColor}`}
+          className={`inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-medium ${statusColor}`}
         >
           <span
             className={`h-1.5 w-1.5 rounded-full ${
@@ -366,7 +366,7 @@ function ControlBar({
                 ? 'Paused'
                 : 'Stopped'}
         </span>
-        <span className="text-[11px] text-text-secondary/70">Interactive</span>
+        <span className="text-xs text-text-secondary/70">Interactive</span>
       </div>
       <div className="flex items-center gap-2">
         <ModelDropdown
@@ -385,7 +385,7 @@ function ControlBar({
               ? 'Resume the suspended agent process'
               : 'Suspend the agent process (SIGTSTP). In-flight network requests keep going — use Interrupt for a hard stop.'
           }
-          className="rounded border border-border-default bg-surface px-2 py-0.5 text-[11px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+          className="rounded border border-border-default bg-surface px-2 py-0.5 text-xs font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
           style={{ cursor: pauseBusy ? 'wait' : sessionAvailable ? 'pointer' : 'not-allowed' }}
         >
           {isPaused ? 'Resume' : 'Pause'}
@@ -396,7 +396,7 @@ function ControlBar({
           disabled={interrupting || !sessionAvailable}
           data-testid="interactive-agent-interrupt"
           title={sessionAvailable ? 'Send Ctrl+C — aborts current generation, agent stays at prompt' : 'Agent session is stopped'}
-          className="rounded border border-border-default bg-surface px-2 py-0.5 text-[11px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+          className="rounded border border-border-default bg-surface px-2 py-0.5 text-xs font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
           style={{ cursor: interrupting ? 'wait' : sessionAvailable ? 'pointer' : 'not-allowed' }}
         >
           Interrupt
@@ -407,7 +407,7 @@ function ControlBar({
           disabled={restarting}
           data-testid="interactive-agent-restart"
           title="Kill the agent and respawn with the same trigger config"
-          className="rounded border border-warning/40 bg-surface px-2 py-0.5 text-[11px] font-medium text-warning hover:bg-warning/10 disabled:opacity-50"
+          className="rounded border border-warning/40 bg-surface px-2 py-0.5 text-xs font-medium text-warning hover:bg-warning/10 disabled:opacity-50"
           style={{ cursor: restarting ? 'wait' : 'pointer' }}
         >
           Restart
@@ -442,7 +442,7 @@ function ModelDropdown({
           ? 'Wait for the agent to finish responding before switching models'
           : 'Send /model <name> to the live agent'
       }
-      className="rounded border border-border-default bg-bg px-1.5 py-0.5 text-[11px] text-text-primary disabled:opacity-50"
+      className="rounded border border-border-default bg-bg px-1.5 py-0.5 text-xs text-text-primary disabled:opacity-50"
     >
       <option value="">Model: pick…</option>
       {MODEL_OPTIONS.map((m) => (

--- a/src/components/panel/orchestrator-terminal-view.tsx
+++ b/src/components/panel/orchestrator-terminal-view.tsx
@@ -46,7 +46,7 @@ export function OrchestratorTerminalView({
             return (
               <div
                 key={shell}
-                className={`group flex items-center gap-1 rounded px-2 py-0.5 text-[11px] ${
+                className={`group flex items-center gap-1 rounded px-2 py-0.5 text-xs ${
                   isActive
                     ? 'bg-surface-hover text-text-primary'
                     : 'text-text-secondary hover:bg-surface-hover/60'

--- a/src/components/panel/pipeline-dashboard.tsx
+++ b/src/components/panel/pipeline-dashboard.tsx
@@ -131,11 +131,11 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
                 >
                   <div className="flex items-center justify-between gap-1">
                     <span className="truncate text-xs font-medium text-text-primary">{task.title}</span>
-                    <span className="shrink-0 text-[10px] text-text-tertiary">{elapsed}</span>
+                    <span className="shrink-0 text-xs text-text-tertiary">{elapsed}</span>
                   </div>
                   <div className="mt-1 flex items-center gap-1.5">
-                    <span className="text-[10px] text-text-tertiary">{col?.name ?? 'Unknown'}</span>
-                    {label && <span className="text-[10px] text-accent">{label}</span>}
+                    <span className="text-xs text-text-tertiary">{col?.name ?? 'Unknown'}</span>
+                    {label && <span className="text-xs text-accent">{label}</span>}
                   </div>
                   {/* Progress bar */}
                   <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-surface-hover">
@@ -166,11 +166,11 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
               >
                 <div className="flex items-center justify-between gap-1">
                   <span className="truncate text-xs font-medium text-text-primary">{task.title}</span>
-                  <span className="text-[10px] text-text-tertiary">{formatRelativeTime(task.updatedAt)}</span>
+                  <span className="text-xs text-text-tertiary">{formatRelativeTime(task.updatedAt)}</span>
                 </div>
-                <div className="mt-0.5 text-[10px] text-text-tertiary">{col?.name ?? 'Unknown'}</div>
+                <div className="mt-0.5 text-xs text-text-tertiary">{col?.name ?? 'Unknown'}</div>
                 {task.pipelineError && (
-                  <div className="mt-1 line-clamp-2 text-[10px] text-error">{task.pipelineError}</div>
+                  <div className="mt-1 line-clamp-2 text-xs text-error">{task.pipelineError}</div>
                 )}
               </button>
             )
@@ -191,13 +191,13 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
               >
                 <div className="flex items-center justify-between gap-1">
                   <span className="truncate text-xs font-medium text-text-primary">{task.title}</span>
-                  <span className="text-[10px] text-text-tertiary">{formatRelativeTime(task.updatedAt)}</span>
+                  <span className="text-xs text-text-tertiary">{formatRelativeTime(task.updatedAt)}</span>
                 </div>
                 {prUrl && (
                   <button
                     type="button"
                     onClick={() => { window.open(prUrl, '_blank') }}
-                    className="mt-0.5 text-[10px] text-accent hover:underline"
+                    className="mt-0.5 text-xs text-accent hover:underline"
                     style={{ cursor: 'pointer' }}
                   >
                     {task.prNumber ? `PR #${String(task.prNumber)}` : 'View PR'}
@@ -222,7 +222,7 @@ export function PipelineDashboard({ workspaceId }: PipelineDashboardProps) {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="mb-3">
-      <h3 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">{title}</h3>
+      <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-tertiary">{title}</h3>
       <div className="flex flex-col gap-1.5">{children}</div>
     </div>
   )

--- a/src/components/panel/pipeline-v2-dashboard.tsx
+++ b/src/components/panel/pipeline-v2-dashboard.tsx
@@ -103,7 +103,7 @@ export function PipelineV2Dashboard({ workspaceId }: PipelineV2DashboardProps) {
     <div className="flex h-full w-72 flex-col overflow-y-auto border-r border-border-default bg-surface-secondary p-3 text-sm">
       {/* Summary stats */}
       <div className="mb-4">
-        <h2 className="text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">Pipeline Status</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-text-tertiary">Pipeline Status</h2>
         <div className="mt-2 flex gap-4">
           <Stat label="In flight" value={String(activeTasks.length)} />
           {colCounts.size > 0 && (
@@ -135,15 +135,15 @@ export function PipelineV2Dashboard({ workspaceId }: PipelineV2DashboardProps) {
             const eta = computeTaskEta(task, sortedColumns, avgCompletionMs)
             return (
               <div key={task.id} className="flex items-center justify-between gap-1">
-                <span className="truncate text-[10px] text-text-secondary">{task.title}</span>
-                <span className="shrink-0 text-[10px] text-text-tertiary">
+                <span className="truncate text-xs text-text-secondary">{task.title}</span>
+                <span className="shrink-0 text-xs text-text-tertiary">
                   {eta > 0 ? `~${formatMs(eta)}` : 'soon'}
                 </span>
               </div>
             )
           })}
           {activeTasks.length > 6 && (
-            <span className="text-[10px] text-text-tertiary">+{activeTasks.length - 6} more</span>
+            <span className="text-xs text-text-tertiary">+{activeTasks.length - 6} more</span>
           )}
         </Section>
       )}
@@ -153,10 +153,10 @@ export function PipelineV2Dashboard({ workspaceId }: PipelineV2DashboardProps) {
         <Section title="Batches">
           {Array.from(batchGroups.entries()).map(([batchId, batchTasks]) => (
             <div key={batchId} className="flex items-center justify-between gap-1">
-              <span className="truncate text-[10px] text-text-secondary">
+              <span className="truncate text-xs text-text-secondary">
                 {batchId === 'ungrouped' ? 'No batch' : batchId.slice(0, 12)}
               </span>
-              <span className="shrink-0 text-[10px] text-text-tertiary">
+              <span className="shrink-0 text-xs text-text-tertiary">
                 {batchTasks.length} {batchTasks.length === 1 ? 'task' : 'tasks'}
               </span>
             </div>
@@ -168,16 +168,16 @@ export function PipelineV2Dashboard({ workspaceId }: PipelineV2DashboardProps) {
       {usageSummary && usageSummary.recordCount > 0 && (
         <Section title="Usage">
           <div className="flex items-center justify-between gap-1">
-            <span className="text-[10px] text-text-secondary">Input tokens</span>
-            <span className="text-[10px] text-text-tertiary">{formatTokens(usageSummary.totalInputTokens)}</span>
+            <span className="text-xs text-text-secondary">Input tokens</span>
+            <span className="text-xs text-text-tertiary">{formatTokens(usageSummary.totalInputTokens)}</span>
           </div>
           <div className="flex items-center justify-between gap-1">
-            <span className="text-[10px] text-text-secondary">Output tokens</span>
-            <span className="text-[10px] text-text-tertiary">{formatTokens(usageSummary.totalOutputTokens)}</span>
+            <span className="text-xs text-text-secondary">Output tokens</span>
+            <span className="text-xs text-text-tertiary">{formatTokens(usageSummary.totalOutputTokens)}</span>
           </div>
           <div className="flex items-center justify-between gap-1">
-            <span className="text-[10px] text-text-secondary">Sessions</span>
-            <span className="text-[10px] text-text-tertiary">{usageSummary.recordCount}</span>
+            <span className="text-xs text-text-secondary">Sessions</span>
+            <span className="text-xs text-text-tertiary">{usageSummary.recordCount}</span>
           </div>
         </Section>
       )}
@@ -233,7 +233,7 @@ function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex flex-col">
       <span className="text-xs font-medium text-text-primary">{value}</span>
-      <span className="text-[10px] text-text-tertiary">{label}</span>
+      <span className="text-xs text-text-tertiary">{label}</span>
     </div>
   )
 }
@@ -241,14 +241,14 @@ function Stat({ label, value }: { label: string; value: string }) {
 function ColumnBar({ column, count, pct }: { column: Column; count: number; pct: number }) {
   return (
     <div className="flex items-center gap-2">
-      <span className="w-20 shrink-0 truncate text-[10px] text-text-secondary">{column.name}</span>
+      <span className="w-20 shrink-0 truncate text-xs text-text-secondary">{column.name}</span>
       <div className="flex-1 overflow-hidden rounded-full bg-surface-hover" style={{ height: 5 }}>
         <div
           className="h-full rounded-full bg-accent transition-all duration-500"
           style={{ width: `${String(pct)}%` }}
         />
       </div>
-      <span className="w-4 shrink-0 text-right text-[10px] text-text-tertiary">{count}</span>
+      <span className="w-4 shrink-0 text-right text-xs text-text-tertiary">{count}</span>
     </div>
   )
 }
@@ -256,7 +256,7 @@ function ColumnBar({ column, count, pct }: { column: Column; count: number; pct:
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="mb-3">
-      <h3 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">{title}</h3>
+      <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-tertiary">{title}</h3>
       <div className="flex flex-col gap-1">{children}</div>
     </div>
   )

--- a/src/components/panel/shared/attachment-button.tsx
+++ b/src/components/panel/shared/attachment-button.tsx
@@ -46,7 +46,7 @@ export function AttachmentButton({
           </svg>
         )}
         {count > 0 && (
-          <span className="absolute -right-1 -top-1 min-w-3 rounded-full bg-accent px-0.5 text-[8px] leading-3 text-bg">
+          <span className="absolute -right-1 -top-1 min-w-3 rounded-full bg-accent px-0.5 text-2xs leading-3 text-bg">
             {count}
           </span>
         )}

--- a/src/components/panel/shared/attachment-preview.tsx
+++ b/src/components/panel/shared/attachment-preview.tsx
@@ -64,7 +64,7 @@ function AttachmentItem({ attachment, onRemove, disabled }: AttachmentItemProps)
           <span className="text-xs text-text-primary truncate max-w-[100px]">
             {attachment.name}
           </span>
-          <span className="text-[10px] text-text-muted">
+          <span className="text-xs text-text-muted">
             {formatFileSize(attachment.size)}
           </span>
         </div>

--- a/src/components/panel/shared/chat-input.tsx
+++ b/src/components/panel/shared/chat-input.tsx
@@ -72,7 +72,7 @@ export function ChatInput({
                 />
               )}
               {config.showModelSelector && (
-                <span className="h-6 rounded border border-border-default/70 px-1.5 py-1 text-[10px] leading-none text-text-secondary/70">
+                <span className="h-6 rounded border border-border-default/70 px-1.5 py-1 text-xs leading-none text-text-secondary/70">
                   {state.currentContextWindow}
                 </span>
               )}
@@ -92,7 +92,7 @@ export function ChatInput({
                   <button
                     type="button"
                     onClick={state.handleContextToggle}
-                    className={`h-6 rounded border px-2 text-[11px] transition-colors ${
+                    className={`h-6 rounded border px-2 text-xs transition-colors ${
                       state.extendedContext
                         ? 'border-accent/30 bg-accent/10 text-accent'
                         : 'border-border-default/70 text-text-secondary hover:bg-surface-hover hover:text-text-primary'
@@ -110,13 +110,13 @@ export function ChatInput({
                 />
               )}
               {deliveryHint && (
-                <span className="min-w-0 truncate text-[11px] text-text-secondary">
+                <span className="min-w-0 truncate text-xs text-text-secondary">
                   {deliveryHint}
                 </span>
               )}
             </div>
             {queueCount > 0 && (
-              <span className="shrink-0 rounded border border-accent/20 px-1.5 py-0.5 text-[10px] text-accent/75">
+              <span className="shrink-0 rounded border border-accent/20 px-1.5 py-0.5 text-xs text-accent/75">
                 {queueCount} queued
               </span>
             )}

--- a/src/components/panel/workspace-files-view.tsx
+++ b/src/components/panel/workspace-files-view.tsx
@@ -43,7 +43,7 @@ export function WorkspaceFilesView({ workspaceId }: { workspaceId: string }) {
                 onClick={() => { setMode(m) }}
                 aria-pressed={mode === m}
                 data-testid={`files-mode-${m}`}
-                className={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                className={`rounded px-1.5 py-0.5 text-xs font-medium transition-colors ${
                   mode === m
                     ? 'bg-surface-hover text-text-primary'
                     : 'text-text-secondary hover:text-text-primary'

--- a/src/components/review/diff-viewer.tsx
+++ b/src/components/review/diff-viewer.tsx
@@ -246,7 +246,7 @@ function ActionButton({
       title={title}
       data-diff-action="true"
       style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
-      className="rounded border border-border-default/80 bg-surface px-1.5 py-0.5 text-[10px] font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+      className="rounded border border-border-default/80 bg-surface px-1.5 py-0.5 text-xs font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
     >
       {children}
     </button>
@@ -712,7 +712,7 @@ export function DiffViewer({
     <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
       {selectable && (
         <div className="mb-2 flex flex-wrap items-center gap-2 rounded border border-border-default bg-surface px-2 py-1.5">
-          <span className="mr-auto text-[11px] text-text-secondary">
+          <span className="mr-auto text-xs text-text-secondary">
             {selectedLineKeys.size > 0
               ? `${String(selectedLineKeys.size)} line${selectedLineKeys.size === 1 ? '' : 's'} selected`
               : 'Select diff lines to copy or send context'}

--- a/src/components/roster/agent-dossier.tsx
+++ b/src/components/roster/agent-dossier.tsx
@@ -40,12 +40,12 @@ function Section({
       <header className="flex items-center gap-2 border-b border-border-default px-4 py-2.5">
         <h4 className="text-xs font-semibold text-text-primary">{title}</h4>
         {count !== undefined && count > 0 && (
-          <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+          <span className="rounded bg-surface-hover px-1.5 py-0.5 text-xs font-medium text-text-secondary">
             {count}
           </span>
         )}
         {v2 && (
-          <span className="ml-auto rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+          <span className="ml-auto rounded bg-accent/10 px-1.5 py-0.5 text-xs font-medium text-accent">
             v2
           </span>
         )}
@@ -64,7 +64,7 @@ function CodeValue({ value, copyable = false }: { value: string; copyable?: bool
 
   if (!copyable) {
     return (
-      <span className="rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] text-text-primary">
+      <span className="rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-xs text-text-primary">
         {value}
       </span>
     )
@@ -88,7 +88,7 @@ function CodeValue({ value, copyable = false }: { value: string; copyable?: bool
       }}
       title="Copy"
       style={{ cursor: 'pointer' }}
-      className="group inline-flex max-w-full items-center gap-1.5 rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] text-text-primary transition-colors hover:border-text-secondary"
+      className="group inline-flex max-w-full items-center gap-1.5 rounded border border-border-default bg-bg px-1.5 py-0.5 font-mono text-xs text-text-primary transition-colors hover:border-text-secondary"
     >
       <span className="truncate">{value}</span>
       <span className="shrink-0">
@@ -128,7 +128,7 @@ function Field({
   return (
     <div className="flex items-baseline gap-3 py-1">
       <span
-        className={`${wideLabel ? 'w-40' : 'w-28'} shrink-0 truncate font-mono text-[11px] text-text-secondary`}
+        className={`${wideLabel ? 'w-40' : 'w-28'} shrink-0 truncate font-mono text-xs text-text-secondary`}
         title={label}
       >
         {label}

--- a/src/components/roster/agent-editor.tsx
+++ b/src/components/roster/agent-editor.tsx
@@ -67,7 +67,7 @@ function Field({
 function FormSection({ title }: { title: string }) {
   return (
     <div className="sm:col-span-2">
-      <h4 className="border-b border-border-default pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary/70">
+      <h4 className="border-b border-border-default pb-1.5 text-xs font-semibold uppercase tracking-wider text-text-secondary/70">
         {title}
       </h4>
     </div>

--- a/src/components/roster/agent-tile.tsx
+++ b/src/components/roster/agent-tile.tsx
@@ -47,14 +47,14 @@ export function AgentTile({
           {avatar.initials}
         </span>
         {selected && (
-          <span className="absolute left-2 top-2 rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium text-bg">
+          <span className="absolute left-2 top-2 rounded bg-accent px-1.5 py-0.5 text-xs font-medium text-bg">
             Selected
           </span>
         )}
       </div>
       <div className="px-3 py-2">
         <div className="truncate text-sm font-medium text-text-primary">{agent.name}</div>
-        <div className="mt-1 font-mono text-[10px] uppercase tracking-wider text-text-secondary">
+        <div className="mt-1 font-mono text-xs uppercase tracking-wider text-text-secondary">
           {agent.runtime}
         </div>
       </div>

--- a/src/components/settings/settings-panel.tsx
+++ b/src/components/settings/settings-panel.tsx
@@ -343,7 +343,7 @@ export function SettingsPanel() {
               <nav className="hidden w-56 shrink-0 overflow-y-auto border-r border-border-default bg-surface/40 p-3 lg:block">
                 {TAB_GROUPS.map((group) => (
                   <div key={group.id} className="mb-4">
-                    <div className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-text-secondary/70">
+                    <div className="mb-1 px-2 text-xs font-semibold uppercase tracking-wider text-text-secondary/70">
                       {group.label}
                     </div>
                     {group.tabs.map((tab) => (

--- a/src/components/settings/tabs/agent-tab.tsx
+++ b/src/components/settings/tabs/agent-tab.tsx
@@ -345,7 +345,7 @@ export function AgentTab() {
                       <span className={`text-sm font-medium ${provider.enabled ? 'text-text-primary' : 'text-text-secondary'}`}>
                         {info.name}
                         {providerModelCount > 0 && (
-                          <span className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-accent/20 px-1 text-[10px] font-medium text-accent">
+                          <span className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-accent/20 px-1 text-xs font-medium text-accent">
                             {providerModelCount}
                           </span>
                         )}
@@ -416,7 +416,7 @@ export function AgentTab() {
                           {supportsApi ? 'API' : 'API unavailable'}
                         </button>
                       </div>
-                      <p className="mt-1.5 text-[11px] text-text-secondary/80">
+                      <p className="mt-1.5 text-xs text-text-secondary/80">
                         {connectionMode === 'cli'
                           ? 'Uses the installed CLI (auth and billing handled by the CLI).'
                           : supportsApi
@@ -460,7 +460,7 @@ export function AgentTab() {
                           const isChecking = checkingUpdate[provider.id]
                           const updateCommand = update?.updateCommand
                           return (
-                            <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
+                            <div className="mt-1.5 flex items-center gap-1.5 text-xs">
                               {isChecking ? (
                                 <span className="flex items-center gap-1 text-text-secondary">
                                   <svg className="h-2.5 w-2.5 animate-spin" viewBox="0 0 24 24" fill="none">
@@ -483,7 +483,7 @@ export function AgentTab() {
                                             setCopiedCmd(provider.id)
                                             setTimeout(() => { setCopiedCmd(null) }, 2000)
                                           }}
-                                          className="ml-0.5 rounded border border-yellow-500/30 px-1 py-0.5 text-[10px] text-yellow-400 transition-colors hover:bg-yellow-500/10"
+                                          className="ml-0.5 rounded border border-yellow-500/30 px-1 py-0.5 text-xs text-yellow-400 transition-colors hover:bg-yellow-500/10"
                                           title={updateCommand}
                                         >
                                           {copiedCmd === provider.id ? '✓ copied' : 'copy upgrade cmd'}
@@ -547,7 +547,7 @@ export function AgentTab() {
                             </label>
                             <button
                               onClick={() => { toggleAll(!allEnabled) }}
-                              className="text-[10px] text-text-secondary transition-colors hover:text-text-primary"
+                              className="text-xs text-text-secondary transition-colors hover:text-text-primary"
                             >
                               {allEnabled ? 'Deselect all' : 'Select all'}
                             </button>
@@ -582,17 +582,17 @@ export function AgentTab() {
                                       {m.displayName}
                                     </span>
                                     {m.alias && (
-                                      <span className="rounded bg-surface-hover px-1 py-0.5 text-[10px] font-mono text-text-secondary">
+                                      <span className="rounded bg-surface-hover px-1 py-0.5 text-xs font-mono text-text-secondary">
                                         {m.alias}
                                       </span>
                                     )}
                                     {m.isNew && (
-                                      <span className="rounded bg-accent/20 px-1 py-0.5 text-[10px] font-medium text-accent">
+                                      <span className="rounded bg-accent/20 px-1 py-0.5 text-xs font-medium text-accent">
                                         New
                                       </span>
                                     )}
                                   </div>
-                                  <span className="text-[10px] text-text-secondary">
+                                  <span className="text-xs text-text-secondary">
                                     {String(Math.round(m.contextWindow / 1000))}k
                                   </span>
                                 </div>
@@ -631,7 +631,7 @@ export function AgentTab() {
                 <div key={item.name} className="rounded-lg border border-border-default bg-surface/40 p-3">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-text-primary">{item.name}</span>
-                    <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-text-secondary">
+                    <span className="rounded bg-surface-hover px-1.5 py-0.5 text-xs uppercase tracking-wide text-text-secondary">
                       Coming soon
                     </span>
                   </div>
@@ -818,7 +818,7 @@ export function AgentTab() {
                       className="w-24 rounded-lg border border-border-default bg-surface px-2 py-1.5 text-right text-sm tabular-nums text-text-primary placeholder:text-text-secondary/50 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
                       aria-label={`${entry.displayName} daily budget`}
                     />
-                    <span className="text-[10px] text-text-secondary/60">/day</span>
+                    <span className="text-xs text-text-secondary/60">/day</span>
                   </label>
                 </div>
               )
@@ -843,7 +843,7 @@ function StatusTile({ label, value, tone }: { label: string; value: string; tone
         : 'border-border-default bg-surface/50 text-text-primary'
   return (
     <div className={`rounded-lg border px-3 py-2 ${accent}`}>
-      <div className="text-[10px] uppercase tracking-wider text-text-secondary/80">{label}</div>
+      <div className="text-xs uppercase tracking-wider text-text-secondary/80">{label}</div>
       <div className="mt-0.5 text-sm font-semibold tabular-nums">{value}</div>
     </div>
   )
@@ -881,7 +881,7 @@ function PermissionCard({
       <div className="flex w-full items-center justify-between">
         <span className="text-sm font-semibold text-text-primary">{label}</span>
         {tag && (
-          <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tagStyle}`}>
+          <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${tagStyle}`}>
             {tag}
           </span>
         )}

--- a/src/components/settings/tabs/debug-tab.tsx
+++ b/src/components/settings/tabs/debug-tab.tsx
@@ -82,7 +82,7 @@ function flagValue(args: string[], flag: string): string | null {
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[10px] font-medium uppercase tracking-wide text-text-secondary/70">{label}</span>
+      <span className="text-xs font-medium uppercase tracking-wide text-text-secondary/70">{label}</span>
       {children}
     </div>
   )
@@ -90,7 +90,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 function Mono({ children }: { children: React.ReactNode }) {
   return (
-    <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-border-default bg-bg p-2 font-mono text-[11px] leading-relaxed text-text-primary">
+    <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-border-default bg-bg p-2 font-mono text-xs leading-relaxed text-text-primary">
       {children}
     </pre>
   )
@@ -99,38 +99,38 @@ function Mono({ children }: { children: React.ReactNode }) {
 function EventRow({ ev }: { ev: ParsedEvent }) {
   switch (ev.kind) {
     case 'system':
-      return <div className="text-[11px] text-text-secondary/60">⚙ {ev.text}</div>
+      return <div className="text-xs text-text-secondary/60">⚙ {ev.text}</div>
     case 'text':
       return (
-        <div className="rounded border-l-2 border-border-default bg-surface/30 px-2 py-1 text-[12px] text-text-primary">
+        <div className="rounded border-l-2 border-border-default bg-surface/30 px-2 py-1 text-sm text-text-primary">
           <span className="text-text-secondary/60">assistant </span>
           <span className="whitespace-pre-wrap break-words">{ev.text}</span>
         </div>
       )
     case 'tool_use':
       return (
-        <div className="rounded border-l-2 border-accent/50 bg-accent/5 px-2 py-1 text-[11px]">
+        <div className="rounded border-l-2 border-accent/50 bg-accent/5 px-2 py-1 text-xs">
           <span className="font-semibold text-accent">🔧 {ev.name}</span>
           <span className="ml-1 break-words font-mono text-text-secondary">{JSON.stringify(ev.input)}</span>
         </div>
       )
     case 'tool_result':
       return (
-        <div className="rounded border-l-2 border-running/40 bg-running/5 px-2 py-1 font-mono text-[11px] text-text-secondary">
+        <div className="rounded border-l-2 border-running/40 bg-running/5 px-2 py-1 font-mono text-xs text-text-secondary">
           <span className="text-running/80">← result </span>
           <span className="break-words">{ev.text.length > 600 ? `${ev.text.slice(0, 600)}…` : ev.text}</span>
         </div>
       )
     case 'result':
       return (
-        <div className="rounded border-l-2 border-running/60 bg-running/5 px-2 py-1 text-[11px]">
+        <div className="rounded border-l-2 border-running/60 bg-running/5 px-2 py-1 text-xs">
           <span className="font-semibold text-running">✓ result</span>
           {ev.meta && <span className="ml-1 text-text-secondary/70">{ev.meta}</span>}
           {ev.text && <div className="mt-0.5 whitespace-pre-wrap break-words text-text-primary">{ev.text}</div>}
         </div>
       )
     case 'raw':
-      return <div className="break-words font-mono text-[10px] text-text-secondary/50">{ev.text}</div>
+      return <div className="break-words font-mono text-xs text-text-secondary/50">{ev.text}</div>
   }
 }
 
@@ -158,30 +158,30 @@ function TurnCard({ turn }: { turn: ChatDebugTurn }) {
       >
         <span className={`text-xs text-text-secondary transition-transform ${open ? 'rotate-90' : ''}`}>▶</span>
         <span className="font-mono text-xs font-semibold text-text-primary">{cli}</span>
-        {model && <span className="rounded bg-bg px-1.5 py-0.5 text-[10px] text-text-secondary">{model}</span>}
-        {mcpConfig && <span className="rounded bg-accent/10 px-1.5 py-0.5 text-[10px] text-accent">mcp</span>}
-        {resume && <span className="rounded bg-bg px-1.5 py-0.5 text-[10px] text-text-secondary">resume</span>}
-        <span className="ml-auto text-[10px] text-text-secondary/60">{events.length} events · {time}</span>
+        {model && <span className="rounded bg-bg px-1.5 py-0.5 text-xs text-text-secondary">{model}</span>}
+        {mcpConfig && <span className="rounded bg-accent/10 px-1.5 py-0.5 text-xs text-accent">mcp</span>}
+        {resume && <span className="rounded bg-bg px-1.5 py-0.5 text-xs text-text-secondary">resume</span>}
+        <span className="ml-auto text-xs text-text-secondary/60">{events.length} events · {time}</span>
       </button>
 
       {open && (
         <div className="space-y-3 border-t border-border-default px-3 py-3">
           {/* SENT */}
           <div className="space-y-2">
-            <div className="text-[10px] font-semibold uppercase tracking-wide text-text-secondary">↑ Sent</div>
+            <div className="text-xs font-semibold uppercase tracking-wide text-text-secondary">↑ Sent</div>
             <Field label="command">
-              <span className="break-words font-mono text-[11px] text-text-primary">
+              <span className="break-words font-mono text-xs text-text-primary">
                 {turn.command} {turn.args.filter((a) => a !== systemPrompt).join(' ')}
               </span>
             </Field>
             {allowedTools && (
               <Field label="allowed tools">
-                <span className="break-words font-mono text-[11px] text-accent">{allowedTools}</span>
+                <span className="break-words font-mono text-xs text-accent">{allowedTools}</span>
               </Field>
             )}
             {systemPrompt && (
               <Field label={`system prompt (${String(systemPrompt.length)} chars)`}>
-                <button type="button" onClick={() => { setShowSys((v) => !v) }} className="self-start text-[11px] text-accent" style={{ cursor: 'pointer' }}>
+                <button type="button" onClick={() => { setShowSys((v) => !v) }} className="self-start text-xs text-accent" style={{ cursor: 'pointer' }}>
                   {showSys ? 'hide' : 'show'}
                 </button>
                 {showSys && <Mono>{systemPrompt}</Mono>}
@@ -195,14 +195,14 @@ function TurnCard({ turn }: { turn: ChatDebugTurn }) {
           {/* RECEIVED */}
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <div className="text-[10px] font-semibold uppercase tracking-wide text-text-secondary">↓ Received</div>
-              <button type="button" onClick={() => { setShowRaw((v) => !v) }} className="text-[10px] text-text-secondary/70 hover:text-text-primary" style={{ cursor: 'pointer' }}>
+              <div className="text-xs font-semibold uppercase tracking-wide text-text-secondary">↓ Received</div>
+              <button type="button" onClick={() => { setShowRaw((v) => !v) }} className="text-xs text-text-secondary/70 hover:text-text-primary" style={{ cursor: 'pointer' }}>
                 {showRaw ? 'parsed' : 'raw'}
               </button>
-              {turn.outputTruncated && <span className="text-[10px] text-warning">(truncated)</span>}
+              {turn.outputTruncated && <span className="text-xs text-warning">(truncated)</span>}
             </div>
             {turn.output.length === 0 ? (
-              <div className="text-[11px] text-text-secondary/60">(no output captured)</div>
+              <div className="text-xs text-text-secondary/60">(no output captured)</div>
             ) : showRaw ? (
               <Mono>{turn.output.join('\n')}</Mono>
             ) : (

--- a/src/components/settings/tabs/git-tab.tsx
+++ b/src/components/settings/tabs/git-tab.tsx
@@ -55,7 +55,7 @@ export function GitTab() {
 
       <SettingSection title="Automation">
         <div className="relative">
-          <span className="absolute -top-7 right-0 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent">
+          <span className="absolute -top-7 right-0 rounded-full bg-accent/15 px-2 py-0.5 text-xs font-medium text-accent">
             Coming Soon
           </span>
           <div className="opacity-50 pointer-events-none">
@@ -75,7 +75,7 @@ export function GitTab() {
 
       <SettingSection title="PR Template" description="Default template for pull request descriptions">
         <div className="relative">
-          <span className="absolute -top-7 right-0 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent">
+          <span className="absolute -top-7 right-0 rounded-full bg-accent/15 px-2 py-0.5 text-xs font-medium text-accent">
             Coming Soon
           </span>
           <div className="opacity-50 pointer-events-none">

--- a/src/components/settings/tabs/model-comparison-section.tsx
+++ b/src/components/settings/tabs/model-comparison-section.tsx
@@ -168,7 +168,7 @@ export function ModelComparisonSection({ models }: Props) {
                           <td className="px-3 py-3">
                             <div className="font-medium">{metadata.displayName}</div>
                             <div
-                              className="mt-0.5 max-w-48 truncate font-mono text-[11px] text-text-secondary"
+                              className="mt-0.5 max-w-48 truncate font-mono text-xs text-text-secondary"
                               title={metadata.id}
                             >
                               {metadata.id}
@@ -261,7 +261,7 @@ function CapabilityBadges({ capabilities }: { capabilities: string[] }) {
       {capabilities.map((capability) => (
         <span
           key={capability}
-          className="rounded border border-border-default bg-surface px-1.5 py-0.5 text-[11px] capitalize text-text-secondary"
+          className="rounded border border-border-default bg-surface px-1.5 py-0.5 text-xs capitalize text-text-secondary"
         >
           {capability}
         </span>

--- a/src/components/settings/tabs/script-editor.tsx
+++ b/src/components/settings/tabs/script-editor.tsx
@@ -29,7 +29,7 @@ function TemplateVarChip({ varKey, label, hint }: { varKey: string; label: strin
       type="button"
       onClick={handleCopy}
       title={`${hint} — click to copy`}
-      className="group flex items-center gap-1 rounded bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-secondary transition-colors hover:bg-accent/10 hover:text-accent"
+      className="group flex items-center gap-1 rounded bg-surface px-1.5 py-0.5 font-mono text-xs text-text-secondary transition-colors hover:bg-accent/10 hover:text-accent"
     >
       {copied ? (
         <span className="text-green-400">✓ copied</span>
@@ -200,7 +200,7 @@ export function ScriptEditor({ script, onSave, onCancel }: ScriptEditorProps) {
               {steps.length === 0 ? (
                 <div className="rounded-lg border border-dashed border-border-default py-6 text-center">
                   <p className="text-xs text-text-secondary">No steps yet</p>
-                  <p className="mt-0.5 text-[11px] text-text-secondary/60">
+                  <p className="mt-0.5 text-xs text-text-secondary/60">
                     Add a Bash command, Agent prompt, or Check assertion below.
                   </p>
                 </div>
@@ -249,7 +249,7 @@ export function ScriptEditor({ script, onSave, onCancel }: ScriptEditorProps) {
 
             {/* Template variables */}
             <div className="rounded-lg bg-surface/50 p-3">
-              <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-text-secondary">
+              <p className="mb-2 text-xs font-medium uppercase tracking-wider text-text-secondary">
                 Template Variables — click to copy
               </p>
               <div className="flex flex-wrap gap-1">
@@ -311,10 +311,10 @@ function StepEditor({
       {/* Step header */}
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${STEP_TYPE_COLORS[step.type] ?? ''}`}>
+          <span className={`rounded px-1.5 py-0.5 text-xs font-semibold ${STEP_TYPE_COLORS[step.type] ?? ''}`}>
             {step.type}
           </span>
-          <span className="text-[11px] text-text-secondary">Step {index + 1}</span>
+          <span className="text-xs text-text-secondary">Step {index + 1}</span>
         </div>
         <div className="flex items-center gap-0.5">
           <button
@@ -392,7 +392,7 @@ function StepEditor({
           )}
           {step.type === 'bash' && (
             <label
-              className="flex items-center gap-1.5 text-[11px] text-text-secondary"
+              className="flex items-center gap-1.5 text-xs text-text-secondary"
               style={{ cursor: 'pointer' }}
             >
               <input

--- a/src/components/settings/tabs/scripts-tab.tsx
+++ b/src/components/settings/tabs/scripts-tab.tsx
@@ -275,7 +275,7 @@ function ScriptCard({
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-sm font-medium text-text-primary">{script.name}</span>
             {script.isBuiltIn && (
-              <span className="rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+              <span className="rounded bg-accent/10 px-1.5 py-0.5 text-xs font-medium text-accent">
                 built-in
               </span>
             )}
@@ -328,7 +328,7 @@ function ScriptCard({
             {showAttach && (
               <div className="absolute right-0 top-8 z-50 w-52 rounded-lg border border-border-default bg-surface shadow-lg">
                 <div className="border-b border-border-default px-3 py-2">
-                  <span className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
+                  <span className="text-xs font-medium uppercase tracking-wider text-text-secondary">
                     Attach as on_entry trigger
                   </span>
                 </div>
@@ -353,15 +353,15 @@ function ScriptCard({
                           className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs text-text-primary hover:bg-surface-hover"
                         >
                           <span className="flex items-center gap-1.5">
-                            {col.icon && <span className="text-[11px]">{col.icon}</span>}
+                            {col.icon && <span className="text-xs">{col.icon}</span>}
                             {col.name}
                           </span>
                           {isAttachedHere ? (
-                            <span className="rounded bg-green-500/10 px-1 py-0.5 text-[9px] text-green-400">
+                            <span className="rounded bg-green-500/10 px-1 py-0.5 text-2xs text-green-400">
                               attached
                             </span>
                           ) : hasOtherEntry ? (
-                            <span className="rounded bg-amber-500/10 px-1 py-0.5 text-[9px] text-amber-400">
+                            <span className="rounded bg-amber-500/10 px-1 py-0.5 text-2xs text-amber-400">
                               has trigger
                             </span>
                           ) : null}
@@ -408,7 +408,7 @@ function ScriptCard({
 
       {/* Attach status feedback */}
       {attachStatus && (
-        <p className={`mt-1.5 text-[11px] font-medium ${attachStatus.startsWith('Failed') ? 'text-error' : 'text-green-400'}`}>
+        <p className={`mt-1.5 text-xs font-medium ${attachStatus.startsWith('Failed') ? 'text-error' : 'text-green-400'}`}>
           {attachStatus}
         </p>
       )}
@@ -420,19 +420,19 @@ function ScriptCard({
             steps.map((step, i) => (
               <span
                 key={i}
-                className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium ${STEP_TYPE_COLORS[step.type] ?? 'bg-surface text-text-secondary'}`}
+                className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${STEP_TYPE_COLORS[step.type] ?? 'bg-surface text-text-secondary'}`}
               >
                 {step.name || step.type}
               </span>
             ))
           ) : (
-            <span className="text-[10px] italic text-text-secondary/50">no steps</span>
+            <span className="text-xs italic text-text-secondary/50">no steps</span>
           )}
         </div>
 
         {/* Show which columns have this script attached */}
         {attachedColumns.length > 0 && (
-          <div className="flex shrink-0 items-center gap-1 text-[10px] text-text-secondary">
+          <div className="flex shrink-0 items-center gap-1 text-xs text-text-secondary">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="currentColor" className="h-2.5 w-2.5 text-accent/60">
               <path d="M5.457 3.525a.563.563 0 0 1 .795 0 2.813 2.813 0 0 1 0 3.978l-1.5 1.5a2.813 2.813 0 1 1-3.978-3.978L1.9 3.9A.562.562 0 0 1 2.697 4.7l-.127.125a1.688 1.688 0 1 0 2.387 2.387l1.5-1.5a1.688 1.688 0 0 0 0-2.387.563.563 0 0 1 0-.8Z" />
               <path d="M6.543 8.475a.563.563 0 0 1-.795 0 2.813 2.813 0 0 1 0-3.978l1.5-1.5a2.813 2.813 0 1 1 3.978 3.978l-.126.125a.562.562 0 0 1-.796-.796l.126-.125a1.688 1.688 0 1 0-2.387-2.387l-1.5 1.5a1.688 1.688 0 0 0 0 2.387.563.563 0 0 1 0 .796Z" />

--- a/src/components/settings/tabs/shortcuts-tab.tsx
+++ b/src/components/settings/tabs/shortcuts-tab.tsx
@@ -50,7 +50,7 @@ export function ShortcutsTab() {
       <div className="rounded-lg border border-accent/30 bg-accent/5 p-4">
         <p className="text-xs text-text-secondary">
           <span className="inline-flex items-center gap-1.5">
-            <span className="rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent">Coming Soon</span>
+            <span className="rounded-full bg-accent/15 px-2 py-0.5 text-xs font-medium text-accent">Coming Soon</span>
             Custom key bindings and conflict detection are not yet active. Shortcuts shown are the current defaults.
           </span>
         </p>

--- a/src/components/settings/tabs/templates-tab.tsx
+++ b/src/components/settings/tabs/templates-tab.tsx
@@ -104,12 +104,12 @@ export function TemplatesTab() {
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium text-text-primary">{template.name}</span>
                   {template.isBuiltIn && (
-                    <span className="rounded bg-surface-hover px-1.5 py-0.5 text-[10px] text-text-secondary">
+                    <span className="rounded bg-surface-hover px-1.5 py-0.5 text-xs text-text-secondary">
                       Built-in
                     </span>
                   )}
                   {defaultTemplateId === template.id && (
-                    <span className="rounded bg-accent/20 px-1.5 py-0.5 text-[10px] text-accent">
+                    <span className="rounded bg-accent/20 px-1.5 py-0.5 text-xs text-accent">
                       Default
                     </span>
                   )}
@@ -173,7 +173,7 @@ export function TemplatesTab() {
                           <span>{col.icon}</span>
                           <span className="text-xs text-text-primary">{col.name}</span>
                           {col.autoAdvance && (
-                            <span className="text-[10px] text-accent">→</span>
+                            <span className="text-xs text-accent">→</span>
                           )}
                         </div>
                       ))}

--- a/src/components/settings/tabs/voice-tab.tsx
+++ b/src/components/settings/tabs/voice-tab.tsx
@@ -64,12 +64,12 @@ function ModelCard({
           <span className="text-sm font-medium text-text-primary capitalize">{model.model}</span>
           <span className="text-xs text-text-secondary">{model.sizeDisplay}</span>
           {isDownloaded && (
-            <span className="rounded bg-green-500/20 px-1.5 py-0.5 text-[10px] font-medium text-green-400">
+            <span className="rounded bg-green-500/20 px-1.5 py-0.5 text-xs font-medium text-green-400">
               Downloaded
             </span>
           )}
           {isSelected && isDownloaded && (
-            <span className="rounded bg-accent/20 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+            <span className="rounded bg-accent/20 px-1.5 py-0.5 text-xs font-medium text-accent">
               Active
             </span>
           )}

--- a/src/components/settings/tabs/workspace-tab.tsx
+++ b/src/components/settings/tabs/workspace-tab.tsx
@@ -147,7 +147,7 @@ export function WorkspaceTab() {
           <div className="space-y-3 rounded-lg border border-accent/40 bg-accent/5 p-4">
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
-                <div className="text-[10px] uppercase tracking-wider text-text-secondary/70">Name</div>
+                <div className="text-xs uppercase tracking-wider text-text-secondary/70">Name</div>
                 <p className="truncate text-sm font-semibold text-text-primary">{workspace.name}</p>
               </div>
               <span className="shrink-0 rounded-full bg-accent/20 px-2 py-0.5 text-xs font-medium text-accent">
@@ -155,7 +155,7 @@ export function WorkspaceTab() {
               </span>
             </div>
             <div>
-              <div className="text-[10px] uppercase tracking-wider text-text-secondary/70">Repository path</div>
+              <div className="text-xs uppercase tracking-wider text-text-secondary/70">Repository path</div>
               <div className="mt-1">
                 <PathPicker
                   value={workspace.repoPath}
@@ -165,7 +165,7 @@ export function WorkspaceTab() {
                 />
               </div>
             </div>
-            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-text-secondary/80">
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-text-secondary/80">
               <span>Created {new Date(workspace.createdAt).toLocaleDateString()}</span>
               <span>Updated {new Date(workspace.updatedAt).toLocaleDateString()}</span>
             </div>

--- a/src/components/shared/empty-state.tsx
+++ b/src/components/shared/empty-state.tsx
@@ -18,7 +18,7 @@ const sizeStyles: Record<EmptyStateSize, { container: string; icon: string; titl
     container: 'py-4 px-3',
     icon: 'h-6 w-6 mb-2',
     title: 'text-xs font-medium',
-    desc: 'text-[11px]',
+    desc: 'text-xs',
   },
   md: {
     container: 'py-8 px-4',

--- a/src/components/shared/panel-tabs.tsx
+++ b/src/components/shared/panel-tabs.tsx
@@ -60,7 +60,7 @@ export function PanelTabs<T extends string>({
             title={showIconsOnly ? tab.label : undefined}
             data-testid={tab.testId}
             onClick={() => { onChange(tab.value) }}
-            className={`relative inline-flex min-w-0 items-center gap-1.5 py-1.5 text-[11px] font-medium transition-colors ${
+            className={`relative inline-flex min-w-0 items-center gap-1.5 py-1.5 text-xs font-medium transition-colors ${
               showIconsOnly ? 'px-1.5' : 'px-2'
             } ${active ? 'text-text-primary' : 'text-text-secondary hover:text-text-primary'}`}
             style={{ cursor: 'pointer' }}

--- a/src/components/shared/selector-dropdown.tsx
+++ b/src/components/shared/selector-dropdown.tsx
@@ -48,7 +48,7 @@ export function SelectorDropdown({
       className={`absolute bottom-full left-0 z-50 mb-1 ${width} overflow-hidden rounded-md border border-border-default bg-surface shadow-lg`}
     >
       {header && (
-        <div className="border-b border-border-default bg-bg/50 px-3 py-1.5 text-[10px] text-text-muted">
+        <div className="border-b border-border-default bg-bg/50 px-3 py-1.5 text-xs text-text-muted">
           {header}
         </div>
       )}
@@ -91,7 +91,7 @@ export function SelectorOption({
       <div className="flex-1 min-w-0">
         <div className="font-medium">{label}</div>
         {description && (
-          <div className="text-text-muted text-[10px]">{description}</div>
+          <div className="text-text-muted text-xs">{description}</div>
         )}
       </div>
       {selected && (
@@ -124,7 +124,7 @@ export function SelectorButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex h-6 items-center gap-1 rounded border border-transparent px-2 text-[11px] text-text-secondary transition-colors hover:border-border-default/70 hover:bg-surface-hover hover:text-text-primary ${className}`}
+      className={`flex h-6 items-center gap-1 rounded border border-transparent px-2 text-xs text-text-secondary transition-colors hover:border-border-default/70 hover:bg-surface-hover hover:text-text-primary ${className}`}
       style={{ cursor: 'pointer' }}
     >
       {children}

--- a/src/components/shared/status-badge.tsx
+++ b/src/components/shared/status-badge.tsx
@@ -14,7 +14,7 @@ type StatusBadgeProps = {
 
 const sizeStyles = {
   sm: {
-    container: 'px-1.5 py-0.5 text-[10px]',
+    container: 'px-1.5 py-0.5 text-xs',
     dot: 'h-1.5 w-1.5',
   },
   md: {

--- a/src/components/shared/thinking-selector.tsx
+++ b/src/components/shared/thinking-selector.tsx
@@ -66,7 +66,7 @@ export function ThinkingSelector({ value, maxLevel, onChange }: ThinkingSelector
             >
               <div className="flex-1 min-w-0">
                 <div className="font-medium">{level.label}</div>
-                <div className="text-text-muted text-[10px]">{level.description}</div>
+                <div className="text-text-muted text-xs">{level.description}</div>
               </div>
               {level.id === value && !disabled && (
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5 shrink-0">

--- a/src/components/shortcuts-modal.tsx
+++ b/src/components/shortcuts-modal.tsx
@@ -80,11 +80,11 @@ function KbdSequence({ keys }: { keys: readonly string[] }) {
     <div className="flex flex-wrap items-center justify-end gap-1">
       {keys.map((key, index) => (
         <span key={`${key}-${String(index)}`} className="flex items-center gap-1">
-          <kbd className="rounded-md border border-border-default bg-bg px-1.5 py-0.5 font-mono text-[11px] leading-5 text-text-primary shadow-sm">
+          <kbd className="rounded-md border border-border-default bg-bg px-1.5 py-0.5 font-mono text-xs leading-5 text-text-primary shadow-sm">
             {key}
           </kbd>
           {index < keys.length - 1 && (
-            <span className="text-[11px] text-text-secondary">+</span>
+            <span className="text-xs text-text-secondary">+</span>
           )}
         </span>
       ))}
@@ -153,7 +153,7 @@ export function ShortcutsModal({ onClose }: Props) {
                         <KbdSequence keys={item.keys} />
                         {item.altKeys && (
                           <>
-                            <span className="text-[10px] uppercase text-text-secondary/60">or</span>
+                            <span className="text-xs uppercase text-text-secondary/60">or</span>
                             <KbdSequence keys={item.altKeys} />
                           </>
                         )}

--- a/src/components/task-detail/commits-section.tsx
+++ b/src/components/task-detail/commits-section.tsx
@@ -35,7 +35,7 @@ export function CommitsSection({ commits }: CommitsSectionProps) {
             key={commit.hash}
             className="flex items-start gap-2 rounded px-2 py-1 text-xs hover:bg-surface-hover"
           >
-            <span className="shrink-0 font-mono text-[11px] text-accent">
+            <span className="shrink-0 font-mono text-xs text-accent">
               {commit.shortHash}
             </span>
             <span className="flex-1 truncate text-text-primary">
@@ -47,7 +47,7 @@ export function CommitsSection({ commits }: CommitsSectionProps) {
           <button
             type="button"
             onClick={() => { setExpanded((current) => !current) }}
-            className="flex w-full items-center justify-center rounded px-2 py-1 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            className="flex w-full items-center justify-center rounded px-2 py-1 text-xs text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
             style={{ cursor: 'pointer' }}
           >
             {expanded ? 'Show less' : `Show ${String(hiddenCommitCount)} more`}

--- a/src/components/task-detail/diff-section.tsx
+++ b/src/components/task-detail/diff-section.tsx
@@ -117,7 +117,7 @@ export function DiffSection({
           <span className="text-xs text-success">+{changes.totalAdditions}</span>
           <span className="text-xs text-error">-{changes.totalDeletions}</span>
           {referenceLabel && (
-            <span className="min-w-0 truncate rounded border border-border-default/70 px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
+            <span className="min-w-0 truncate rounded border border-border-default/70 px-1.5 py-0.5 font-mono text-xs text-text-secondary">
               {referenceLabel}
             </span>
           )}
@@ -125,7 +125,7 @@ export function DiffSection({
         <button
           type="button"
           onClick={() => { void toggleAll() }}
-          className="text-[11px] text-text-secondary hover:text-text-primary underline-offset-2 hover:underline"
+          className="text-xs text-text-secondary hover:text-text-primary underline-offset-2 hover:underline"
           style={{ cursor: 'pointer' }}
         >
           {showAll ? 'Hide combined diff' : 'View all'}
@@ -148,7 +148,7 @@ export function DiffSection({
             >
               <StatusIcon status={file.status} />
               <span
-                className={`flex-1 truncate font-mono text-[11px] ${
+                className={`flex-1 truncate font-mono text-xs ${
                   active ? 'text-text-primary' : 'text-text-secondary'
                 }`}
                 title={file.path}
@@ -164,7 +164,7 @@ export function DiffSection({
           <button
             type="button"
             onClick={() => { setFilesExpanded((current) => !current) }}
-            className="mt-1 flex w-full items-center justify-center rounded px-2 py-1 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            className="mt-1 flex w-full items-center justify-center rounded px-2 py-1 text-xs text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
             style={{ cursor: 'pointer' }}
           >
             {filesExpanded ? 'Show less' : `Show ${String(hiddenFileCount)} more`}
@@ -216,7 +216,7 @@ function StatusIcon({ status }: { status: string }) {
   const letter = status[0]?.toUpperCase() ?? '?'
 
   return (
-    <span className={`w-3 shrink-0 text-center font-mono text-[10px] font-bold ${color}`}>
+    <span className={`w-3 shrink-0 text-center font-mono text-xs font-bold ${color}`}>
       {letter}
     </span>
   )

--- a/src/components/task-detail/notification-section.tsx
+++ b/src/components/task-detail/notification-section.tsx
@@ -100,13 +100,13 @@ export function NotificationSection({
   return (
     <div className="rounded-lg border border-border-default bg-surface p-3">
       <div className="mb-2 flex items-center justify-between">
-        <h4 className="text-[11px] font-medium uppercase tracking-wider text-text-secondary">
+        <h4 className="text-xs font-medium uppercase tracking-wider text-text-secondary">
           Notify
         </h4>
         <button
           type="button"
           onClick={() => { setIsEditing(!isEditing); }}
-          className="text-[10px] text-accent hover:text-accent-hover"
+          className="text-xs text-accent hover:text-accent-hover"
         >
           {isEditing ? 'Done' : 'Edit'}
         </button>
@@ -167,7 +167,7 @@ export function NotificationSection({
             type="button"
             onClick={() => void handleAddStakeholder()}
             disabled={isLoading || !input.trim()}
-            className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+            className="rounded bg-accent px-2 py-1 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
           >
             Add
           </button>
@@ -179,8 +179,8 @@ export function NotificationSection({
         {notificationSentAt ? (
           <div className="flex items-center justify-between">
             <div>
-              <span className="text-[10px] text-success">Notified</span>
-              <span className="ml-1 text-[10px] text-text-secondary">
+              <span className="text-xs text-success">Notified</span>
+              <span className="ml-1 text-xs text-text-secondary">
                 {formatDateWithTime(notificationSentAt)}
               </span>
             </div>
@@ -188,7 +188,7 @@ export function NotificationSection({
               type="button"
               onClick={() => void handleClearNotified()}
               disabled={isLoading}
-              className="text-[10px] text-text-secondary hover:text-text-primary disabled:opacity-50"
+              className="text-xs text-text-secondary hover:text-text-primary disabled:opacity-50"
             >
               Clear
             </button>

--- a/src/components/task-detail/siege-status.tsx
+++ b/src/components/task-detail/siege-status.tsx
@@ -57,14 +57,14 @@ export function SiegeStatus({ task, onUpdate }: SiegeStatusProps) {
             style={{ width: `${String(progress)}%` }}
           />
         </div>
-        <span className="text-[11px] font-mono text-text-secondary tabular-nums">
+        <span className="text-xs font-mono text-text-secondary tabular-nums">
           {task.siegeIteration}/{task.siegeMaxIterations}
         </span>
       </div>
 
       {/* Status info */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-1.5 text-[11px]">
+        <div className="flex items-center gap-1.5 text-xs">
           {task.siegeActive ? (
             <>
               <span className="relative flex h-1.5 w-1.5">
@@ -91,7 +91,7 @@ export function SiegeStatus({ task, onUpdate }: SiegeStatusProps) {
           type="button"
           onClick={() => { void (task.siegeActive ? handleStop() : handleStart()) }}
           disabled={isLoading || !task.prNumber}
-          className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors disabled:opacity-40 ${
+          className={`rounded px-2 py-0.5 text-xs font-medium transition-colors disabled:opacity-40 ${
             task.siegeActive
               ? 'bg-error/10 text-error hover:bg-error/20'
               : 'bg-accent/10 text-accent hover:bg-accent/20'
@@ -104,14 +104,14 @@ export function SiegeStatus({ task, onUpdate }: SiegeStatusProps) {
 
       {/* Last checked */}
       {task.siegeLastChecked && (
-        <div className="text-[10px] text-text-secondary/70">
+        <div className="text-xs text-text-secondary/70">
           Last checked: {new Date(task.siegeLastChecked).toLocaleTimeString()}
         </div>
       )}
 
       {/* No PR warning */}
       {!task.prNumber && (
-        <div className="text-[10px] text-amber-500">
+        <div className="text-xs text-amber-500">
           Create a PR first to use the siege loop.
         </div>
       )}

--- a/src/components/task-detail/task-checklist.tsx
+++ b/src/components/task-detail/task-checklist.tsx
@@ -169,7 +169,7 @@ export function TaskChecklist({ task, onUpdate, repoPath }: TaskChecklistProps) 
               style={{ width: `${String(progressPercent)}%` }}
             />
           </div>
-          <span className="text-[11px] text-text-secondary tabular-nums">
+          <span className="text-xs text-text-secondary tabular-nums">
             {checkedCount}/{totalCount}
           </span>
         </div>
@@ -255,7 +255,7 @@ export function TaskChecklist({ task, onUpdate, repoPath }: TaskChecklistProps) 
           <button
             type="button"
             onClick={handleAddItem}
-            className="text-[11px] text-accent hover:text-accent/80"
+            className="text-xs text-accent hover:text-accent/80"
           >
             Add
           </button>
@@ -269,7 +269,7 @@ export function TaskChecklist({ task, onUpdate, repoPath }: TaskChecklistProps) 
             type="button"
             onClick={() => { void handleGenerateFromPr() }}
             disabled={isGenerating}
-            className="flex w-full items-center justify-center gap-1.5 rounded px-2 py-1.5 text-[11px] text-accent hover:bg-accent/10 transition-colors disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-1.5 rounded px-2 py-1.5 text-xs text-accent hover:bg-accent/10 transition-colors disabled:opacity-50"
           >
             {isGenerating ? (
               <>
@@ -289,14 +289,14 @@ export function TaskChecklist({ task, onUpdate, repoPath }: TaskChecklistProps) 
             )}
           </button>
           {generateError && (
-            <p className="mt-1 text-[10px] text-error text-center">{generateError}</p>
+            <p className="mt-1 text-xs text-error text-center">{generateError}</p>
           )}
         </div>
       )}
 
       {/* Empty state */}
       {items.length === 0 && !newItemText && !canGenerateFromPr && (
-        <p className="text-[11px] text-text-secondary/60 px-1">
+        <p className="text-xs text-text-secondary/60 px-1">
           Add test items to verify before advancing this task.
         </p>
       )}

--- a/src/components/task-detail/usage-section.tsx
+++ b/src/components/task-detail/usage-section.tsx
@@ -46,7 +46,7 @@ export function UsageSection({ agentType, agentStatus, startedAt }: UsageSection
 
   return (
     <div className="rounded-lg border border-border-default bg-surface p-3">
-      <h4 className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-secondary">
+      <h4 className="mb-2 text-xs font-medium uppercase tracking-wider text-text-secondary">
         Usage
       </h4>
       <div className="space-y-1.5">

--- a/src/components/usage/metrics-dashboard.tsx
+++ b/src/components/usage/metrics-dashboard.tsx
@@ -226,13 +226,13 @@ export function MetricsDashboard({ workspaceId, onClose }: Props) {
                           style={{ height: `${String((day.costUsd / maxDailyCost) * 100)}%`, minHeight: day.costUsd > 0 ? '4px' : '0' }}
                         />
                         {dailyCosts.length <= 14 && (
-                          <div className="mt-1 text-[10px] text-text-secondary">{formatUsageDate(day.date)}</div>
+                          <div className="mt-1 text-xs text-text-secondary">{formatUsageDate(day.date)}</div>
                         )}
                       </div>
                     ))}
                   </div>
                   {dailyCosts.length > 14 && (
-                    <div className="mt-2 flex justify-between text-[10px] text-text-secondary">
+                    <div className="mt-2 flex justify-between text-xs text-text-secondary">
                       <span>{formatUsageDate(dailyCosts[0]?.date ?? '')}</span>
                       <span>{formatUsageDate(dailyCosts[dailyCosts.length - 1]?.date ?? '')}</span>
                     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,18 @@
   --font-sans: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
+  /* Type scale. Tailwind stops at `xs`; this app is dense enough to need one
+     step below it for badges and count bubbles. Defining it here — in rem —
+     is what lets Settings → Appearance → Font Size move it, which an
+     arbitrary pixel size never could. */
+  --text-2xs: 0.625rem;
+  --text-2xs--line-height: calc(0.875 / 0.625);
+
+  /* Animation Speed reaches every `transition-*` utility through Tailwind's
+     own default, rather than through a `.transition-appearance` class each
+     component would have to remember to opt into. */
+  --default-transition-duration: var(--transition-duration);
+
   /* Theme colors mapped to Tailwind utilities */
   --color-bg: var(--bg);
   --color-surface: var(--surface);
@@ -219,20 +231,6 @@ optgroup {
 
 ::-webkit-scrollbar-corner {
   background: var(--scrollbar-track);
-}
-
-/* Card styles using appearance variables */
-.card-padding {
-  padding: var(--card-padding);
-}
-
-.card-gap {
-  gap: var(--card-gap);
-}
-
-/* Transitions using appearance variables */
-.transition-appearance {
-  transition-duration: var(--transition-duration);
 }
 
 /* xterm needs explicit box ownership inside the animated Tauri panel. */

--- a/src/lib/appearance.test.ts
+++ b/src/lib/appearance.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  DEFAULT_APPEARANCE,
+  applyAppearance,
+  getAppearanceConfig,
+  initializeAppearance,
+} from './appearance'
+
+/**
+ * These settings work by putting attributes and a custom property on the
+ * document *element*, which `src/index.css` then selects on. jsdom can't
+ * evaluate the Tailwind side of that, but it can pin the half that broke
+ * before: every value has to land on <html>, not <body>, or the `[data-*]`
+ * selectors and `--base-font-size` never match anything.
+ */
+describe('appearance', () => {
+  const root = document.documentElement
+
+  beforeEach(() => {
+    localStorage.clear()
+    root.removeAttribute('style')
+    for (const attr of ['data-font-size', 'data-card-density', 'data-animation-speed']) {
+      root.removeAttribute(attr)
+    }
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('applies every setting to the document element', () => {
+    applyAppearance({
+      accentColor: '#123456',
+      fontSize: 'large',
+      cardDensity: 'compact',
+      animationSpeed: 'none',
+    })
+
+    expect(root.style.getPropertyValue('--accent')).toBe('#123456')
+    expect(root.getAttribute('data-font-size')).toBe('large')
+    expect(root.getAttribute('data-card-density')).toBe('compact')
+    expect(root.getAttribute('data-animation-speed')).toBe('none')
+    expect(document.body.getAttribute('data-font-size')).toBeNull()
+  })
+
+  it('leaves untouched settings alone on a partial update', () => {
+    applyAppearance({ fontSize: 'small', cardDensity: 'spacious' })
+    applyAppearance({ fontSize: 'large' })
+
+    expect(root.getAttribute('data-font-size')).toBe('large')
+    expect(root.getAttribute('data-card-density')).toBe('spacious')
+  })
+
+  it('reads the persisted settings blob', () => {
+    localStorage.setItem(
+      'bento-settings',
+      JSON.stringify({ state: { global: { appearance: { fontSize: 'large' } } } }),
+    )
+
+    const config = getAppearanceConfig()
+    expect(config.fontSize).toBe('large')
+    // Absent keys fall back rather than coming back undefined.
+    expect(config.cardDensity).toBe(DEFAULT_APPEARANCE.cardDensity)
+  })
+
+  it('falls back to defaults when storage is missing or corrupt', () => {
+    expect(getAppearanceConfig()).toEqual(DEFAULT_APPEARANCE)
+
+    localStorage.setItem('bento-settings', 'not json')
+    expect(getAppearanceConfig()).toEqual(DEFAULT_APPEARANCE)
+  })
+
+  it('initializes from storage on startup', () => {
+    localStorage.setItem(
+      'bento-settings',
+      JSON.stringify({ state: { global: { appearance: { animationSpeed: 'reduced' } } } }),
+    )
+
+    initializeAppearance()
+    expect(root.getAttribute('data-animation-speed')).toBe('reduced')
+    // Defaults still get applied for the keys storage didn't carry.
+    expect(root.getAttribute('data-font-size')).toBe(DEFAULT_APPEARANCE.fontSize)
+  })
+})


### PR DESCRIPTION
Roadmap Important #2. Theme and accent colour worked; the other three Appearance settings did not.

## Font Size — was worse than unwired

`--base-font-size` does reach `<html>`, so rem utilities scale. But **247 arbitrary `text-[Npx]` values across 63 files** are absolute and never move. At "small" that **inverts the hierarchy**: the root drops to 12px so `text-sm` renders 10.5px, while a caption pinned at 11px stays 11px and comes out *larger* than the body text it sits under.

Measured in a real browser, before:

| setting | `html` | `text-sm` | `text-xs` | `text-[11px]` |
|---|---|---|---|---|
| small | 12px | 10.5px | 9px | **11px** |
| medium | 14px | 12.25px | 10.5px | **11px** |
| large | 16px | 14px | 12px | **11px** |

The scale in use was nine tiers inside 6px — 8, 9, 10, 10.5, 11, 12, 12.25, 13, 14. That is noise, not a hierarchy. It is now four rem steps:

| token | rem | @ medium | role |
|---|---|---|---|
| `text-2xs` | 0.625 | 8.75px | count bubbles, micro badges |
| `text-xs` | 0.75 | 10.5px | chips, dense labels |
| `text-sm` | 0.875 | 12.25px | body, metadata |
| `text-base` | 1 | 14px | headings in-panel |

Tailwind stops at `xs`, so `--text-2xs` joins the `@theme` block. 8/9px collapse into it, 10/11px into `text-xs`, 12/13px into `text-sm`. **At the default size nothing moves more than 0.75px**, and every step now tracks the setting.

`scripts/check-type-scale.js` fails CI on the next absolute font size, so this can't silently accumulate again (wired into both `ci.yml` and `release.yml`).

## Card Density and Animation Speed — fully inert

The chain ran store → data attribute → CSS var → `.card-padding` / `.card-gap` / `.transition-appearance`, and died at the last hop: those three helper classes were used by **zero** components.

- **Density** now drives the task card's padding and the column's inter-card gap directly, at the call site where the dependency is visible rather than through a class a component has to remember. The defaults were already identical (`p-3` = `--card-padding` comfortable), so nothing shifts at the default.
- **Animation Speed** rides Tailwind's own `--default-transition-duration`, so every `transition-*` utility in the app honours it without opting in.
- The three dead classes are deleted.

## Verified in the browser, not inferred

| | small / compact / none | medium / comfortable / reduced | large / spacious / normal |
|---|---|---|---|
| root font | 12px | 14px | 16px |
| `text-sm` → `text-2xs` | 10.5 → 7.5px | 12.25 → 8.75px | 14 → 10px |
| card padding / gap | 7 / 3.5px | 10.5 / 7px | 14 / 10.5px |
| `transition-colors` | 0s | 0.075s | 0.15s |

Checked visually on the board at "small": the card title is now unambiguously the largest element, where before the meta row and branch rendered larger than the description above them.

## Known gap

Framer Motion animations still ignore Animation Speed — they read no CSS variable, so "none" doesn't fully mean none. Noted on the roadmap rather than fixed here.

## Checks

`tsc --noEmit` · `eslint` · `test:ipc` · `test:type-scale` · `vitest` 434 passed (+5 new `appearance.test.ts`) · `vite build` · `pnpm audit`. No Rust touched.
