### PR TITLE
feat(agents): wire Kaiten Agents into columns

### DIFF
--- a/.tickets/_docs/ROADMAP.md
+++ b/.tickets/_docs/ROADMAP.md
@@ -35,6 +35,15 @@ replaces the terminal.
   with a 60s budget and **never** hard-kills — exhausting it injects anyway and
   leaves the pane inspectable. `CLI_HEALTH_SPECS` now probes the interactive
   codex path so the same drift can't ship silently again.
+- Kaiten Agents wired into columns (2026-08-21): a `spawn_cli` trigger carries
+  `agent_id`, and the agent then supplies the CLI, instructions, tools and its
+  preferred model, with the column able to override **model only** — enforced in
+  `pipeline::spawn::resolve()` alone. All three runtimes run, script agents
+  included, through the same tmux transport. Instructions and skills ship as
+  `.agent.md` rather than a system-prompt flag: codex has no such flag, claude's
+  `--append-system-prompt` is last-wins and interactive mode already spends it on
+  the done-sentinel, and scripts have no prompt at all. `get_agent_usage` shows
+  which columns run an agent so deleting one names what it would break.
 - Settings wiring pass (Appearance): all five settings now reach the UI. Font Size
   was worse than unwired — 247 arbitrary `text-[Npx]` values across 63 files were
   absolute, so at "small" the root dropped to 12px while a caption pinned at 11px

--- a/.tickets/_docs/specs/KAITEN_AGENTS.md
+++ b/.tickets/_docs/specs/KAITEN_AGENTS.md
@@ -1,7 +1,8 @@
 # Spec — Kaiten Agents (craftable agents + character-select roster)
 
-> Status: **IN PROGRESS** (started 2026-08-21). This session ships the Agent as a
-> *definition* + the Roster UI. Pipeline wiring and execution are v2, deliberately.
+> Status: **SHIPPED** (2026-08-21). The Agent as a *definition*, the Roster UI,
+> and the column wiring are all in. RAG, typed I/O, the MCP surface and
+> Orchestrator-as-section remain v2 — see "Still v2" below.
 > Design origin: artifact *"Kaiten Agents — IA & Roster Mockup"* (2026-07-02).
 
 ## Goal
@@ -142,24 +143,80 @@ as "missing skill" rather than throwing.
 **Boundary:** skills become real, persisted, editable and attachable data now.
 *Injecting* them into a spawned CLI is execution — that lands with the wiring.
 
-## What v2 (the wiring session) must do
+## Wiring — shipped 2026-08-21
 
-1. **Columns reference an agent.** A `spawn_cli` action gains `agent_id`; when
-   set, the agent supplies cli/model/prompt/tools and the column may override
-   **model only**. Enforce that in one place — `pipeline::spawn::resolve()`.
-2. **Skill injection** into the spawned CLI.
-3. **`/api/*` + MCP surface** for agents, following the `create_script` route
+Items 1 and 2 of the original v2 list are done.
+
+**1. Columns reference an agent.** `spawn_cli` carries `agent_id`.
+`roster::plan::plan_for()` turns a definition into an `AgentSpawnPlan` (command,
+model, instructions, extra argv, env); `pipeline::spawn::resolve()` applies it
+against the other tiers. The precedence is
+
+```text
+task > trigger > agent > workspace > global > default
+```
+
+and **model is the only tier a column may take from the agent**. A leftover
+`cli` token on the column is logged and ignored rather than obeyed — the roster
+tile has to tell the truth about what runs. The UI encodes the same rule: the
+CLI token disappears from the automation sentence once an agent is attached, and
+the Advanced editor replaces its CLI dropdown with "Set by <agent>".
+
+**2. Skill injection — via `.agent.md`, not a system-prompt flag.**
+
+This was the one real design decision, and the flags forced it:
+
+- **codex has no system-prompt flag at all** (codex-cli 0.145.0).
+- **claude's `--append-system-prompt` is last-wins, not cumulative** (verified
+  against 2.1.239: two flags, only the second applied). Interactive mode already
+  spends that flag on the done-sentinel and appends it *after* user args, so
+  routing instructions through it would silently drop them in exactly the
+  columns most likely to use an agent.
+- **script agents have no prompt concept.**
+
+So instructions and skills render to `.agent.md` in the working dir, and the
+prompt gains a newline-free pointer to it — the convention `.task.md` already
+established. One mechanism across 3 runtimes x 3 runtime modes, no
+flag-existence assumptions, and switching a column between headless and
+interactive cannot change what the agent was told. Runtime mode is a rendering
+and billing choice; it has no business altering behaviour. Verified end-to-end
+against a real `claude -p`.
+
+A stale `.agent.md` is removed when a column has no agent — worktrees are reused
+across columns, so leaving it would let one column's agent keep instructing the
+next.
+
+**Script agents run too.** Same tmux transport, so they get a live terminal,
+exit-code completion and an agent card. They bypass `validate_agent_cli_path`:
+that allow-list guards *hand-editable trigger JSON*, and a script agent's command
+comes from an `agents` row authored in the Roster UI — the same trust level
+`run_script` already grants user-authored scripts. They are forced to `terminal`
+mode and receive the prompt through `$TRIGGER_PROMPT` rather than argv, since the
+generic command builder would otherwise append prose as a positional argument.
+
+**Deleting an agent that columns use** is allowed, not blocked — forbidding it
+would leave no way to remove an agent attached to a workspace you no longer have
+open. `get_agent_usage` sweeps every workspace; the dossier shows the columns and
+the delete confirmation names them, and a fired trigger for a missing agent fails
+loudly by name rather than falling back to a bare CLI.
+
+## Still v2
+
+1. **`/api/*` + MCP surface** for agents, following the `create_script` route
    shape in `api.rs` (snake_case bodies) + `emit_entities_changed(app, "", "agent")`
    and a new `'agent'` arm in `EntityKind` / `useEntitySync`.
-4. **Orchestrator as a rail section.** It is currently a dock panel inside
+2. **Orchestrator as a rail section.** It is currently a dock panel inside
    `Board` owning its own dock/size/collapse state and Cmd+J. Promoting it is a
-   geometry restructure, so the rail ships Board + Roster first; the rail is
-   generic over its items, so adding a third is small once that's untangled.
-5. RAG; typed inputs/outputs.
+   geometry restructure; the rail is generic over its items, so adding a third is
+   small once that's untangled.
+3. **Per-task agent override.** Tasks already override model and runtime mode;
+   an agent override would be natural but wasn't needed to make columns work.
+4. RAG; typed inputs/outputs.
 
-## Non-goals for the first cut
+## Non-goals, and how they resolved
 
-Deploy-to-column · agent execution · MCP/API tools for agents · RAG · typed
-I/O · Orchestrator-as-section · rebrand. The precedence rule above is
-**specified** here but not implemented — there is nothing to enforce it against
-until columns reference agents.
+The first cut deliberately excluded deploy-to-column, agent execution and skill
+injection, on the grounds that the precedence rule had nothing to enforce it
+against until columns referenced agents. That is no longer true: all three
+shipped in the wiring pass above. The remaining exclusions are listed under
+"Still v2".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,8 +199,32 @@ Deliberately **not** `viewMode`, which means "is the chat panel open" and is
 load-bearing via `isChatOpen`. Orchestrator is not a section yet — it's still a
 dock panel inside `Board` with its own geometry.
 
-**Not wired yet (v2):** columns referencing an agent, execution, skill injection
-into the CLI, MCP/`/api/*` tools, RAG. Spec:
+**Wired into columns.** A `spawn_cli` trigger carries `agent_id`. When set, the
+agent supplies the CLI, instructions, tools and its preferred model, and the
+column may override **model only** — enforced in `pipeline::spawn::resolve()`
+and nowhere else. `roster::plan::plan_for()` turns a definition into spawn
+parameters; the `Runtime` trait still has no `execute`.
+
+**Instructions ship as `.agent.md`, not a system-prompt flag.** Written to the
+working dir next to `.task.md`, with a newline-free prompt line pointing at it.
+There is no flag that spans the three runtimes: codex has none, claude's
+`--append-system-prompt` is **last-wins** (verified against 2.1.239) and
+interactive mode already spends it on the done-sentinel, and scripts have no
+prompt concept. A file also means runtime mode can't change what the agent is
+told. Skills render into the same file.
+
+**Script agents** run through the same tmux transport, bypassing the
+claude/codex allow-list — that guard is for hand-editable trigger JSON, and an
+`agents` row is the same trust level `run_script` already grants. They are
+forced to `terminal` mode (managed/interactive assume an LLM CLI) and receive
+the prompt via `$TRIGGER_PROMPT`, never as argv.
+
+`commands::roster::get_agent_usage` lists the columns running an agent, across
+every workspace; the dossier shows them and the delete confirmation names them.
+Deleting is allowed anyway — a fired trigger then fails loudly by name.
+
+**Still v2:** MCP/`/api/*` tools for agents, RAG, typed inputs/outputs,
+Orchestrator-as-section, rebrand. Spec:
 `.tickets/_docs/specs/KAITEN_AGENTS.md`.
 
 ### Database (`src-tauri/src/db/`)

--- a/src-tauri/src/commands/roster.rs
+++ b/src-tauri/src/commands/roster.rs
@@ -8,6 +8,7 @@
 
 use crate::db::{self, Agent, AppState, Skill};
 use crate::error::AppError;
+use crate::pipeline::triggers::{columns_using_agent, AgentUsage};
 use crate::roster;
 use tauri::State;
 
@@ -105,9 +106,38 @@ pub fn update_agent(
     )?)
 }
 
+/// Which columns currently run this agent.
+///
+/// Agents are global, so this sweeps every workspace, not just the open board.
+/// The Roster shows the count on the dossier and names the columns in the
+/// delete confirmation — a column pointing at a deleted agent fails its
+/// trigger, and finding that out at 3am is worse than a slightly busier dialog.
+#[tauri::command]
+pub fn get_agent_usage(state: State<AppState>, id: String) -> Result<Vec<AgentUsage>, AppError> {
+    let conn = conn!(state);
+    Ok(columns_using_agent(&conn, &id))
+}
+
 #[tauri::command]
 pub fn delete_agent(state: State<AppState>, id: String) -> Result<(), AppError> {
     let conn = conn!(state);
+    // Deliberately *not* blocked when columns still reference it. The UI names
+    // them in the confirmation, and forbidding the delete outright would leave
+    // no way to remove an agent from a workspace you no longer have open.
+    // `execute_spawn_cli` fails loudly and by name if one is later fired.
+    let usage = columns_using_agent(&conn, &id);
+    if !usage.is_empty() {
+        log::info!(
+            "[roster] Deleting agent '{}' still attached to {} column(s): {}",
+            id,
+            usage.len(),
+            usage
+                .iter()
+                .map(|u| format!("{}/{}", u.workspace_name, u.column_name))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
     Ok(db::delete_agent(&conn, &id)?)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -357,6 +357,7 @@ pub fn run() {
             commands::roster::create_agent,
             commands::roster::update_agent,
             commands::roster::delete_agent,
+            commands::roster::get_agent_usage,
             commands::roster::list_agent_runtimes,
             commands::roster::list_skills,
             commands::roster::create_skill,

--- a/src-tauri/src/pipeline/spawn.rs
+++ b/src-tauri/src/pipeline/spawn.rs
@@ -8,8 +8,15 @@
 //! documented precedence lives:
 //!
 //! ```text
-//! trigger > task > column > workspace > global > default
+//! task > trigger > agent > workspace > global > default
 //! ```
+//!
+//! The **agent** tier is new: a column's `spawn_cli` action may name an agent
+//! from the Roster, and when it does the agent supplies the CLI, the
+//! instructions, the tools and its preferred model. Per the Kaiten Agents spec
+//! the column may override **model only** — everything else about the agent is
+//! the agent's own, which is the entire point of crafting one. That rule is
+//! enforced here and nowhere else.
 //!
 //! It is deliberately **`AppHandle`-free and pure** (takes `&Task` / `&Column`
 //! / `&Workspace` and plain defaults, returns data) so it is fully
@@ -17,9 +24,10 @@
 //! writes, the actual process launch, event emission — stay in the thin
 //! spawn/emit wrappers that call this.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::db::{Column, Task, Workspace};
+use crate::roster::plan::AgentSpawnPlan;
 use crate::error::AppError;
 
 use super::template::{self, TemplateContext};
@@ -72,6 +80,20 @@ pub(crate) struct ResolvedAgentSpawn {
     /// Prompt with the `.task.md` default applied and any slash command
     /// prepended.
     pub initial_prompt: String,
+    /// Name of the attached agent, for errors and telemetry. `None` when the
+    /// column spawns a bare CLI the old way.
+    pub agent_name: Option<String>,
+    /// True when the resolved command is a script agent's own command rather
+    /// than a known CLI binary. Callers must not treat it as claude/codex.
+    pub is_script_agent: bool,
+    /// Extra argv the agent contributes (MCP flags, or a script's own args).
+    pub agent_args: Vec<String>,
+    /// Environment overrides from a script agent.
+    pub agent_env: BTreeMap<String, String>,
+    /// Rendered `.agent.md` contents, when the agent has anything to say. The
+    /// caller writes the file; see `roster::plan` for why instructions travel
+    /// as a file rather than a system-prompt flag.
+    pub agent_instructions: Option<String>,
 }
 
 /// Resolve the full spawn parameter set for a trigger-driven agent. Pure: no
@@ -82,12 +104,14 @@ pub(crate) struct ResolvedAgentSpawn {
 /// `default_cli` / `default_model` carry the workspace+global tiers (the caller
 /// derives them from `EffectivePipelineSettings`); `prev_column` feeds the
 /// template context so `{prev_column.*}` variables interpolate.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn resolve(
     task: &Task,
     column: &Column,
     workspace: &Workspace,
     prev_column: Option<&Column>,
     overrides: &SpawnOverrides,
+    agent: Option<&AgentSpawnPlan>,
     default_cli: &str,
     default_model: Option<&str>,
 ) -> Result<ResolvedAgentSpawn, AppError> {
@@ -116,33 +140,96 @@ pub(crate) fn resolve(
         task_md_default_prompt(task)
     };
 
-    // CLI: trigger config > workspace/global default. User-editable JSON is
-    // normalized through the same backend allowlist used by direct agent
-    // commands before it reaches the shell launcher.
-    let raw_cli_type = overrides
-        .cli
-        .filter(|c| !c.trim().is_empty())
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| default_cli.to_string());
-    let cli_type = if raw_cli_type.trim() == "auto" {
-        "codex".to_string()
+    // CLI. An attached agent owns this outright — picking "Code Smith" and
+    // then having the column's stale `cli` token silently run codex instead
+    // would make the roster a lie. A leftover token is logged, not obeyed.
+    let cli_type = if let Some(plan) = agent {
+        if let Some(stale) = overrides.cli.filter(|c| !c.trim().is_empty()) {
+            if stale != plan.command {
+                log::info!(
+                    "[spawn] Column names agent '{}' ({}) — ignoring its leftover cli token '{}'",
+                    plan.agent_name,
+                    plan.command,
+                    stale
+                );
+            }
+        }
+        if plan.is_script {
+            // Script agents are arbitrary commands by design; that is the
+            // point of the runtime. The claude/codex allow-list guards
+            // *hand-editable trigger JSON*, and this command did not come
+            // from there — it came from an `agents` row authored in the
+            // Roster UI, the same trust level `run_script` already grants
+            // user-authored scripts. Emptiness is still refused.
+            if plan.command.trim().is_empty() {
+                return Err(AppError::InvalidInput(format!(
+                    "Agent '{}' has no command to run",
+                    plan.agent_name
+                )));
+            }
+            plan.command.clone()
+        } else {
+            crate::commands::agent::validate_agent_cli_path(&plan.command)?
+        }
     } else {
-        crate::commands::agent::validate_agent_cli_path(&raw_cli_type)?
+        // No agent: trigger config > workspace/global default. User-editable
+        // JSON is normalized through the same backend allowlist used by direct
+        // agent commands before it reaches the shell launcher.
+        let raw_cli_type = overrides
+            .cli
+            .filter(|c| !c.trim().is_empty())
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| default_cli.to_string());
+        if raw_cli_type.trim() == "auto" {
+            "codex".to_string()
+        } else {
+            crate::commands::agent::validate_agent_cli_path(&raw_cli_type)?
+        }
     };
 
     // Prepend slash command if provided.
-    let initial_prompt = match overrides.command {
+    let mut initial_prompt = match overrides.command {
         Some(cmd) if resolved_prompt.is_empty() => cmd.to_string(),
         Some(cmd) => format!("{}\n\n{}", cmd, resolved_prompt),
         None => resolved_prompt,
     };
 
+    // Point the agent at its own instructions, the same way the default prompt
+    // points at `.task.md`. Only when there is a file to read — a bare agent
+    // gets no dangling reference.
+    let agent_instructions = agent.and_then(|p| p.instructions.clone());
+    if agent_instructions.is_some() {
+        let suffix = crate::roster::plan::instructions_prompt_suffix();
+        if initial_prompt.trim().is_empty() {
+            initial_prompt = suffix;
+        } else {
+            initial_prompt = format!("{}\n\n{}", initial_prompt, suffix);
+        }
+    }
+
     // Runtime mode: `normalize_agent_runtime_mode` downgrades `interactive`
     // to `terminal` when the dev flag is unset or the CLI is unsupported.
-    let runtime_mode = normalize_agent_runtime_mode(overrides.runtime_mode, &cli_type).to_string();
+    //
+    // A script agent is always `terminal`. The other two modes are shaped
+    // around an LLM CLI — `managed` parses a semantic JSON event stream and
+    // `interactive` drives a TUI — and a render script has neither. Forcing it
+    // here beats letting a column's leftover `runtime_mode` produce a pane
+    // that waits forever for events that will never come.
+    let runtime_mode = if agent.is_some_and(|p| p.is_script) {
+        "terminal".to_string()
+    } else {
+        normalize_agent_runtime_mode(overrides.runtime_mode, &cli_type).to_string()
+    };
 
-    // Model: task override > trigger config > workspace/global default.
-    let model = resolve_model_override(task.model.as_deref(), overrides.model, default_model);
+    // Model: task override > trigger config > agent > workspace/global default.
+    // This is the *only* tier a column may take from an attached agent — the
+    // rest of the agent's config is the agent's own (Kaiten Agents spec). The
+    // agent slots in below the trigger so "this column, but with opus" stays
+    // possible without redefining the agent.
+    let agent_or_default = agent
+        .and_then(|p| p.model.as_deref())
+        .or(default_model);
+    let model = resolve_model_override(task.model.as_deref(), overrides.model, agent_or_default);
 
     Ok(ResolvedAgentSpawn {
         cli_type,
@@ -150,6 +237,11 @@ pub(crate) fn resolve(
         runtime_mode,
         working_dir,
         initial_prompt,
+        agent_name: agent.map(|p| p.agent_name.clone()),
+        is_script_agent: agent.is_some_and(|p| p.is_script),
+        agent_args: agent.map(|p| p.args.clone()).unwrap_or_default(),
+        agent_env: agent.map(|p| p.env.clone()).unwrap_or_default(),
+        agent_instructions,
     })
 }
 
@@ -196,6 +288,7 @@ mod tests {
             &ws,
             None,
             &SpawnOverrides::default(),
+            None,
             "claude",
             None,
         )
@@ -222,6 +315,7 @@ mod tests {
                 model: Some("gpt-5"),
                 ..Default::default()
             },
+            None,
             "claude",
             Some("sonnet"),
         )
@@ -254,6 +348,7 @@ mod tests {
                 model: Some("sonnet"),
                 ..Default::default()
             },
+            None,
             "claude",
             Some("opus"),
         )
@@ -273,6 +368,7 @@ mod tests {
                 cli: Some("auto"),
                 ..Default::default()
             },
+            None,
             "claude",
             None,
         )
@@ -293,6 +389,7 @@ mod tests {
                 command: Some("/review"),
                 ..Default::default()
             },
+            None,
             "claude",
             None,
         )
@@ -313,6 +410,7 @@ mod tests {
                 command: Some("/review"),
                 ..Default::default()
             },
+            None,
             "claude",
             None,
         )
@@ -323,6 +421,270 @@ mod tests {
             resolved.initial_prompt,
             "/review\n\nMy Task\n\nSee .task.md for full spec."
         );
+    }
+
+    // ── Attached agents ────────────────────────────────────────────────
+    //
+    // The contract from the Kaiten Agents spec: the agent owns its config and
+    // the column may override *model only*. These pin both halves.
+
+    fn plan(command: &str, is_script: bool) -> AgentSpawnPlan {
+        AgentSpawnPlan {
+            agent_name: "Code Smith".to_string(),
+            command: command.to_string(),
+            is_script,
+            model: None,
+            instructions: None,
+            args: Vec::new(),
+            env: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn an_attached_agent_supplies_the_cli() {
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            Some(&plan("codex", false)),
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.cli_type, "codex");
+        assert_eq!(resolved.agent_name.as_deref(), Some("Code Smith"));
+    }
+
+    #[test]
+    fn an_attached_agent_beats_a_stale_cli_token_on_the_column() {
+        // Columns configured before the agent was attached still carry a `cli`.
+        // Obeying it would run a different binary than the roster tile shows.
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                cli: Some("claude"),
+                ..Default::default()
+            },
+            Some(&plan("codex", false)),
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.cli_type, "codex");
+    }
+
+    #[test]
+    fn the_column_may_override_the_agents_model_and_nothing_else() {
+        let (ws, col, task, _conn) = fixture();
+        let mut agent = plan("claude", false);
+        agent.model = Some("haiku".to_string());
+        agent.args = vec!["--strict-mcp-config".to_string()];
+
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides {
+                model: Some("opus"),
+                ..Default::default()
+            },
+            Some(&agent),
+            "claude",
+            None,
+        )
+        .unwrap();
+        // Model: the column wins — that is the one permitted override.
+        assert_eq!(resolved.model.as_deref(), Some("opus"));
+        // Tools: still the agent's.
+        assert_eq!(resolved.agent_args, vec!["--strict-mcp-config".to_string()]);
+    }
+
+    #[test]
+    fn the_agents_model_beats_the_workspace_default() {
+        let (ws, col, task, _conn) = fixture();
+        let mut agent = plan("claude", false);
+        agent.model = Some("haiku".to_string());
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            Some(&agent),
+            "claude",
+            Some("sonnet"),
+        )
+        .unwrap();
+        assert_eq!(resolved.model.as_deref(), Some("haiku"));
+    }
+
+    #[test]
+    fn a_task_model_still_beats_the_agent() {
+        // Task is the narrowest tier; attaching an agent must not take away
+        // per-task control that already worked.
+        let (ws, col, _task, conn) = fixture();
+        let task = db::insert_task_full(
+            &conn,
+            &db::NewTask {
+                workspace_id: &ws.id,
+                column_id: &col.id,
+                title: "Modeled Task",
+                model: Some("opus"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let mut agent = plan("claude", false);
+        agent.model = Some("haiku".to_string());
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            Some(&agent),
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.model.as_deref(), Some("opus"));
+    }
+
+    #[test]
+    fn a_script_agent_skips_the_cli_allow_list() {
+        // `./render.sh` is not claude or codex and never will be. The allow
+        // list guards hand-edited trigger JSON; this command came from an
+        // agents row instead.
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            Some(&plan("./render.sh", true)),
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.cli_type, "./render.sh");
+        assert!(resolved.is_script_agent);
+    }
+
+    #[test]
+    fn a_script_agent_is_forced_to_terminal_mode() {
+        // `managed` parses an LLM event stream and `interactive` drives a TUI.
+        // A render script produces neither, so a leftover mode token would
+        // leave the pane waiting on events that never arrive.
+        let (ws, col, task, _conn) = fixture();
+        for mode in ["managed", "interactive"] {
+            let resolved = resolve(
+                &task,
+                &col,
+                &ws,
+                None,
+                &SpawnOverrides {
+                    runtime_mode: Some(mode),
+                    ..Default::default()
+                },
+                Some(&plan("./render.sh", true)),
+                "claude",
+                None,
+            )
+            .unwrap();
+            assert_eq!(resolved.runtime_mode, "terminal", "mode {}", mode);
+        }
+    }
+
+    #[test]
+    fn a_script_agent_with_no_command_is_refused() {
+        let (ws, col, task, _conn) = fixture();
+        assert!(resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            Some(&plan("   ", true)),
+            "claude",
+            None,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn instructions_add_a_prompt_pointer_to_the_file() {
+        let (ws, col, task, _conn) = fixture();
+        let mut agent = plan("claude", false);
+        agent.instructions = Some("# Code Smith\n\nDo the thing.\n".to_string());
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            Some(&agent),
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert!(
+            resolved.initial_prompt.ends_with(&crate::roster::plan::instructions_prompt_suffix()),
+            "{}",
+            resolved.initial_prompt
+        );
+        // The task spec pointer survives alongside it.
+        assert!(resolved.initial_prompt.contains(".task.md"));
+        assert!(resolved.agent_instructions.is_some());
+    }
+
+    #[test]
+    fn a_bare_agent_adds_no_prompt_pointer() {
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            Some(&plan("claude", false)),
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert!(!resolved.initial_prompt.contains(".agent.md"));
+        assert_eq!(resolved.agent_instructions, None);
+    }
+
+    #[test]
+    fn no_agent_leaves_every_agent_field_empty() {
+        // The old path has to stay byte-identical — most columns have no agent.
+        let (ws, col, task, _conn) = fixture();
+        let resolved = resolve(
+            &task,
+            &col,
+            &ws,
+            None,
+            &SpawnOverrides::default(),
+            None,
+            "claude",
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved.agent_name, None);
+        assert!(!resolved.is_script_agent);
+        assert!(resolved.agent_args.is_empty());
+        assert!(resolved.agent_env.is_empty());
+        assert_eq!(resolved.agent_instructions, None);
+        assert_eq!(resolved.initial_prompt, "My Task\n\nSee .task.md for full spec.");
     }
 
     #[test]
@@ -337,6 +699,7 @@ mod tests {
                 cli: Some("aider"),
                 ..Default::default()
             },
+            None,
             "claude",
             None,
         );

--- a/src-tauri/src/pipeline/triggers.rs
+++ b/src-tauri/src/pipeline/triggers.rs
@@ -8,6 +8,7 @@ use crate::config::{self, EffectivePipelineSettings};
 use crate::db::{self, Column, Task, Workspace};
 use crate::error::AppError;
 use crate::git::branch_manager;
+use crate::roster;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -103,6 +104,11 @@ impl<'a> Drop for SetupLockGuard<'a> {
 pub enum TriggerActionV2 {
     AutoSetup,
     SpawnCli {
+        /// Id into the global `agents` table. When set, the agent supplies the
+        /// CLI, instructions, tools and its preferred model, and the fields
+        /// below are ignored except `model` — see `pipeline::spawn::resolve`.
+        #[serde(default)]
+        agent_id: Option<String>,
         #[serde(default)]
         cli: Option<String>,
         #[serde(default)]
@@ -263,6 +269,54 @@ pub fn parse_column_triggers(triggers_json: Option<&str>) -> ColumnTriggersV2 {
     triggers_json
         .and_then(|json| serde_json::from_str::<ColumnTriggersV2>(json).ok())
         .unwrap_or_default()
+}
+
+/// Where an agent is currently attached: one column, named for a human.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentUsage {
+    pub workspace_id: String,
+    pub workspace_name: String,
+    pub column_id: String,
+    pub column_name: String,
+    /// `"on_entry"` or `"on_exit"`.
+    pub hook: String,
+}
+
+/// Every column across every workspace whose triggers name this agent.
+///
+/// Agents are global, so this deliberately sweeps all workspaces — deleting an
+/// agent from the Roster is not scoped to whichever board happens to be open.
+pub fn columns_using_agent(conn: &Connection, agent_id: &str) -> Vec<AgentUsage> {
+    let Ok(workspaces) = db::list_workspaces(conn) else {
+        return Vec::new();
+    };
+    let mut usages = Vec::new();
+    for workspace in workspaces {
+        let Ok(columns) = db::list_columns(conn, &workspace.id) else {
+            continue;
+        };
+        for column in columns {
+            let triggers = parse_column_triggers(column.triggers.as_deref());
+            for (hook, action) in [
+                ("on_entry", triggers.on_entry.as_ref()),
+                ("on_exit", triggers.on_exit.as_ref()),
+            ] {
+                if let Some(TriggerActionV2::SpawnCli { agent_id: id, .. }) = action {
+                    if id.as_deref().map(str::trim) == Some(agent_id) {
+                        usages.push(AgentUsage {
+                            workspace_id: workspace.id.clone(),
+                            workspace_name: workspace.name.clone(),
+                            column_id: column.id.clone(),
+                            column_name: column.name.clone(),
+                            hook: hook.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    usages
 }
 
 // ─── Runtime mode resolver (Phase 2) ──────────────────────────────────────
@@ -708,6 +762,7 @@ fn execute_action(
 ) -> Result<Task, AppError> {
     match action {
         TriggerActionV2::SpawnCli {
+            agent_id,
             cli,
             command,
             prompt_template,
@@ -722,6 +777,7 @@ fn execute_action(
             task,
             column,
             other_column,
+            agent_id.as_deref(),
             cli.as_deref(),
             command.as_deref(),
             prompt_template.as_deref(),
@@ -999,6 +1055,34 @@ pub(crate) fn resolve_model_override(
         .or_else(|| trigger_model.and_then(non_empty_trimmed))
         .or_else(|| default_model.and_then(non_empty_trimmed))
         .map(ToString::to_string)
+}
+
+/// Look up the skills an agent references, dropping ids that no longer exist.
+///
+/// Deliberately lenient: a deleted skill shows in the dossier as "missing
+/// skill" rather than breaking the agent, and the same should hold at spawn
+/// time — losing one capability is not a reason to fail the column.
+fn resolve_agent_skills(conn: &Connection, agent: &db::Agent) -> Vec<db::Skill> {
+    let Ok(config) = roster::parse_and_validate(&agent.runtime, &agent.config) else {
+        return Vec::new();
+    };
+    let Some(llm) = config.llm() else {
+        return Vec::new();
+    };
+    llm.skill_ids
+        .iter()
+        .filter_map(|id| match db::get_skill(conn, id) {
+            Ok(skill) => Some(skill),
+            Err(_) => {
+                log::warn!(
+                    "[triggers] Agent '{}' references skill '{}', which no longer exists — skipping it",
+                    agent.name,
+                    id
+                );
+                None
+            }
+        })
+        .collect()
 }
 
 fn non_empty_trimmed(value: &str) -> Option<&str> {
@@ -1530,6 +1614,7 @@ fn execute_spawn_cli(
     task: &Task,
     column: &Column,
     other_column: Option<&Column>,
+    agent_id: Option<&str>,
     cli: Option<&str>,
     command: Option<&str>,
     prompt_template: Option<&str>,
@@ -1637,6 +1722,30 @@ fn execute_spawn_cli(
     // Resolve cli / model / runtime-mode / prompt / cwd precedence in one
     // place (see pipeline::spawn::resolve). All side effects below — worktree
     // .task.md, DB writes, event emission, dispatch — stay here in the caller.
+    // Load the attached agent, if the column names one. A column pointing at a
+    // deleted agent fails loudly here rather than silently falling back to a
+    // bare CLI — the whole reason to attach an agent is that its instructions
+    // and tools matter, and running without them is not a lesser success.
+    let agent_plan = match agent_id.map(str::trim).filter(|id| !id.is_empty()) {
+        Some(id) => {
+            let agent = db::get_agent(conn, id).map_err(|_| {
+                AppError::NotFound(format!(
+                    "Column '{}' is set to run agent '{}', which no longer exists",
+                    column.name, id
+                ))
+            })?;
+            // Dangling skill ids are dropped, not fatal — matching how the
+            // dossier renders them as "missing skill" rather than refusing to
+            // open. A removed skill shouldn't stop the column running.
+            let skills = resolve_agent_skills(conn, &agent);
+            Some(
+                roster::plan::plan_for(&agent, &skills)
+                    .map_err(|e| AppError::InvalidInput(format!("Agent '{}': {}", agent.name, e)))?,
+            )
+        }
+        None => None,
+    };
+
     let resolved = spawn::resolve(
         &task,
         column,
@@ -1650,13 +1759,15 @@ fn execute_spawn_cli(
             runtime_mode,
             model,
         },
+        agent_plan.as_ref(),
         &pipeline_settings.default_agent_cli,
         pipeline_settings.default_model.as_deref(),
     )?;
-    let cli_type = resolved.cli_type;
-    let initial_prompt = resolved.initial_prompt;
-    let runtime_mode = resolved.runtime_mode;
-    let resolved_model = resolved.model;
+    let cli_type = resolved.cli_type.clone();
+    let initial_prompt = resolved.initial_prompt.clone();
+    let runtime_mode = resolved.runtime_mode.clone();
+    let resolved_model = resolved.model.clone();
+    let is_script_agent = resolved.is_script_agent;
 
     let mut working_dir = resolved.working_dir;
 
@@ -1706,6 +1817,30 @@ fn execute_spawn_cli(
             log::warn!("Failed to write .task.md for task {}: {}", task.id, e);
         }
 
+        // The attached agent's instructions ride the same convention: a file
+        // in the working dir, referenced from the prompt. See `roster::plan`
+        // for why they don't go through a system-prompt flag.
+        let agent_md_path =
+            std::path::Path::new(&working_dir).join(roster::plan::AGENT_INSTRUCTIONS_FILE);
+        match resolved.agent_instructions.as_deref() {
+            Some(instructions) => {
+                if let Err(e) = std::fs::write(&agent_md_path, instructions) {
+                    log::warn!(
+                        "Failed to write {} for task {}: {}",
+                        roster::plan::AGENT_INSTRUCTIONS_FILE,
+                        task.id,
+                        e
+                    );
+                }
+            }
+            // Worktrees are reused across columns, so a stale file from a
+            // previous column's agent would otherwise keep instructing this
+            // one. Removing it is the only way "no agent" actually means it.
+            None => {
+                let _ = std::fs::remove_file(&agent_md_path);
+            }
+        }
+
         // Exclude .task.md from git (avoid agent committing it)
         let exclude_path = std::path::Path::new(&working_dir)
             .join(".git")
@@ -1716,7 +1851,22 @@ fn execute_spawn_cli(
                 if !content.contains(".task.md") {
                     let _ = std::fs::write(
                         &exclude_path,
-                        format!("{}\n.task.md\n.task-handoff.md\n", content.trim_end()),
+                        format!(
+                            "{}\n.task.md\n.task-handoff.md\n{}\n",
+                            content.trim_end(),
+                            roster::plan::AGENT_INSTRUCTIONS_FILE
+                        ),
+                    );
+                } else if !content.contains(roster::plan::AGENT_INSTRUCTIONS_FILE) {
+                    // Worktrees created before agents existed already list
+                    // .task.md, so the branch above never fires for them.
+                    let _ = std::fs::write(
+                        &exclude_path,
+                        format!(
+                            "{}\n{}\n",
+                            content.trim_end(),
+                            roster::plan::AGENT_INSTRUCTIONS_FILE
+                        ),
                     );
                 }
             }
@@ -1772,9 +1922,24 @@ fn execute_spawn_cli(
         Some(format!("CLI trigger: {}", cli_type)),
     );
 
-    let mut cli_args = spawn::model_to_args(resolved_model.as_deref());
-    if let Some(flags) = flags {
-        cli_args.extend(flags.iter().cloned());
+    // A script agent's command has no `--model` to speak of, and the column's
+    // free-text `flags` were written for a CLI it isn't. Its own args are the
+    // whole argv.
+    let mut cli_args = if is_script_agent {
+        resolved.agent_args.clone()
+    } else {
+        let mut args = spawn::model_to_args(resolved_model.as_deref());
+        args.extend(resolved.agent_args.iter().cloned());
+        if let Some(flags) = flags {
+            args.extend(flags.iter().cloned());
+        }
+        args
+    };
+    cli_args.retain(|a| !a.is_empty());
+
+    // Script agents contribute environment overrides; nothing else does.
+    for (key, value) in &resolved.agent_env {
+        env_vars.insert(key.clone(), value.clone());
     }
 
     if runtime_mode == "managed" {
@@ -1813,13 +1978,25 @@ fn execute_spawn_cli(
         // reusing it breaks zsh with `getcwd: cannot access parent
         // directories`. See `pipeline::column_is_terminal` for the
         // definition of "terminal".
+        // A script agent gets its prompt through `$TRIGGER_PROMPT`, not argv.
+        // The generic branch of `build_trigger_command` appends the prompt as a
+        // positional argument, which is right for a CLI that takes one and
+        // wrong for `./render.sh --preset high` — a script with strict argument
+        // parsing would simply fail on the extra word. The env var is already
+        // set above, and is how `run_script` has always passed it.
+        let launch_prompt = if is_script_agent {
+            String::new()
+        } else {
+            initial_prompt
+        };
+
         bridge::spawn_cli_trigger_task(
             app.clone(),
             task.id.clone(),
             cli_type,
             cli_args,
             working_dir,
-            initial_prompt,
+            launch_prompt,
             Some(env_vars),
             is_terminal_column,
         );
@@ -3329,6 +3506,64 @@ mod tests {
     use super::*;
     use crate::db;
 
+    fn set_triggers(conn: &Connection, column_id: &str, agent_id: Option<&str>) {
+        let json = serde_json::to_string(&ColumnTriggersV2 {
+            on_entry: Some(TriggerActionV2::SpawnCli {
+                agent_id: agent_id.map(str::to_string),
+                cli: None,
+                command: None,
+                prompt_template: None,
+                prompt: None,
+                flags: None,
+                use_queue: None,
+                runtime_mode: None,
+                model: None,
+            }),
+            ..Default::default()
+        })
+        .unwrap();
+        db::update_column(conn, column_id, None, None, None, None, None, Some(&json)).unwrap();
+    }
+
+    #[test]
+    fn columns_using_agent_sweeps_every_workspace() {
+        // Agents are global, so deleting one has to account for boards the
+        // user doesn't happen to have open.
+        let conn = db::init_test().unwrap();
+        let ws_a = db::insert_workspace(&conn, "Alpha", "/tmp/a").unwrap();
+        let ws_b = db::insert_workspace(&conn, "Beta", "/tmp/b").unwrap();
+        let col_a = db::insert_column(&conn, &ws_a.id, "Working", 0).unwrap();
+        let col_b = db::insert_column(&conn, &ws_b.id, "Review", 0).unwrap();
+        let col_c = db::insert_column(&conn, &ws_b.id, "Idle", 1).unwrap();
+
+        set_triggers(&conn, &col_a.id, Some("agent-1"));
+        set_triggers(&conn, &col_b.id, Some("agent-1"));
+        set_triggers(&conn, &col_c.id, Some("agent-2"));
+
+        let usage = columns_using_agent(&conn, "agent-1");
+        assert_eq!(usage.len(), 2);
+        let names: Vec<_> = usage.iter().map(|u| u.column_name.as_str()).collect();
+        assert!(names.contains(&"Working"));
+        assert!(names.contains(&"Review"));
+        assert!(usage.iter().all(|u| u.hook == "on_entry"));
+        // The workspace name travels with it, so the dialog can tell apart two
+        // columns that happen to share a name.
+        assert!(usage.iter().any(|u| u.workspace_name == "Alpha"));
+        assert!(usage.iter().any(|u| u.workspace_name == "Beta"));
+    }
+
+    #[test]
+    fn columns_without_that_agent_are_not_reported() {
+        let conn = db::init_test().unwrap();
+        let ws = db::insert_workspace(&conn, "Alpha", "/tmp/a").unwrap();
+        let col = db::insert_column(&conn, &ws.id, "Working", 0).unwrap();
+        set_triggers(&conn, &col.id, None);
+        assert!(columns_using_agent(&conn, "agent-1").is_empty());
+        // A column with no triggers at all must not blow up the sweep.
+        db::insert_column(&conn, &ws.id, "Bare", 1).unwrap();
+        assert!(columns_using_agent(&conn, "agent-1").is_empty());
+    }
+
     #[test]
     fn test_validate_triggers_json() {
         // Empty / "{}" means "no triggers" — valid.
@@ -3423,6 +3658,7 @@ mod tests {
     fn make_spawn_cli_triggers(runtime_mode: Option<&str>) -> ColumnTriggersV2 {
         ColumnTriggersV2 {
             on_entry: Some(TriggerActionV2::SpawnCli {
+                agent_id: None,
                 cli: Some("claude".to_string()),
                 command: None,
                 prompt_template: None,
@@ -3733,6 +3969,7 @@ mod tests {
 
         let triggers = ColumnTriggersV2 {
             on_entry: Some(TriggerActionV2::SpawnCli {
+                agent_id: None,
                 cli: Some("claude".to_string()),
                 command: None,
                 prompt_template: None,
@@ -3805,6 +4042,7 @@ mod tests {
 
         let triggers = ColumnTriggersV2 {
             on_entry: Some(TriggerActionV2::SpawnCli {
+                agent_id: None,
                 cli: Some("claude".to_string()),
                 command: None,
                 prompt_template: None,
@@ -3843,6 +4081,7 @@ mod tests {
 
         let triggers = ColumnTriggersV2 {
             on_entry: Some(TriggerActionV2::SpawnCli {
+                agent_id: None,
                 cli: Some("claude".to_string()),
                 command: Some("/start-task".to_string()),
                 prompt_template: None,
@@ -3880,6 +4119,7 @@ mod tests {
 
         let triggers = ColumnTriggersV2 {
             on_entry: Some(TriggerActionV2::SpawnCli {
+                agent_id: None,
                 cli: None,
                 command: None,
                 prompt_template: None,

--- a/src-tauri/src/roster/mod.rs
+++ b/src-tauri/src/roster/mod.rs
@@ -13,13 +13,16 @@
 //!   care.
 //! - [`Runtime`] — the **seam**. Small on purpose.
 //!
-//! There is deliberately **no `execute`/`spawn` method here.** The decision was
-//! "design the seam, ship a few plugins behind it, no execution engine on day
-//! one". When agents are wired into columns, spawning should reuse the existing
-//! `pipeline::spawn::resolve()` rather than growing a second copy of the
-//! cli/model/cwd/prompt precedence rules.
+//! There is deliberately **no `execute`/`spawn` method here** — and there still
+//! isn't. Columns can now reference an agent, but the seam stayed shut: [`plan`]
+//! turns a definition into spawn *parameters*, and
+//! `pipeline::spawn::resolve()` applies precedence against the
+//! task/column/workspace tiers. Neither launches anything, so there is still
+//! exactly one copy of the cli/model/cwd/prompt rules.
 //!
 //! Spec: `.tickets/_docs/specs/KAITEN_AGENTS.md`
+
+pub mod plan;
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/src-tauri/src/roster/plan.rs
+++ b/src-tauri/src/roster/plan.rs
@@ -1,0 +1,336 @@
+//! Turning an agent *definition* into spawn parameters.
+//!
+//! This is the piece the module docs anticipated: still no execution here, just
+//! "what would running this agent look like". [`crate::pipeline::spawn::resolve`]
+//! consumes the result and applies precedence against the task/column/workspace
+//! tiers; the actual launch stays in `chat::bridge`.
+//!
+//! ## Why instructions ship as a file, not a system-prompt flag
+//!
+//! An agent's instructions have to reach three runtimes across three runtime
+//! modes, and there is no flag that spans them:
+//!
+//! - **codex has no system-prompt flag at all** (verified against codex-cli
+//!   0.145.0 — assuming otherwise is what broke every sentinel-carrying column
+//!   before).
+//! - **claude's `--append-system-prompt` is last-wins, not cumulative**
+//!   (verified against 2.1.239). Interactive mode already spends that flag on
+//!   the done-sentinel and appends it *after* user args, so routing agent
+//!   instructions through it would silently drop them in exactly the columns
+//!   most likely to use an agent.
+//! - **script agents have no prompt concept whatsoever.**
+//!
+//! So instructions are written to `.agent.md` in the working directory and the
+//! prompt points at them — the same convention `.task.md` already established
+//! for the task spec. One mechanism, no flag-existence assumptions, and
+//! switching a column between headless and interactive can't change what the
+//! agent was told. Runtime mode is a rendering and billing choice; it has no
+//! business altering behaviour.
+
+use std::collections::BTreeMap;
+
+use crate::db::{Agent, Skill};
+
+use super::{parse_and_validate, AgentConfig, LlmConfig, ScriptConfig};
+
+/// The filename an attached agent's instructions are written to, alongside the
+/// `.task.md` the trigger already writes.
+pub const AGENT_INSTRUCTIONS_FILE: &str = ".agent.md";
+
+/// Everything an attached agent contributes to a spawn, with nothing resolved
+/// against the column/task tiers yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentSpawnPlan {
+    /// Display name, for errors and telemetry.
+    pub agent_name: String,
+    /// What to execute: `claude`, `codex`, or a script agent's own command.
+    pub command: String,
+    /// True when `command` is a user-authored script rather than a known CLI.
+    /// The CLI allow-list does not apply to these — see `pipeline::spawn`.
+    pub is_script: bool,
+    /// The agent's preferred model. A column or task may still override it;
+    /// everything else about the agent is the agent's own.
+    pub model: Option<String>,
+    /// Rendered instructions + skills for `.agent.md`. `None` for script
+    /// agents, which have no prompt.
+    pub instructions: Option<String>,
+    /// Extra argv: MCP flags for LLM agents, the command's own args for
+    /// script agents.
+    pub args: Vec<String>,
+    /// Environment overrides. Script agents only.
+    pub env: BTreeMap<String, String>,
+}
+
+/// Build the spawn plan for an agent, given the skills it references.
+///
+/// `skills` is the resolved subset — dangling ids are dropped by the caller
+/// rather than failing, matching how the dossier renders them as "missing".
+pub fn plan_for(agent: &Agent, skills: &[Skill]) -> Result<AgentSpawnPlan, String> {
+    let config = parse_and_validate(&agent.runtime, &agent.config)?;
+
+    Ok(match &config {
+        AgentConfig::Claude(llm) => llm_plan(agent, "claude", llm, skills),
+        AgentConfig::Codex(llm) => llm_plan(agent, "codex", llm, skills),
+        AgentConfig::Script(script) => script_plan(agent, script),
+    })
+}
+
+fn llm_plan(agent: &Agent, cli: &str, llm: &LlmConfig, skills: &[Skill]) -> AgentSpawnPlan {
+    let mut args = Vec::new();
+
+    // `--allowedTools` only means anything alongside an MCP config — the pair
+    // is validated together in `roster::validate_llm`, so by here either both
+    // are set or the allow-list is empty. `--strict-mcp-config` keeps the
+    // user's own ~/.claude servers out, matching how chef sessions load theirs.
+    if !llm.mcp_config_path.trim().is_empty() {
+        args.push("--strict-mcp-config".to_string());
+        args.push("--mcp-config".to_string());
+        args.push(llm.mcp_config_path.trim().to_string());
+        if !llm.allowed_tools.is_empty() {
+            args.push("--allowedTools".to_string());
+            args.push(llm.allowed_tools.join(","));
+        }
+    }
+
+    AgentSpawnPlan {
+        agent_name: agent.name.clone(),
+        command: cli.to_string(),
+        is_script: false,
+        model: non_empty(&llm.model),
+        instructions: render_instructions(agent, llm, skills),
+        args,
+        env: BTreeMap::new(),
+    }
+}
+
+fn script_plan(agent: &Agent, script: &ScriptConfig) -> AgentSpawnPlan {
+    AgentSpawnPlan {
+        agent_name: agent.name.clone(),
+        command: script.command.trim().to_string(),
+        is_script: true,
+        model: None,
+        // A script has no prompt to carry, so no `.agent.md` is written.
+        instructions: None,
+        args: script.args.clone(),
+        env: script.env.clone(),
+    }
+}
+
+/// Render `.agent.md`: who the agent is, its instructions, and the skills it
+/// can reach for.
+///
+/// Returns `None` when there is genuinely nothing to say, so a bare agent
+/// doesn't get a near-empty file and a prompt line pointing at it.
+fn render_instructions(agent: &Agent, llm: &LlmConfig, skills: &[Skill]) -> Option<String> {
+    let prompt = llm.system_prompt.trim();
+    if prompt.is_empty() && skills.is_empty() {
+        return None;
+    }
+
+    let mut out = format!("# {}\n", agent.name.trim());
+    if !agent.role.trim().is_empty() {
+        out.push_str(&format!("\n{}\n", agent.role.trim()));
+    }
+
+    if !prompt.is_empty() {
+        out.push_str("\n## Instructions\n\n");
+        out.push_str(prompt);
+        out.push('\n');
+    }
+
+    if !skills.is_empty() {
+        out.push_str("\n## Skills\n\n");
+        out.push_str(
+            "Capabilities available to you. Reach for one when its situation applies.\n\n",
+        );
+        for skill in skills {
+            out.push_str(&format!("### {}\n\n", skill.name.trim()));
+            if !skill.description.trim().is_empty() {
+                out.push_str(&format!("{}\n\n", skill.description.trim()));
+            }
+            if !skill.trigger.trim().is_empty() {
+                out.push_str(&format!("Use when: {}\n\n", skill.trigger.trim()));
+            }
+            if !skill.script.trim().is_empty() {
+                out.push_str(&format!("```sh\n{}\n```\n\n", skill.script.trim()));
+            }
+        }
+    }
+
+    Some(out)
+}
+
+/// The one-line prompt suffix pointing the agent at its instructions file.
+///
+/// Newline-free on purpose: in interactive mode the prompt is injected as a
+/// single `tmux send-keys -l` payload, where a literal newline submits early.
+pub fn instructions_prompt_suffix() -> String {
+    format!("Follow the instructions in {}.", AGENT_INSTRUCTIONS_FILE)
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(runtime: &str, config: &AgentConfig) -> Agent {
+        Agent {
+            id: "agent-1".into(),
+            name: "Code Smith".into(),
+            role: "Implements the task in its worktree".into(),
+            runtime: runtime.into(),
+            config: serde_json::to_string(config).unwrap(),
+            avatar: "{}".into(),
+            created_at: "2026-08-21T00:00:00Z".into(),
+            updated_at: "2026-08-21T00:00:00Z".into(),
+        }
+    }
+
+    fn skill(name: &str, trigger: &str, script: &str) -> Skill {
+        Skill {
+            id: format!("skill-{}", name),
+            name: name.into(),
+            description: format!("{} does a thing", name),
+            trigger: trigger.into(),
+            script: script.into(),
+            created_at: "2026-08-21T00:00:00Z".into(),
+            updated_at: "2026-08-21T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn llm_runtime_maps_to_its_cli() {
+        for (runtime, cli) in [("claude", "claude"), ("codex", "codex")] {
+            let cfg = AgentConfig::default_for(runtime).unwrap();
+            let plan = plan_for(&agent(runtime, &cfg), &[]).unwrap();
+            assert_eq!(plan.command, cli);
+            assert!(!plan.is_script);
+            assert!(plan.env.is_empty());
+        }
+    }
+
+    #[test]
+    fn script_runtime_carries_command_args_and_env() {
+        let mut env = BTreeMap::new();
+        env.insert("RENDER_THREADS".to_string(), "8".to_string());
+        let cfg = AgentConfig::Script(ScriptConfig {
+            command: "./render.sh".into(),
+            args: vec!["--preset".into(), "high".into()],
+            env,
+        });
+        let plan = plan_for(&agent("script", &cfg), &[]).unwrap();
+        assert_eq!(plan.command, "./render.sh");
+        assert!(plan.is_script);
+        assert_eq!(plan.args, vec!["--preset".to_string(), "high".to_string()]);
+        assert_eq!(plan.env.get("RENDER_THREADS").map(String::as_str), Some("8"));
+        // A script has no prompt, so nothing to write to `.agent.md`.
+        assert_eq!(plan.instructions, None);
+        assert_eq!(plan.model, None);
+    }
+
+    #[test]
+    fn mcp_config_becomes_strict_flags_and_allow_list() {
+        let cfg = AgentConfig::Claude(LlmConfig {
+            mcp_config_path: "  /tmp/mcp.json  ".into(),
+            allowed_tools: vec!["get_board".into(), "get_task".into()],
+            ..Default::default()
+        });
+        let plan = plan_for(&agent("claude", &cfg), &[]).unwrap();
+        assert_eq!(
+            plan.args,
+            vec![
+                "--strict-mcp-config".to_string(),
+                "--mcp-config".to_string(),
+                // Trimmed — a stray space would make the path unopenable.
+                "/tmp/mcp.json".to_string(),
+                "--allowedTools".to_string(),
+                "get_board,get_task".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn no_mcp_config_means_no_flags() {
+        let cfg = AgentConfig::default_for("claude").unwrap();
+        assert!(plan_for(&agent("claude", &cfg), &[]).unwrap().args.is_empty());
+    }
+
+    #[test]
+    fn blank_model_means_cli_default_not_an_empty_flag() {
+        let cfg = AgentConfig::Claude(LlmConfig {
+            model: "   ".into(),
+            ..Default::default()
+        });
+        assert_eq!(plan_for(&agent("claude", &cfg), &[]).unwrap().model, None);
+    }
+
+    #[test]
+    fn instructions_carry_prompt_and_skills() {
+        let cfg = AgentConfig::Claude(LlmConfig {
+            system_prompt: "Implement it, then run the tests.".into(),
+            ..Default::default()
+        });
+        let skills = vec![skill("Run tests", "before handing work back", "npm test")];
+        let md = plan_for(&agent("claude", &cfg), &skills)
+            .unwrap()
+            .instructions
+            .expect("instructions");
+
+        assert!(md.starts_with("# Code Smith"));
+        assert!(md.contains("Implements the task in its worktree"));
+        assert!(md.contains("Implement it, then run the tests."));
+        assert!(md.contains("### Run tests"));
+        assert!(md.contains("Use when: before handing work back"));
+        assert!(md.contains("```sh\nnpm test\n```"));
+    }
+
+    #[test]
+    fn a_bare_agent_gets_no_instructions_file() {
+        // Otherwise a prompt would point the agent at a file saying nothing.
+        let cfg = AgentConfig::default_for("claude").unwrap();
+        assert_eq!(plan_for(&agent("claude", &cfg), &[]).unwrap().instructions, None);
+    }
+
+    #[test]
+    fn skills_alone_are_enough_to_warrant_instructions() {
+        let cfg = AgentConfig::default_for("codex").unwrap();
+        let skills = vec![skill("Lint", "after editing", "npm run lint")];
+        let md = plan_for(&agent("codex", &cfg), &skills)
+            .unwrap()
+            .instructions
+            .expect("skills alone should still produce a file");
+        assert!(md.contains("## Skills"));
+        assert!(!md.contains("## Instructions"));
+    }
+
+    #[test]
+    fn a_runtime_config_mismatch_is_refused() {
+        // agents.runtime is plain TEXT, so a hand-edited row can disagree with
+        // the tag inside agents.config. Better to refuse than to spawn codex
+        // believing it is claude.
+        let cfg = AgentConfig::Script(ScriptConfig {
+            command: "ls".into(),
+            ..Default::default()
+        });
+        let mut a = agent("script", &cfg);
+        a.runtime = "claude".into();
+        assert!(plan_for(&a, &[]).is_err());
+    }
+
+    #[test]
+    fn the_prompt_suffix_stays_newline_free() {
+        // Interactive mode injects the prompt as one `tmux send-keys -l`
+        // payload; a literal newline submits the line early in the TUI.
+        let suffix = instructions_prompt_suffix();
+        assert!(!suffix.contains('\n'), "{:?}", suffix);
+        assert!(suffix.contains(AGENT_INSTRUCTIONS_FILE));
+    }
+}

--- a/src/components/kanban/column-automation-sentence.test.tsx
+++ b/src/components/kanban/column-automation-sentence.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
-import type { ExitCriteria, TriggerAction } from '@/types'
+import type { Agent, ExitCriteria, TriggerAction } from '@/types'
+import { useRosterStore } from '@/stores/roster-store'
 import { AutomationSentence } from './column-automation-sentence'
 import { automationSummary } from './column-recipes'
 
@@ -17,6 +18,26 @@ function setup(onEntry: TriggerAction = { type: 'none' }, exit: ExitCriteria = {
   )
   return { setOnEntry, setExitCriteria }
 }
+
+const agent = (id: string, name: string, runtime: Agent['runtime']): Agent => ({
+  id,
+  name,
+  role: '',
+  runtime,
+  config: JSON.stringify({ runtime }),
+  avatar: '{}',
+  createdAt: '',
+  updatedAt: '',
+})
+
+/** Seed the roster without hitting IPC — `load()` is a no-op once `loaded`. */
+function seedRoster(agents: Agent[]) {
+  useRosterStore.setState({ agents, skills: [], runtimes: [], loaded: true })
+}
+
+beforeEach(() => {
+  seedRoster([])
+})
 
 describe('AutomationSentence', () => {
   it('renders the sentence and the recipe gallery', () => {
@@ -44,6 +65,60 @@ describe('AutomationSentence', () => {
     expect(screen.queryByLabelText('Model')).not.toBeInTheDocument()
   })
 
+  it('offers roster agents alongside the bare-CLI escape hatch', () => {
+    seedRoster([agent('a1', 'Code Smith', 'claude')])
+    setup({ type: 'spawn_cli', cli: 'claude' })
+    const picker = screen.getByLabelText('Agent')
+    expect(picker).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Code Smith' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'a bare CLI' })).toBeInTheDocument()
+  })
+
+  it('attaching an agent removes the CLI token, because the agent owns it', () => {
+    seedRoster([agent('a1', 'Code Smith', 'claude')])
+    setup({ type: 'spawn_cli', agent_id: 'a1' })
+    expect(screen.queryByLabelText('CLI')).not.toBeInTheDocument()
+    // Model survives — the one override the spec allows a column to keep.
+    expect(screen.getByLabelText('Model')).toBeInTheDocument()
+  })
+
+  it('relabels the default model option to point at the agent', () => {
+    seedRoster([agent('a1', 'Code Smith', 'claude')])
+    setup({ type: 'spawn_cli', agent_id: 'a1' })
+    expect(screen.getByRole('option', { name: "the agent's model" })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'auto' })).not.toBeInTheDocument()
+  })
+
+  it('drops the model token for a script agent, which has no model', () => {
+    seedRoster([agent('a2', 'Video Editor', 'script')])
+    setup({ type: 'spawn_cli', agent_id: 'a2' })
+    expect(screen.queryByLabelText('Model')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('CLI')).not.toBeInTheDocument()
+    expect(screen.getByText('as-is')).toBeInTheDocument()
+  })
+
+  it('surfaces an agent the roster no longer has instead of silently resetting', () => {
+    seedRoster([agent('a1', 'Code Smith', 'claude')])
+    setup({ type: 'spawn_cli', agent_id: 'deleted-agent' })
+    expect(screen.getByRole('option', { name: 'missing agent' })).toBeInTheDocument()
+  })
+
+  it('choosing the bare CLI clears the agent and restores a CLI', () => {
+    seedRoster([agent('a1', 'Code Smith', 'claude')])
+    const { setOnEntry } = setup({ type: 'spawn_cli', agent_id: 'a1' })
+    fireEvent.change(screen.getByLabelText('Agent'), { target: { value: '__bare_cli__' } })
+    expect(setOnEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: undefined, cli: 'claude' }),
+    )
+  })
+
+  it('picking an agent stores its id', () => {
+    seedRoster([agent('a1', 'Code Smith', 'claude')])
+    const { setOnEntry } = setup({ type: 'spawn_cli', cli: 'claude' })
+    fireEvent.change(screen.getByLabelText('Agent'), { target: { value: 'a1' } })
+    expect(setOnEntry).toHaveBeenCalledWith(expect.objectContaining({ agent_id: 'a1' }))
+  })
+
   it('picking a real exit condition implies auto-advance; "manually" does not', () => {
     const { setExitCriteria } = setup({ type: 'spawn_cli' }, { type: 'manual' })
     fireEvent.change(screen.getByLabelText('Advance when'), { target: { value: 'agent_complete' } })
@@ -59,7 +134,7 @@ describe('automationSummary', () => {
   })
   it('reads a plain-language summary for an agent column', () => {
     expect(automationSummary({ type: 'spawn_cli' }, { type: 'agent_complete' })).toBe(
-      'Run an AI agent · advance when the agent finishes',
+      'Run an agent · advance when the agent finishes',
     )
   })
 })

--- a/src/components/kanban/column-automation-sentence.tsx
+++ b/src/components/kanban/column-automation-sentence.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react'
 import type { ActionType, ExitCriteria, ExitCriteriaType, SpawnCliAction, TriggerAction } from '@/types'
+import { useRosterStore } from '@/stores/roster-store'
 import { CLI_TYPES } from './column-config-constants'
 import {
   ACTION_CLAUSES,
@@ -7,6 +9,13 @@ import {
   SENTENCE_MODELS,
   defaultActionForType,
 } from './column-recipes'
+
+/**
+ * Sentinel for "no roster agent — just run a bare CLI", the pre-agents
+ * behaviour. Not the empty string: an empty `<option>` value is easy to
+ * confuse with "nothing selected".
+ */
+const BARE_CLI = '__bare_cli__'
 
 type Props = {
   onEntry: TriggerAction
@@ -47,6 +56,32 @@ function Token({
 export function AutomationSentence({ onEntry, setOnEntry, exitCriteria, setExitCriteria }: Props) {
   const actionType = onEntry.type
   const spawn = onEntry.type === 'spawn_cli' ? onEntry : null
+
+  const agents = useRosterStore((s) => s.agents)
+  const loadRoster = useRosterStore((s) => s.load)
+  useEffect(() => { void loadRoster() }, [loadRoster])
+
+  const attachedAgent = spawn?.agent_id
+    ? agents.find((a) => a.id === spawn.agent_id)
+    : undefined
+  const isScriptAgent = attachedAgent?.runtime === 'script'
+
+  const agentOptions = [
+    ...agents.map((a) => ({ value: a.id, label: a.name })),
+    // An agent the column names but the roster no longer has. Shown rather
+    // than silently resetting the column to a bare CLI, which would look like
+    // it still worked.
+    ...(spawn?.agent_id && !attachedAgent
+      ? [{ value: spawn.agent_id, label: 'missing agent' }]
+      : []),
+    { value: BARE_CLI, label: 'a bare CLI' },
+  ]
+
+  // With an agent attached, "auto" no longer means the workspace default — it
+  // means whatever the agent asked for. Say so.
+  const modelOptionsWithAgentDefault = SENTENCE_MODELS.map((m) =>
+    m.value === '' ? { ...m, label: "the agent's model" } : m,
+  )
 
   const setActionType = (t: string) => { setOnEntry(defaultActionForType(t as ActionType)) }
   const setSpawn = (patch: Partial<SpawnCliAction>) => {
@@ -97,17 +132,42 @@ export function AutomationSentence({ onEntry, setOnEntry, exitCriteria, setExitC
           <>
             <span>using</span>
             <Token
-              ariaLabel="CLI"
-              value={spawn.cli ?? 'claude'}
-              onChange={(v) => { setSpawn({ cli: v as SpawnCliAction['cli'] }) }}
-              options={CLI_TYPES}
+              ariaLabel="Agent"
+              value={spawn.agent_id ?? BARE_CLI}
+              onChange={(v) => {
+                setSpawn(
+                  v === BARE_CLI
+                    ? { agent_id: undefined, cli: spawn.cli ?? 'claude' }
+                    : { agent_id: v },
+                )
+              }}
+              options={agentOptions}
             />
-            <Token
-              ariaLabel="Model"
-              value={spawn.model ?? ''}
-              onChange={(v) => { setSpawn({ model: v || undefined }) }}
-              options={SENTENCE_MODELS}
-            />
+            {/* The CLI token is deliberately gone once an agent is chosen: the
+                agent owns its runtime, and offering a control that silently
+                loses would misrepresent what actually runs. Model stays,
+                because a column overriding the model is the one exception the
+                Kaiten Agents spec allows. */}
+            {!attachedAgent && (
+              <Token
+                ariaLabel="CLI"
+                value={spawn.cli ?? 'claude'}
+                onChange={(v) => { setSpawn({ cli: v as SpawnCliAction['cli'] }) }}
+                options={CLI_TYPES}
+              />
+            )}
+            {isScriptAgent ? (
+              // A script agent has no model to pick, and showing "auto" next to
+              // one implies a choice that doesn't exist.
+              <span className="mx-0.5 text-text-secondary/70">as-is</span>
+            ) : (
+              <Token
+                ariaLabel="Model"
+                value={spawn.model ?? ''}
+                onChange={(v) => { setSpawn({ model: v || undefined }) }}
+                options={attachedAgent ? modelOptionsWithAgentDefault : SENTENCE_MODELS}
+              />
+            )}
           </>
         )}
 

--- a/src/components/kanban/column-recipes.ts
+++ b/src/components/kanban/column-recipes.ts
@@ -69,7 +69,7 @@ export const COLUMN_RECIPES: ColumnRecipe[] = [
 
 /** Plain-language action verbs for the sentence's "do" clause. */
 export const ACTION_CLAUSES: { value: ActionType; label: string }[] = [
-  { value: 'spawn_cli', label: 'run an AI agent' },
+  { value: 'spawn_cli', label: 'run an agent' },
   { value: 'run_script', label: 'run a script' },
   { value: 'create_pr', label: 'open a PR' },
   { value: 'auto_setup', label: 'set up a branch + worktree' },

--- a/src/components/kanban/spawn-cli-action-editor.tsx
+++ b/src/components/kanban/spawn-cli-action-editor.tsx
@@ -1,4 +1,6 @@
 import type { AgentRuntimeMode, CliType, SpawnCliAction } from '@/types'
+import { useEffect } from 'react'
+import { useRosterStore } from '@/stores/roster-store'
 import { CLI_TYPES, COMMON_COMMANDS } from './column-config-constants'
 
 type SpawnCliActionEditorProps = {
@@ -49,6 +51,13 @@ export function SpawnCliActionEditor({
   const runtimeMode = action.runtime_mode ?? 'terminal'
   const isManagedMode = runtimeMode === 'managed'
 
+  const agents = useRosterStore((s) => s.agents)
+  const loadRoster = useRosterStore((s) => s.load)
+  useEffect(() => { void loadRoster() }, [loadRoster])
+  const attachedAgent = action.agent_id
+    ? agents.find((a) => a.id === action.agent_id)
+    : undefined
+
   return (
     <div className="space-y-3 rounded-lg border border-border-default bg-bg/50 p-3">
       {/* CLI + Command */}
@@ -57,17 +66,30 @@ export function SpawnCliActionEditor({
           <label className="mb-1 block text-xs font-medium text-text-secondary">
             CLI
           </label>
-          <select
-            value={action.cli || 'claude'}
-            onChange={(e) => { setAction({ ...action, cli: e.target.value as CliType }) }}
-            className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
-          >
-            {CLI_TYPES.map((cli) => (
-              <option key={cli.value} value={cli.value}>
-                {cli.label}
-              </option>
-            ))}
-          </select>
+          {action.agent_id ? (
+            // An attached agent owns its runtime. A live dropdown here would
+            // be a control whose value is discarded at spawn time — say what
+            // actually runs instead.
+            <div
+              data-testid="spawn-cli-owned-by-agent"
+              className="rounded-lg border border-border-default bg-surface/40 px-3 py-2 text-sm text-text-secondary"
+            >
+              Set by{' '}
+              <span className="text-text-primary">{attachedAgent?.name ?? 'a missing agent'}</span>
+            </div>
+          ) : (
+            <select
+              value={action.cli || 'claude'}
+              onChange={(e) => { setAction({ ...action, cli: e.target.value as CliType }) }}
+              className="w-full rounded-lg border border-border-default bg-bg px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+            >
+              {CLI_TYPES.map((cli) => (
+                <option key={cli.value} value={cli.value}>
+                  {cli.label}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
 
         <div>

--- a/src/components/roster/agent-dossier.tsx
+++ b/src/components/roster/agent-dossier.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react'
-import type { Agent, LlmConfig, ScriptRuntimeConfig } from '@/types'
+import type { Agent, AgentUsage, LlmConfig, ScriptRuntimeConfig } from '@/types'
 import { parseAgentAvatar, parseAgentConfig } from '@/types'
 import { useRosterStore } from '@/stores/roster-store'
 
@@ -267,11 +267,14 @@ export function AgentDossier({
   onEdit,
   onDuplicate,
   onDelete,
+  usage,
 }: {
   agent: Agent
   onEdit: () => void
   onDuplicate: () => void
   onDelete: () => void
+  /** Columns currently running this agent, across every workspace. */
+  usage: AgentUsage[]
 }) {
   const avatar = parseAgentAvatar(agent.avatar, agent.name)
   const config = parseAgentConfig(agent.config, agent.runtime)
@@ -336,6 +339,35 @@ export function AgentDossier({
 
       <div className="flex-1 px-6 py-5">
         <div className="grid items-start gap-3 xl:grid-cols-2">
+          {/* Where this agent actually runs. First card because "is this thing
+              wired up?" is the question you open a dossier to answer. */}
+          <Section title="Columns" count={usage.length}>
+            {usage.length > 0 ? (
+              <ul className="flex flex-col gap-1">
+                {usage.map((u) => (
+                  <li
+                    key={`${u.columnId}-${u.hook}`}
+                    className="flex items-baseline justify-between gap-3"
+                  >
+                    <span className="min-w-0 truncate text-sm text-text-primary">
+                      {u.columnName}
+                      <span className="ml-1.5 text-xs text-text-secondary">
+                        {u.workspaceName}
+                      </span>
+                    </span>
+                    <span className="shrink-0 font-mono text-2xs uppercase tracking-wider text-text-secondary">
+                      {u.hook === 'on_exit' ? 'on exit' : 'on entry'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <Empty>
+                Not attached to a column yet. Pick it in a column&apos;s automation sentence.
+              </Empty>
+            )}
+          </Section>
+
           {config.runtime === 'script' ? (
             <ScriptSections config={config} />
           ) : (

--- a/src/components/roster/roster-view.test.tsx
+++ b/src/components/roster/roster-view.test.tsx
@@ -2,7 +2,28 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
 import { RosterView } from './roster-view'
 import { useRosterStore } from '@/stores/roster-store'
-import type { Agent } from '@/types'
+import * as ipc from '@/lib/ipc'
+import type { Agent, AgentUsage } from '@/types'
+
+vi.mock('@/lib/ipc', async (orig) => ({
+  ...(await orig<typeof ipc>()),
+  getAgentUsage: vi.fn(),
+}))
+
+const usageMock = vi.mocked(ipc.getAgentUsage)
+
+function usedBy(...rows: Partial<AgentUsage>[]) {
+  usageMock.mockResolvedValue(
+    rows.map((r, i) => ({
+      workspaceId: 'ws-1',
+      workspaceName: 'Alpha',
+      columnId: `col-${String(i)}`,
+      columnName: 'Working',
+      hook: 'on_entry',
+      ...r,
+    })),
+  )
+}
 
 function agent(overrides: Partial<Agent> = {}): Agent {
   return {
@@ -54,6 +75,36 @@ describe('RosterView', () => {
   beforeEach(() => {
     cleanup()
     vi.clearAllMocks()
+    usageMock.mockResolvedValue([])
+  })
+
+  it('the dossier says where an agent actually runs', async () => {
+    usedBy({ columnName: 'Working' }, { columnName: 'Review', workspaceName: 'Beta' })
+    seed([agent()])
+    render(<RosterView />)
+    fireEvent.click(screen.getByTestId('agent-tile-a1'))
+    expect(await screen.findByText('Working')).toBeInTheDocument()
+    expect(screen.getByText('Review')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+
+  it('the dossier says so plainly when nothing uses the agent', async () => {
+    seed([agent()])
+    render(<RosterView />)
+    fireEvent.click(screen.getByTestId('agent-tile-a1'))
+    expect(await screen.findByText(/Not attached to a column yet/)).toBeInTheDocument()
+  })
+
+  it('the delete confirmation names the columns that would break', async () => {
+    usedBy({ columnName: 'Working', workspaceName: 'Alpha' })
+    seed([agent()])
+    render(<RosterView />)
+    fireEvent.click(screen.getByTestId('agent-tile-a1'))
+    await screen.findByText('Working')
+    fireEvent.click(screen.getByTestId('agent-delete'))
+    expect(
+      await screen.findByText(/Working \(Alpha\) still runs this agent/),
+    ).toBeInTheDocument()
   })
 
   it('filters the grid by runtime', () => {

--- a/src/components/roster/roster-view.tsx
+++ b/src/components/roster/roster-view.tsx
@@ -6,6 +6,7 @@ import * as ipc from '@/lib/ipc'
 import { AgentTile, NewAgentTile } from './agent-tile'
 import { AgentDossier } from './agent-dossier'
 import { AgentEditor } from './agent-editor'
+import { useAgentUsage } from './use-agent-usage'
 
 /**
  * The Roster section — character-select for agents.
@@ -42,6 +43,8 @@ export function RosterView() {
   useEffect(() => {
     void load()
   }, [load])
+
+  const selectedUsage = useAgentUsage(selectedId ?? undefined)
 
   const visible = useMemo(
     () => (filter === 'all' ? agents : agents.filter((a) => a.runtime === filter)),
@@ -151,6 +154,7 @@ export function RosterView() {
               onDelete={() => {
                 setConfirmDelete(selected.id)
               }}
+              usage={selectedUsage}
             />
           ) : (
             <div className="flex h-full items-center justify-center p-6">
@@ -181,7 +185,13 @@ export function RosterView() {
       {confirmDelete !== null && (
         <ConfirmDialog
           title="Delete this agent?"
-          body="This removes the definition. Work it has already done is unaffected."
+          body={
+            selectedUsage.length > 0
+              ? `${selectedUsage
+                  .map((u) => `${u.columnName} (${u.workspaceName})`)
+                  .join(', ')} still run${selectedUsage.length === 1 ? 's' : ''} this agent. Those columns will fail until you point them somewhere else.`
+              : 'This removes the definition. Work it has already done is unaffected.'
+          }
           testId="roster-confirm-delete"
           onConfirm={() => {
             void handleDelete(confirmDelete)

--- a/src/components/roster/use-agent-usage.ts
+++ b/src/components/roster/use-agent-usage.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import type { AgentUsage } from '@/types'
+import * as ipc from '@/lib/ipc'
+
+/**
+ * Which columns currently run this agent.
+ *
+ * Fetched rather than derived from a store because columns are per-workspace
+ * and only the open workspace's are loaded, while agents are global — an agent
+ * is very often attached to a board that isn't on screen.
+ */
+export function useAgentUsage(agentId: string | undefined): AgentUsage[] {
+  const [usage, setUsage] = useState<AgentUsage[]>([])
+
+  useEffect(() => {
+    if (!agentId) {
+      setUsage([])
+      return
+    }
+    let live = true
+    ipc
+      .getAgentUsage(agentId)
+      .then((rows) => {
+        if (live) setUsage(rows)
+      })
+      .catch(() => {
+        // Usage is advisory — a failed lookup shouldn't blank the dossier.
+        if (live) setUsage([])
+      })
+    return () => {
+      live = false
+    }
+  }, [agentId])
+
+  return usage
+}
+
+/** "Review in Alpha" / "2 columns" — the phrasing both the dossier and the
+ *  delete confirmation use, so they can't describe the same thing differently. */
+export function describeUsage(usage: AgentUsage[]): string {
+  if (usage.length === 0) return 'Not used by any column'
+  const only = usage.length === 1 ? usage[0] : undefined
+  if (only) {
+    return `Used by ${only.columnName} in ${only.workspaceName}`
+  }
+  return `Used by ${String(usage.length)} columns`
+}

--- a/src/lib/browser-mock.ts
+++ b/src/lib/browser-mock.ts
@@ -1064,6 +1064,23 @@ const mockCommands: Record<string, CommandHandler> = {
     return undefined
   },
   list_agent_runtimes: () => mockRuntimeDescriptors,
+  // Derived from the mock columns rather than a fixture list, so browser mode
+  // shows the same "used by" count the real backend would.
+  get_agent_usage: (args) =>
+    mockColumns.flatMap((column) =>
+      (['on_entry', 'on_exit'] as const)
+        .filter((hook) => {
+          const action = column.triggers?.[hook]
+          return action?.type === 'spawn_cli' && action.agent_id === args?.id
+        })
+        .map((hook) => ({
+          workspaceId: column.workspaceId,
+          workspaceName: mockWorkspaces.find((w) => w.id === column.workspaceId)?.name ?? '',
+          columnId: column.id,
+          columnName: column.name,
+          hook,
+        })),
+    ),
 
   list_skills: () => [...mockSkills].sort((a, b) => a.name.localeCompare(b.name)),
   create_skill: (args) => {

--- a/src/lib/ipc/roster.ts
+++ b/src/lib/ipc/roster.ts
@@ -1,5 +1,5 @@
 import { invoke } from './invoke'
-import type { Agent, RuntimeDescriptor, Skill } from '@/types'
+import type { Agent, AgentUsage, RuntimeDescriptor, Skill } from '@/types'
 
 // ─── Roster commands (Kaiten Agents) ──────────────────────────────────────
 //
@@ -33,6 +33,9 @@ export const updateAgent = (
 export const deleteAgent = (id: string): Promise<void> => invoke('delete_agent', { id })
 
 export const listAgentRuntimes = () => invoke<RuntimeDescriptor[]>('list_agent_runtimes')
+
+/** Which columns currently run this agent, across every workspace. */
+export const getAgentUsage = (id: string) => invoke<AgentUsage[]>('get_agent_usage', { id })
 
 export const listSkills = () => invoke<Skill[]>('list_skills')
 

--- a/src/types/column.ts
+++ b/src/types/column.ts
@@ -20,7 +20,14 @@ export type ResourceProfile = 'light' | 'standard' | 'heavy' | 'exclusive'
 
 export interface SpawnCliAction {
   type: 'spawn_cli'
-  /** CLI to spawn */
+  /**
+   * Id of an agent from the Roster. When set, the agent supplies the CLI,
+   * instructions, tools and its preferred model; every field below is ignored
+   * except `model`, which a column may still override. Enforced in
+   * `pipeline::spawn::resolve` on the Rust side.
+   */
+  agent_id?: string
+  /** CLI to spawn. Ignored when `agent_id` is set — the agent owns this. */
   cli?: CliType
   /** Slash command to run: /start-task, /loop-review, /code-check */
   command?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,7 @@ export type { TaskTemplate } from './task-template'
 export type { AgentSession, AgentStatus, AgentMode, AgentMessage } from './agent'
 export type {
   Agent, AgentRuntime, AgentConfig, LlmConfig, ScriptRuntimeConfig,
-  AgentAvatar, Skill, RuntimeDescriptor,
+  AgentAvatar, Skill, RuntimeDescriptor, AgentUsage,
 } from './roster'
 export {
   parseAgentConfig, parseAgentAvatar, deriveInitials, defaultConfigFor,

--- a/src/types/roster.ts
+++ b/src/types/roster.ts
@@ -74,6 +74,21 @@ export interface RuntimeDescriptor {
   usesScriptFields: boolean
 }
 
+/**
+ * One place an agent is currently attached, from `get_agent_usage`.
+ *
+ * Carries the workspace name as well as the column's, because agents are
+ * global — two boards can each have a column called "Review".
+ */
+export interface AgentUsage {
+  workspaceId: string
+  workspaceName: string
+  columnId: string
+  columnName: string
+  /** `'on_entry'` or `'on_exit'`. */
+  hook: string
+}
+
 export const DEFAULT_LLM_CONFIG: Omit<LlmConfig, 'runtime'> = {
   systemPrompt: '',
   model: '',


### PR DESCRIPTION
The Roster shipped agents you could craft but never run. Now a column can run one.

A `spawn_cli` trigger carries `agent_id`. When set the agent supplies the CLI, instructions, tools and its preferred model, and the column may override **model only** — the rule the Kaiten Agents spec locked in, enforced in `pipeline::spawn::resolve()` and nowhere else.

```
task > trigger > agent > workspace > global > default
```

A leftover `cli` token on the column is logged and ignored rather than obeyed: the roster tile has to tell the truth about what runs. The UI says the same thing by removing controls it can't honour — the CLI token disappears from the automation sentence once an agent is attached, and Advanced swaps its dropdown for "Set by \<agent\>".

## The one real design decision: instructions ship as a file

No flag spans the three runtimes, so I checked each rather than assuming:

| runtime | system-prompt flag |
|---|---|
| codex | **none at all** (0.145.0) |
| claude | `--append-system-prompt` is **last-wins, not cumulative** — verified against 2.1.239: two flags, only the second applied |
| script | no prompt concept |

That second one is the trap. Interactive mode already spends `--append-system-prompt` on the done-sentinel and appends it *after* user args, so routing an agent's instructions through it would have **silently dropped them in exactly the columns most likely to use an agent** — the same class of bug as the codex flag that killed every sentinel-carrying column before.

So instructions and skills render to `.agent.md` in the working dir and the prompt gains a newline-free pointer to it — the convention `.task.md` already established. One mechanism across 3 runtimes × 3 runtime modes, no flag-existence assumptions, and switching a column between headless and interactive **cannot change what the agent was told**. Mode is a rendering and billing choice; it has no business altering behaviour.

Verified end-to-end against a real `claude -p`: given an `.agent.md` saying "begin every reply with BENTO-OK", the reply began with BENTO-OK.

A stale `.agent.md` is removed when a column has no agent — worktrees are reused across columns, so leaving it would let one column's agent keep instructing the next.

## Script agents run too

Same tmux transport, so they get a live terminal, exit-code completion and an agent card. Two things they need that LLM agents don't:

- **They bypass `validate_agent_cli_path`.** That allow-list guards *hand-editable trigger JSON*; a script agent's command comes from an `agents` row authored in the Roster UI — the same trust level `run_script` already grants user-authored scripts. Flagging explicitly because it is me widening a security boundary.
- **They get the prompt via `$TRIGGER_PROMPT`, never argv.** The generic command builder appends the prompt as a positional argument, which would break `./render.sh --preset high` on the extra word. They're also forced to `terminal` mode, since `managed` parses an LLM event stream and `interactive` drives a TUI.

## Deleting an agent that columns use

`get_agent_usage` sweeps **every** workspace — agents are global, so scoping to the open board would miss most attachments. The dossier lists the columns; the delete confirmation names them.

Deleting is still allowed, not blocked: forbidding it would leave no way to remove an agent attached to a workspace you no longer have open. A fired trigger for a missing agent fails loudly by name instead of quietly falling back to a bare CLI, which would look like it still worked.

## The seam stayed shut

`Runtime` still has no `execute`. `roster::plan::plan_for()` builds spawn parameters, `resolve()` applies precedence, neither launches anything — so there is still exactly one copy of the cli/model/cwd/prompt rules.

## Not in this slice

MCP + `/api/*` tools for agents, RAG, typed I/O, Orchestrator-as-section, per-task agent override. Listed under "Still v2" in the spec.

## Checks

`cargo clippy -D warnings` · `cargo test` **557** (+13) · `tsc` · `eslint` · `test:ipc` · `test:type-scale` · `vitest` **444** (+10) · `vite build` · `pnpm audit`.

Visually verified in browser-mock: picker lists agents plus a bare-CLI escape hatch, CLI token vanishes on attach, script agents show neither CLI nor model.